### PR TITLE
Fix reggression, save not activated repos to database on sync again

### DIFF
--- a/server/api/user.go
+++ b/server/api/user.go
@@ -93,7 +93,10 @@ func GetRepos(c *gin.Context) {
 	if flush || time.Unix(user.Synced, 0).Add(time.Hour*72).Before(time.Now()) {
 		log.Debug().Msgf("sync begin: %s", user.Login)
 		user.Synced = time.Now().Unix()
-		store_.UpdateUser(user)
+		if err := store_.UpdateUser(user); err != nil {
+			log.Err(err).Msgf("update user '%s'", user.Login)
+			return
+		}
 
 		config := ToConfig(c)
 

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -28,7 +28,7 @@ type ConfigStore interface {
 type Config struct {
 	ID     int64  `json:"-"    xorm:"pk autoincr 'config_id'"`
 	RepoID int64  `json:"-"    xorm:"UNIQUE(s) 'config_repo_id'"`
-	Hash   string `json:"hash" xorm:"UNIQUE(s) INDEX 'config_hash'"`
+	Hash   string `json:"hash" xorm:"UNIQUE(s) 'config_hash'"`
 	Name   string `json:"name" xorm:"config_name"`
 	Data   []byte `json:"data" xorm:"config_data"`
 }

--- a/server/store/datastore/repo.go
+++ b/server/store/datastore/repo.go
@@ -83,7 +83,7 @@ func (s storage) RepoBatch(repos []*model.Repo) error {
 
 	for i := range repos {
 		if repos[i].UserID == 0 || len(repos[i].Owner) == 0 || len(repos[i].Name) == 0 || len(repos[i].FullName) == 0 {
-			log.Debug().Msgf("skip insert/update repo: %v", repos[i])
+			log.Debug().Msgf("skip insert/update repo: %#v", repos[i])
 			continue
 		}
 		exist, err := sess.

--- a/server/store/datastore/repo.go
+++ b/server/store/datastore/repo.go
@@ -82,7 +82,7 @@ func (s storage) RepoBatch(repos []*model.Repo) error {
 	}
 
 	for i := range repos {
-		if repos[i].UserID == 0 || len(repos[i].Owner) == 0 || len(repos[i].Name) == 0 || len(repos[i].FullName) == 0 {
+		if len(repos[i].Owner) == 0 || len(repos[i].Name) == 0 || len(repos[i].FullName) == 0 {
 			log.Debug().Msgf("skip insert/update repo: %#v", repos[i])
 			continue
 		}

--- a/server/store/datastore/repo_test.go
+++ b/server/store/datastore/repo_test.go
@@ -279,33 +279,45 @@ func TestRepoBatch(t *testing.T) {
 		return
 	}
 
-	if !assert.NoError(t, store.RepoBatch(
-		[]*model.Repo{
-			{
-				UserID:   1,
-				FullName: "foo/bar",
-				Owner:    "foo",
-				Name:     "bar",
-				IsActive: true,
-			},
-			{
-				UserID:   1,
-				FullName: "bar/baz",
-				Owner:    "bar",
-				Name:     "baz",
-				IsActive: true,
-			},
-			{
-				UserID:   1,
-				FullName: "baz/qux",
-				Owner:    "baz",
-				Name:     "qux",
-				IsActive: true,
-			},
+	repos := []*model.Repo{
+		{
+			UserID:   1,
+			FullName: "foo/bar",
+			Owner:    "foo",
+			Name:     "bar",
+			IsActive: true,
 		},
-	)) {
+		{
+			UserID:   1,
+			FullName: "bar/baz",
+			Owner:    "bar",
+			Name:     "baz",
+			IsActive: true,
+		},
+		{
+			UserID:   1,
+			FullName: "baz/qux",
+			Owner:    "baz",
+			Name:     "qux",
+			IsActive: true,
+		},
+		{
+			UserID:   1,
+			FullName: "baz/notes",
+			Owner:    "baz",
+			Name:     "notes",
+			IsActive: false,
+		},
+	}
+	if !assert.NoError(t, store.RepoBatch(repos)) {
 		return
 	}
+	for i := range repos {
+		assert.EqualValues(t, i+1, repos[i].ID, "repo do not got an id: %#v", repos[i])
+	}
+	result, err := store.RepoList(&model.User{ID: 1}, true)
+	assert.NoError(t, err)
+	assert.Len(t, result, 4)
 
 	count, err := store.GetRepoCount()
 	assert.NoError(t, err)

--- a/server/store/datastore/repo_test.go
+++ b/server/store/datastore/repo_test.go
@@ -302,7 +302,7 @@ func TestRepoBatch(t *testing.T) {
 			IsActive: true,
 		},
 		{
-			UserID:   1,
+			UserID:   0, // not activated repos do hot have a user id assigned
 			FullName: "baz/notes",
 			Owner:    "baz",
 			Name:     "notes",
@@ -312,12 +312,11 @@ func TestRepoBatch(t *testing.T) {
 	if !assert.NoError(t, store.RepoBatch(repos)) {
 		return
 	}
-	for i := range repos {
-		assert.EqualValues(t, i+1, repos[i].ID, "repo do not got an id: %#v", repos[i])
-	}
-	result, err := store.RepoList(&model.User{ID: 1}, true)
+
+	allRepos := make([]*model.Repo, 0, 4)
+	err := store.engine.Find(&allRepos)
 	assert.NoError(t, err)
-	assert.Len(t, result, 4)
+	assert.Len(t, allRepos, 4)
 
 	count, err := store.GetRepoCount()
 	assert.NoError(t, err)


### PR DESCRIPTION
close  #508

caused by #474 

there a test was added to exclude repos with user id 0, but that's not jet posible ->  #485 ...