### PR TITLE
Improve release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,8 @@ docker-compose.yml
 *.out
 /.env
 extras/
-release/
 /build/
-cli/release/
+/dist/
 
 server/swagger/files/*.json
 server/swagger/swagger_gen.go

--- a/.woodpecker/main.yml
+++ b/.woodpecker/main.yml
@@ -43,16 +43,10 @@ pipeline:
     commands:
       - make build-frontend
 
-  build:
+  build-release:
     image: golang:1.16
     commands:
-      - go get github.com/woodpecker-ci/togo
-      - (cd web/; go generate ./...)
       - make release
-
-  build-cli:
-    image: golang:1.16
-    commands: make release-cli
 
   publish-server:
     image: plugins/docker

--- a/.woodpecker/main.yml
+++ b/.woodpecker/main.yml
@@ -38,12 +38,31 @@ pipeline:
     commands:
       - go test -timeout 30s github.com/woodpecker-ci/woodpecker/server/store/datastore
 
-  build-release:
+  build-frontend:
+    image: node:10.17.0-stretch
+    commands:
+      - make release-frontend
+
+  build-server:
+    group: build
     image: golang:1.16
     commands:
-      - make release
+      - make release-server
+
+  build-agent:
+    group: build
+    image: golang:1.16
+    commands:
+      - make release-agent
+
+  build-cli:
+    group: build
+    image: golang:1.16
+    commands:
+      - make release-cli
 
   publish-server:
+    group: docker
     image: plugins/docker
     repo: woodpeckerci/woodpecker-server
     dockerfile: docker/Dockerfile.server
@@ -55,6 +74,7 @@ pipeline:
       event: push
 
   publish-server-alpine:
+    group: docker
     image: plugins/docker
     repo: woodpeckerci/woodpecker-server
     dockerfile: docker/Dockerfile.server.alpine
@@ -66,6 +86,7 @@ pipeline:
       event: push
 
   publish-agent:
+    group: docker
     image: plugins/docker
     repo: woodpeckerci/woodpecker-agent
     dockerfile: docker/Dockerfile.agent
@@ -77,6 +98,7 @@ pipeline:
       event: push
 
   publish-agent-alpine:
+    group: docker
     image: plugins/docker
     repo: woodpeckerci/woodpecker-agent
     dockerfile: docker/Dockerfile.agent.alpine
@@ -88,6 +110,7 @@ pipeline:
       event: push
 
   release-server:
+    group: docker
     image: plugins/docker
     repo: woodpeckerci/woodpecker-server
     dockerfile: docker/Dockerfile.server
@@ -97,6 +120,7 @@ pipeline:
       event: tag
 
   release-server-alpine:
+    group: docker
     image: plugins/docker
     repo: woodpeckerci/woodpecker-server
     dockerfile: docker/Dockerfile.server.alpine
@@ -106,6 +130,7 @@ pipeline:
       event: tag
 
   release-agent:
+    group: docker
     image: plugins/docker
     repo: woodpeckerci/woodpecker-agent
     dockerfile: docker/Dockerfile.agent
@@ -115,6 +140,7 @@ pipeline:
       event: tag
 
   release-agent-alpine:
+    group: docker
     image: plugins/docker
     repo: woodpeckerci/woodpecker-agent
     dockerfile: docker/Dockerfile.agent.alpine

--- a/.woodpecker/main.yml
+++ b/.woodpecker/main.yml
@@ -38,11 +38,6 @@ pipeline:
     commands:
       - go test -timeout 30s github.com/woodpecker-ci/woodpecker/server/store/datastore
 
-  build-frontend:
-    image: node:10.17.0-stretch
-    commands:
-      - make build-frontend
-
   build-release:
     image: golang:1.16
     commands:
@@ -128,11 +123,21 @@ pipeline:
     when:
       event: tag
 
-  release-cli:
+  checksums:
+    image: golang:1.16
+    commands:
+      - make release-checksums
+    when:
+      event: tag
+
+  # TODO: upload build artifacts for pushes to master
+
+  release:
     image: plugins/github-release
     files:
-      - cli/release/woodpecker_*.tar.gz
-      - cli/release/woodpecker_checksums.txt
+      - dist/*.tar.gz
+      - dist/checksums.txt
+    title: ${DRONE_TAG##v}
     secrets:
       - source: github_token
         target: github_release_api_key

--- a/Makefile
+++ b/Makefile
@@ -55,33 +55,33 @@ test-lib:
 
 test: test-lib test-agent test-server
 
-build-agent:
-	$(DOCKER_RUN) go build -o dist/woodpecker-agent github.com/woodpecker-ci/woodpecker/cmd/agent
-
 build-frontend:
 	(cd web/; yarn; yarn build)
 
 build-server: build-frontend
 	$(DOCKER_RUN) go build -o dist/woodpecker-server github.com/woodpecker-ci/woodpecker/cmd/server
 
+build-agent:
+	$(DOCKER_RUN) go build -o dist/woodpecker-agent github.com/woodpecker-ci/woodpecker/cmd/agent
+
 build-cli:
 	$(DOCKER_RUN) go build -o dist/woodpecker-cli github.com/woodpecker-ci/woodpecker/cmd/cli
 
 build: build-agent build-server build-cli
+
+release-frontend: build-frontend
+
+release-server:
+	# compile
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags '${LDFLAGS}' -o dist/server/linux_amd64/woodpecker-server github.com/woodpecker-ci/woodpecker/cmd/server
+	# tar binary files
+	tar -cvzf dist/woodpecker-server_linux_amd64.tar.gz   -C dist/server/linux_amd64 woodpecker-server
 
 release-agent:
 	# compile
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '${LDFLAGS}' -o dist/agent/linux_amd64/woodpecker-agent github.com/woodpecker-ci/woodpecker/cmd/agent
 	# tar binary files
 	tar -cvzf dist/woodpecker-agent_linux_amd64.tar.gz   -C dist/agent/linux_amd64 woodpecker-agent
-
-release-frontend: build-frontend
-
-release-server: release-frontend
-	# compile
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags '${LDFLAGS}' -o dist/server/linux_amd64/woodpecker-server github.com/woodpecker-ci/woodpecker/cmd/server
-	# tar binary files
-	tar -cvzf dist/woodpecker-server_linux_amd64.tar.gz   -C dist/server/linux_amd64 woodpecker-server
 
 release-cli:
 	# compile
@@ -103,7 +103,7 @@ release-checksums:
 	# generate shas for tar files
 	(cd dist/; sha256sum *.{tar.gz,apk,deb,rpm} > checksums.txt)
 
-release: release-server release-agent release-cli
+release: release-frontend release-server release-agent release-cli
 
 .PHONY: version
 version:

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,18 @@ DOCKER_RUN_GO_VERSION=1.16
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")
 GO_PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
 
-VERSION ?= ${DRONE_TAG}
-ifeq ($(VERSION),)
-	VERSION := $(shell echo ${DRONE_COMMIT_SHA} | head -c 8)
+VERSION ?= next
+ifneq ($(DRONE_TAG),)
+	VERSION := $(DRONE_TAG:v%=%)
 endif
 
-LDFLAGS ?= -extldflags "-static"
-ifneq ($(VERSION),)
-	LDFLAGS := ${LDFLAGS} -X github.com/woodpecker-ci/woodpecker/version.Version=${VERSION}
+# append commit-sha to next version
+BUILD_VERSION := $(VERSION)
+ifeq ($(BUILD_VERSION),next)
+	BUILD_VERSION := $(shell echo "next-$(shell echo ${DRONE_COMMIT_SHA} | head -c 8)")
 endif
 
+LDFLAGS := -s -w -extldflags "-static" -X github.com/woodpecker-ci/woodpecker/version.Version=${BUILD_VERSION}
 
 DOCKER_RUN?=
 _with-docker:
@@ -54,38 +56,55 @@ test-lib:
 test: test-lib test-agent test-server
 
 build-agent:
-	$(DOCKER_RUN) go build -o build/woodpecker-agent github.com/woodpecker-ci/woodpecker/cmd/agent
-
-build-server:
-	$(DOCKER_RUN) go build -o build/woodpecker-server github.com/woodpecker-ci/woodpecker/cmd/server
+	$(DOCKER_RUN) go build -o dist/woodpecker-agent github.com/woodpecker-ci/woodpecker/cmd/agent
 
 build-frontend:
-	(cd web/; yarn; yarn run build)
+	(cd web/; yarn; yarn build)
 
-build: build-agent build-server
+build-server: build-frontend
+	$(DOCKER_RUN) go build -o dist/woodpecker-server github.com/woodpecker-ci/woodpecker/cmd/server
+
+build-cli:
+	$(DOCKER_RUN) go build -o dist/woodpecker-cli github.com/woodpecker-ci/woodpecker/cmd/cli
+
+build: build-agent build-server build-cli
 
 release-agent:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '${LDFLAGS}' -o release/woodpecker-agent github.com/woodpecker-ci/woodpecker/cmd/agent
+	# compile
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '${LDFLAGS}' -o dist/agent/linux_amd64/woodpecker-agent github.com/woodpecker-ci/woodpecker/cmd/agent
+	# tar binary files
+	tar -cvzf dist/woodpecker-agent_linux_amd64.tar.gz   -C dist/agent/linux_amd64 woodpecker-agent
 
-release-server:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags '${LDFLAGS}' -o release/woodpecker-server github.com/woodpecker-ci/woodpecker/cmd/server
+release-frontend: build-frontend
+
+release-server: release-frontend
+	# compile
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags '${LDFLAGS}' -o dist/server/linux_amd64/woodpecker-server github.com/woodpecker-ci/woodpecker/cmd/server
+	# tar binary files
+	tar -cvzf dist/woodpecker-server_linux_amd64.tar.gz   -C dist/server/linux_amd64 woodpecker-server
 
 release-cli:
-	# disable CGO for cross-compiling
-	export CGO_ENABLED=0
-	# compile for all architectures
-	GOOS=linux   GOARCH=amd64 go build -ldflags '${LDFLAGS}' -o cli/release/linux/amd64/woodpecker-cli   github.com/woodpecker-ci/woodpecker/cmd/cli
-	GOOS=linux   GOARCH=arm64 go build -ldflags '${LDFLAGS}' -o cli/release/linux/arm64/woodpecker-cli   github.com/woodpecker-ci/woodpecker/cmd/cli
-	GOOS=linux   GOARCH=arm   go build -ldflags '${LDFLAGS}' -o cli/release/linux/arm/woodpecker-cli     github.com/woodpecker-ci/woodpecker/cmd/cli
-	GOOS=windows GOARCH=amd64 go build -ldflags '${LDFLAGS}' -o cli/release/windows/amd64/woodpecker-cli github.com/woodpecker-ci/woodpecker/cmd/cli
-	GOOS=darwin  GOARCH=amd64 go build -ldflags '${LDFLAGS}' -o cli/release/darwin/amd64/woodpecker-cli  github.com/woodpecker-ci/woodpecker/cmd/cli
-	# tar binary files prior to upload
-	tar -cvzf cli/release/woodpecker_linux_amd64.tar.gz   -C cli/release/linux/amd64   woodpecker-cli
-	tar -cvzf cli/release/woodpecker_linux_arm64.tar.gz   -C cli/release/linux/arm64   woodpecker-cli
-	tar -cvzf cli/release/woodpecker_linux_arm.tar.gz     -C cli/release/linux/arm     woodpecker-cli
-	tar -cvzf cli/release/woodpecker_windows_amd64.tar.gz -C cli/release/windows/amd64 woodpecker-cli
-	tar -cvzf cli/release/woodpecker_darwin_amd64.tar.gz  -C cli/release/darwin/amd64  woodpecker-cli
-	# generate shas for tar files
-	sha256sum cli/release/*.tar.gz > cli/release/woodpecker_checksums.txt
+	# compile
+	GOOS=linux   GOARCH=amd64 go build -ldflags '${LDFLAGS}' -o dist/cli/linux_amd64/woodpecker-cli   github.com/woodpecker-ci/woodpecker/cmd/cli
+	GOOS=linux   GOARCH=arm64 go build -ldflags '${LDFLAGS}' -o dist/cli/linux_arm64/woodpecker-cli   github.com/woodpecker-ci/woodpecker/cmd/cli
+	GOOS=linux   GOARCH=arm   go build -ldflags '${LDFLAGS}' -o dist/cli/linux_arm/woodpecker-cli     github.com/woodpecker-ci/woodpecker/cmd/cli
+	GOOS=windows GOARCH=amd64 go build -ldflags '${LDFLAGS}' -o dist/cli/windows_amd64/woodpecker-cli github.com/woodpecker-ci/woodpecker/cmd/cli
+	GOOS=darwin  GOARCH=amd64 go build -ldflags '${LDFLAGS}' -o dist/cli/darwin_amd64/woodpecker-cli  github.com/woodpecker-ci/woodpecker/cmd/cli
+	GOOS=darwin  GOARCH=arm64 go build -ldflags '${LDFLAGS}' -o dist/cli/darwin_arm64/woodpecker-cli  github.com/woodpecker-ci/woodpecker/cmd/cli
+	# tar binary files
+	tar -cvzf dist/woodpecker-cli_linux_amd64.tar.gz   -C dist/cli/linux_amd64   woodpecker-cli
+	tar -cvzf dist/woodpecker-cli_linux_arm64.tar.gz   -C dist/cli/linux_arm64   woodpecker-cli
+	tar -cvzf dist/woodpecker-cli_linux_arm.tar.gz     -C dist/cli/linux_arm     woodpecker-cli
+	tar -cvzf dist/woodpecker-cli_windows_amd64.tar.gz -C dist/cli/windows_amd64 woodpecker-cli
+	tar -cvzf dist/woodpecker-cli_darwin_amd64.tar.gz  -C dist/cli/darwin_amd64  woodpecker-cli
+	tar -cvzf dist/woodpecker-cli_darwin_arm64.tar.gz  -C dist/cli/darwin_arm64  woodpecker-cli
 
-release: release-agent release-server
+release-checksums:
+	# generate shas for tar files
+	(cd dist/; sha256sum *.{tar.gz,apk,deb,rpm} > checksums.txt)
+
+release: release-server release-agent release-cli
+
+.PHONY: version
+version:
+	@echo ${VERSION}


### PR DESCRIPTION
Extraction from #257 
closes #309 

# Changes
- use `next-<commit-sha>` or `<tag>` as version
- release binaries of agent and server (`.tar.gz`) and add checksums to release