### PR TITLE
Also show WOODPECKER_HOST and WOODPECKER_SERVER_HOST environment variables in log messages

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -532,18 +532,18 @@ func server(c *cli.Context) error {
 
 	// must configure the drone_host variable
 	if c.String("server-host") == "" {
-		logrus.Fatalln("DRONE_HOST/DRONE_SERVER_HOST is not properly configured")
+		logrus.Fatalln("DRONE_HOST/DRONE_SERVER_HOST/WOODPECKER_HOST/WOODPECKER_SERVER_HOST is not properly configured")
 	}
 
 	if !strings.Contains(c.String("server-host"), "://") {
 		logrus.Fatalln(
-			"DRONE_HOST/DRONE_SERVER_HOST must be <scheme>://<hostname> format",
+			"DRONE_HOST/DRONE_SERVER_HOST/WOODPECKER_HOST/WOODPECKER_SERVER_HOST must be <scheme>://<hostname> format",
 		)
 	}
 
 	if strings.HasSuffix(c.String("server-host"), "/") {
 		logrus.Fatalln(
-			"DRONE_HOST/DRONE_SERVER_HOST must not have trailing slash",
+			"DRONE_HOST/DRONE_SERVER_HOST/WOODPECKER_HOST/WOODPECKER_SERVER_HOST must not have trailing slash",
 		)
 	}
 


### PR DESCRIPTION
If no server host is configured, messages like 

```
DRONE_HOST/DRONE_SERVER_HOST is not properly configured
```

are printed. In fact, there are four different environment variables instead of two which can configure this value. If the user had used `WOODPECKER_HOST` or `WOODPECKER_SERVER_HOST`, they might not find the source of the error easily.

This PR changes the error message to include all four possible names.