### PR TITLE
Fix sanitziePath

### DIFF
--- a/server/hook.go
+++ b/server/hook.go
@@ -330,7 +330,7 @@ func findOrPersistPipelineConfig(repo *model.Repo, build *model.Build, remoteYam
 			RepoID: build.RepoID,
 			Data:   string(remoteYamlConfig.Data),
 			Hash:   sha,
-			Name:   sanitizePath(remoteYamlConfig.Name, repo.Config),
+			Name:   sanitizePath(remoteYamlConfig.Name),
 		}
 		err = Config.Storage.Config.ConfigCreate(conf)
 		if err != nil {

--- a/server/procBuilder.go
+++ b/server/procBuilder.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -78,7 +79,7 @@ func (b *procBuilder) Build() ([]*buildItem, error) {
 				PGID:    pidSequence,
 				State:   model.StatusPending,
 				Environ: axis,
-				Name:    sanitizePath(y.Name, b.Repo.Config),
+				Name:    sanitizePath(y.Name),
 			}
 
 			metadata := metadataFromStruct(b.Repo, b.Curr, b.Last, proc, b.Link)
@@ -358,9 +359,9 @@ func metadataFromStruct(repo *model.Repo, build, last *model.Build, proc *model.
 	}
 }
 
-func sanitizePath(path string, configFolder string) string {
+func sanitizePath(path string) string {
+	path = filepath.Base(path)
 	path = strings.TrimSuffix(path, ".yml")
-	path = strings.TrimPrefix(path, configFolder)
 	path = strings.TrimPrefix(path, ".")
 	return path
 }

--- a/server/procBuilder_test.go
+++ b/server/procBuilder_test.go
@@ -37,13 +37,13 @@ bbb`,
 		Regs:  []*model.Registry{},
 		Link:  "",
 		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 pipeline:
   xxx:
     image: scratch
     yyy: ${DRONE_COMMIT_MESSAGE}
 `)},
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 pipeline:
   build:
     image: scratch
@@ -70,12 +70,12 @@ func TestMultiPipeline(t *testing.T) {
 		Regs:  []*model.Registry{},
 		Link:  "",
 		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 pipeline:
   xxx:
     image: scratch
 `)},
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 pipeline:
   build:
     image: scratch
@@ -104,17 +104,17 @@ func TestDependsOn(t *testing.T) {
 		Regs:  []*model.Registry{},
 		Link:  "",
 		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Name: "lint", Data: []byte(`
+			{Name: "lint", Data: []byte(`
 pipeline:
   build:
     image: scratch
 `)},
-			&remote.FileMeta{Name: "test", Data: []byte(`
+			{Name: "test", Data: []byte(`
 pipeline:
   build:
     image: scratch
 `)},
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 pipeline:
   deploy:
     image: scratch
@@ -150,7 +150,7 @@ func TestRunsOn(t *testing.T) {
 		Regs:  []*model.Registry{},
 		Link:  "",
 		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 pipeline:
   deploy:
     image: scratch
@@ -186,13 +186,13 @@ func TestBranchFilter(t *testing.T) {
 		Regs:  []*model.Registry{},
 		Link:  "",
 		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 pipeline:
   xxx:
     image: scratch
 branches: master
 `)},
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 pipeline:
   build:
     image: scratch
@@ -234,7 +234,7 @@ func TestZeroSteps(t *testing.T) {
 		Regs:  []*model.Registry{},
 		Link:  "",
 		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Data: []byte(`
+			{Data: []byte(`
 skip_clone: true
 pipeline:
   build:
@@ -268,7 +268,7 @@ func TestZeroStepsAsMultiPipelineDeps(t *testing.T) {
 		Regs:  []*model.Registry{},
 		Link:  "",
 		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Name: "zerostep", Data: []byte(`
+			{Name: "zerostep", Data: []byte(`
 skip_clone: true
 pipeline:
   build:
@@ -276,12 +276,12 @@ pipeline:
       branch: notdev
     image: scratch
 `)},
-			&remote.FileMeta{Name: "justastep", Data: []byte(`
+			{Name: "justastep", Data: []byte(`
 pipeline:
   build:
     image: scratch
 `)},
-			&remote.FileMeta{Name: "shouldbefiltered", Data: []byte(`
+			{Name: "shouldbefiltered", Data: []byte(`
 pipeline:
   build:
     image: scratch
@@ -316,7 +316,7 @@ func TestZeroStepsAsMultiPipelineTransitiveDeps(t *testing.T) {
 		Regs:  []*model.Registry{},
 		Link:  "",
 		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Name: "zerostep", Data: []byte(`
+			{Name: "zerostep", Data: []byte(`
 skip_clone: true
 pipeline:
   build:
@@ -324,18 +324,18 @@ pipeline:
       branch: notdev
     image: scratch
 `)},
-			&remote.FileMeta{Name: "justastep", Data: []byte(`
+			{Name: "justastep", Data: []byte(`
 pipeline:
   build:
     image: scratch
 `)},
-			&remote.FileMeta{Name: "shouldbefiltered", Data: []byte(`
+			{Name: "shouldbefiltered", Data: []byte(`
 pipeline:
   build:
     image: scratch
 depends_on: [ zerostep ]
 `)},
-			&remote.FileMeta{Name: "shouldbefilteredtoo", Data: []byte(`
+			{Name: "shouldbefilteredtoo", Data: []byte(`
 pipeline:
   build:
     image: scratch
@@ -369,8 +369,7 @@ func TestTree(t *testing.T) {
 		Secs:  []*model.Secret{},
 		Regs:  []*model.Registry{},
 		Link:  "",
-		Yamls: []*remote.FileMeta{
-			&remote.FileMeta{Data: []byte(`
+		Yamls: []*remote.FileMeta{{Data: []byte(`
 pipeline:
   build:
     image: scratch
@@ -392,4 +391,33 @@ pipeline:
 	if build.Procs[2].PPID != 1 {
 		t.Fatal("Build step should be a children of the stage")
 	}
+}
+
+func TestSanitizePath(t *testing.T) {
+	t.Parallel()
+
+	testTable := []struct {
+		path          string
+		sanitizedPath string
+	}{
+		{
+			path:          ".woodpecker/test.yml",
+			sanitizedPath: "test",
+		},
+		{
+			path:          ".woodpecker.yml",
+			sanitizedPath: "woodpecker",
+		},
+		{
+			path:          "folder/sub-folder/test.yml",
+			sanitizedPath: "test",
+		},
+	}
+
+	for _, test := range testTable {
+		if test.sanitizedPath != sanitizePath(test.path) {
+			t.Fatal("Path hasn't been sanitized correctly")
+		}
+	}
+
 }


### PR DESCRIPTION
With #299 the `sanitizePath` has a bug now. If no special config (empty string) has been set it falls back to default values, but the `sanitizePath` function  the used the pipelince-config-path to sanitize pipeline names.