### PR TITLE
Fix bug where db file is posible moved outside of docker volume

### DIFF
--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -97,7 +97,7 @@ func fallbackSqlite3File(path string) (string, error) {
 		return "", err
 	}
 	if err == nil {
-		return path, nil
+		return dockerDefaultPath, nil
 	}
 
 	// file is in new folder but not renamed

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -86,7 +86,7 @@ func fallbackSqlite3File(path string) (string, error) {
 	}
 	if err == nil {
 		// rename in same folder should be fine as it should be same docker volume
-		log.Warn().Msgf("found sqlite3 file at '%s', rename to '%s'", standaloneOld, standaloneDefault)
+		log.Warn().Msgf("found sqlite3 file at '%s' and moved to '%s'", standaloneOld, standaloneDefault)
 		return standaloneDefault, os.Rename(standaloneOld, standaloneDefault)
 	}
 
@@ -106,14 +106,14 @@ func fallbackSqlite3File(path string) (string, error) {
 	}
 	if err == nil {
 		// rename in same folder should be fine as it should be same docker volume
-		log.Warn().Msgf("found sqlite3 file at '%s', rename to '%s'", dockerDefaultDir, dockerDefaultPath)
+		log.Warn().Msgf("found sqlite3 file at '%s' and moved to '%s'", dockerDefaultDir, dockerDefaultPath)
 		return dockerDefaultPath, os.Rename(dockerDefaultDir, dockerDefaultPath)
 	}
 
 	// file is still at old location
 	_, err = os.Stat(dockerOldPath)
 	if err == nil {
-		log.Error().Msgf("found sqlite3 file at deprecated path '%s', please migrate to '%s'", dockerOldPath, dockerDefaultPath)
+		log.Error().Msgf("found sqlite3 file at deprecated path '%s', please move it to '%s' and update your volume path if necessary", dockerOldPath, dockerDefaultPath)
 		return dockerOldPath, nil
 	}
 

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -89,6 +89,15 @@ func fallbackSqlite3File(path string) (string, error) {
 		return dockerDefaultPath, nil
 	}
 
+	// file is at new default("woodpecker.sqlite")
+	_, err = os.Stat(standaloneDefault)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if err == nil {
+		return standaloneDefault, nil
+	}
+
 	// woodpecker run in standalone mode, file is in same folder but not renamed
 	_, err = os.Stat(standaloneOld)
 	if err != nil && !os.IsNotExist(err) {

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -72,7 +72,7 @@ func fallbackSqlite3File(path string) (string, error) {
 	const defaultDir = "/var/lib/woodpecker/drone.sqlite"
 	const oldPath = "/var/lib/drone/drone.sqlite"
 
-	// file is in new default("/var/lib/woodpecker/woodpecker.sqlite") / custom location
+	// file is at new default("/var/lib/woodpecker/woodpecker.sqlite") / custom location
 	_, err := os.Stat(path)
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
@@ -91,13 +91,13 @@ func fallbackSqlite3File(path string) (string, error) {
 		return defaultPath, os.Rename(defaultDir, defaultPath)
 	}
 
-	// file is still old location
+	// file is still at old location
 	_, err = os.Stat(oldPath)
 	if err == nil {
 		return oldPath, nil
 	}
 
-	// file do not exist at all, use default / custom location
+	// file does not exist at all => use default / custom location
 	return path, nil
 }
 

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -66,7 +66,8 @@ func setupStore(c *cli.Context) (store.Store, error) {
 	return datastore.New(opts)
 }
 
-// TODO: Remove this once we are sure users aren't attempting to migrate from Drone to Woodpecker (possibly never)
+// TODO: convert it to a check and fail hard only function in v0.16.0 to be able to remove it in v0.17.0
+// TODO: add it to the "how to migrate from drone docs"
 func fallbackSqlite3File(path string) (string, error) {
 	const dockerDefaultPath = "/var/lib/woodpecker/woodpecker.sqlite"
 	const dockerDefaultDir = "/var/lib/woodpecker/drone.sqlite"

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -80,8 +80,17 @@ func fallbackSqlite3File(path string) (string, error) {
 		return path, nil
 	}
 
+	// file is at new default("/var/lib/woodpecker/woodpecker.sqlite")
+	_, err := os.Stat(dockerDefaultPath)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if err == nil {
+		return dockerDefaultPath, nil
+	}
+
 	// woodpecker run in standalone mode, file is in same folder but not renamed
-	_, err := os.Stat(standaloneOld)
+	_, err = os.Stat(standaloneOld)
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
 	}
@@ -89,15 +98,6 @@ func fallbackSqlite3File(path string) (string, error) {
 		// rename in same folder should be fine as it should be same docker volume
 		log.Warn().Msgf("found sqlite3 file at '%s' and moved to '%s'", standaloneOld, standaloneDefault)
 		return standaloneDefault, os.Rename(standaloneOld, standaloneDefault)
-	}
-
-	// file is at new default("/var/lib/woodpecker/woodpecker.sqlite")
-	_, err = os.Stat(dockerDefaultPath)
-	if err != nil && !os.IsNotExist(err) {
-		return "", err
-	}
-	if err == nil {
-		return dockerDefaultPath, nil
 	}
 
 	// file is in new folder but not renamed

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -114,6 +114,7 @@ func fallbackSqlite3File(path string) (string, error) {
 	// file is still at old location
 	_, err = os.Stat(dockerOldPath)
 	if err == nil {
+    // TODO: use log.Fatal()... in next version
 		log.Error().Msgf("found sqlite3 file at deprecated path '%s', please move it to '%s' and update your volume path if necessary", dockerOldPath, dockerDefaultPath)
 		return dockerOldPath, nil
 	}

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -114,7 +114,7 @@ func fallbackSqlite3File(path string) (string, error) {
 	// file is still at old location
 	_, err = os.Stat(dockerOldPath)
 	if err == nil {
-    // TODO: use log.Fatal()... in next version
+		// TODO: use log.Fatal()... in next version
 		log.Error().Msgf("found sqlite3 file at deprecated path '%s', please move it to '%s' and update your volume path if necessary", dockerOldPath, dockerDefaultPath)
 		return dockerOldPath, nil
 	}


### PR DESCRIPTION
https://github.com/woodpecker-ci/woodpecker/pull/494#discussion_r739373503 introduced a bug, where a migration function can remove the sqlite3 file outside of the mounted docker volume.
that would result in a data lose after a container recreate.

this fix it by only rename the file if in same folder else just use the old path as fallback and put warnings into the log