### PR TITLE
Flag for specific grpc server addr

### DIFF
--- a/cmd/drone-server/flags.go
+++ b/cmd/drone-server/flags.go
@@ -47,6 +47,12 @@ var flags = []cli.Flag{
 		Name:   "server-key",
 		Usage:  "server ssl key path",
 	},
+	cli.StringFlag{
+		EnvVar: "WOODPECKER_GRPC_ADDR",
+		Name:   "grpc-addr",
+		Usage:  "grpc address",
+		Value:  ":9000",
+	},
 	cli.BoolFlag{
 		EnvVar: "DRONE_LETS_ENCRYPT,WOODPECKER_LETS_ENCRYPT",
 		Name:   "lets-encrypt",

--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -108,7 +108,7 @@ func server(c *cli.Context) error {
 	// start the grpc server
 	g.Go(func() error {
 
-		lis, err := net.Listen("tcp", ":9000")
+		lis, err := net.Listen("tcp", c.String("grpc-addr"))
 		if err != nil {
 			logrus.Error(err)
 			return err


### PR DESCRIPTION
Adding flag to server for setting up listen addr of grpc:

--grpc-addr / $WOODPECKER_GRPC_ADDR
