### PR TITLE
Append trailing slash to default GH API URL

### DIFF
--- a/server/remote/github/github.go
+++ b/server/remote/github/github.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	defaultURL = "https://github.com"     // Default GitHub URL
-	defaultAPI = "https://api.github.com" // Default GitHub API URL
+	defaultURL = "https://github.com"      // Default GitHub URL
+	defaultAPI = "https://api.github.com/" // Default GitHub API URL
 )
 
 // Opts defines configuration options.


### PR DESCRIPTION
https://github.com/google/go-github/blob/f6640949b0de67474e3987b3e014b2e818386c52/github/github.go#L31
https://github.com/google/go-github/blob/f6640949b0de67474e3987b3e014b2e818386c52/github/github.go#L369

User in Discord reported

> time="2021-10-06T18:54:53Z" level=error msg="cannot authenticate user. BaseURL must have a trailing slash, but "https://api.github.com" does not