### PR TITLE
Use monospace font for build logs

### DIFF
--- a/web/src/components/repo/build/BuildLogs.vue
+++ b/web/src/components/repo/build/BuildLogs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="build" class="bg-gray-700 dark:bg-dark-gray-700 p-4">
+  <div v-if="build" class="font-mono bg-gray-700 dark:bg-dark-gray-700 p-4">
     <div v-for="logLine in logLines" :key="logLine.pos" class="flex items-center">
       <div class="text-gray-500 text-sm w-4">{{ (logLine.pos || 0) + 1 }}</div>
       <!-- eslint-disable-next-line vue/no-v-html -->


### PR DESCRIPTION
I just started using woodpecker and the build logs not being a monospace font was bugging me, so here's a PR to fix it :slightly_smiling_face: 

I don't do frontend development so I'm not sure if the styling here should go somewhere else; if so just let me know and I'll update the patch.