### PR TITLE
fix: allow multi pipeline file to be named .drone.yml

### DIFF
--- a/web/src/screens/repo/screens/build/components/procs.js
+++ b/web/src/screens/repo/screens/build/components/procs.js
@@ -33,7 +33,7 @@ class ProcListHolder extends Component {
 
     return (
       <div className={styles.list}>
-        {renderName && vars.name !== "drone" ? (
+        {renderName ? (
           <div
             onClick={this.toggleOpen}
             className={`${styles.group} ${groupExpandStatus}`}
@@ -60,9 +60,9 @@ class ProcListHolder extends Component {
 
 export class ProcList extends Component {
   render() {
-    const { repo, build, rootProc, selectedProc, renderName } = this.props;
+    const { repo, build, rootProc, selectedProc } = this.props;
     return (
-      <ProcListHolder vars={rootProc} renderName={renderName}>
+      <ProcListHolder vars={rootProc} renderName={build.procs.length > 1}>
         {this.props.rootProc.children.map(function(child) {
           return (
             <Link

--- a/web/src/screens/repo/screens/build/index.js
+++ b/web/src/screens/repo/screens/build/index.js
@@ -207,7 +207,6 @@ export default class BuildLogs extends Component {
                       build={build}
                       rootProc={rootProc}
                       selectedProc={selectedProc}
-                      renderName={build.procs.length > 1}
                     />
                   </div>
                 );


### PR DESCRIPTION
Closes #239 

The check for `vars.name !== "drone"` was actually not needed as the decision if the title should be shown or not is done by the amount of `build.procs`.

## Screenshots

#### Multiple pipeline inside `.drone/` folder with `.drone/.drone.yml` and `.drone/.drone.yaml` files:
https://github.com/anbraten/woodpecker-demo
![Screenshot from 2021-07-20 11-39-04](https://user-images.githubusercontent.com/6918444/126301122-0cd4c219-adde-4d95-b581-b59c398ade19.png)

#### Single pipeline at `.drone.yml`:
https://github.com/anbraten/woodpecker-demo2
![Screenshot from 2021-07-20 11-38-49](https://user-images.githubusercontent.com/6918444/126301126-fe6db6c7-e9e2-481e-b9d2-832d2c661b5c.png)


### Thanks
Thanks to @ygbillet for finding that lines of code already