### PR TITLE
Add linter misspell

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 linters-settings:
   gofmt:
     simplify: true
+  misspell:
+    locale: US
 
 linters:
   disable-all: true
@@ -13,6 +15,7 @@ linters:
     - typecheck
     - errcheck
     - bidichk
+    - misspell
 
 run:
   timeout: 5m

--- a/agent/runner.go
+++ b/agent/runner.go
@@ -98,12 +98,12 @@ func (r *Runner) Run(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctxmeta, timeout)
 	defer cancel()
 
-	cancelled := abool.New()
+	canceled := abool.New()
 	go func() {
 		logger.Debug().Msg("listen for cancel signal")
 
 		if werr := r.client.Wait(ctx, work.ID); werr != nil {
-			cancelled.SetTo(true)
+			canceled.SetTo(true)
 			logger.Warn().Err(werr).Msg("cancel signal received")
 
 			cancel()
@@ -312,7 +312,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			state.ExitCode = 1
 			state.Error = err.Error()
 		}
-		if cancelled.IsSet() {
+		if canceled.IsSet() {
 			state.ExitCode = 137
 		}
 	}

--- a/cmd/agent/signal.go
+++ b/cmd/agent/signal.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 )
 
-// WithContextFunc returns a copy of parent context that is cancelled when
+// WithContextFunc returns a copy of parent context that is canceled when
 // an os interrupt signal is received. The callback function f is invoked
 // before cancellation.
 func WithContextFunc(ctx context.Context, f func()) context.Context {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -157,12 +157,12 @@ func run(c *cli.Context) error {
 			log.Err(err).Msg("")
 			return err
 		}
-		auther := &authorizer{
+		authorizer := &authorizer{
 			password: c.String("agent-secret"),
 		}
 		grpcServer := grpc.NewServer(
-			grpc.StreamInterceptor(auther.streamInterceptor),
-			grpc.UnaryInterceptor(auther.unaryIntercaptor),
+			grpc.StreamInterceptor(authorizer.streamInterceptor),
+			grpc.UnaryInterceptor(authorizer.unaryIntercaptor),
 			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 				MinTime: c.Duration("keepalive-min-time"),
 			}),

--- a/pipeline/error.go
+++ b/pipeline/error.go
@@ -12,7 +12,7 @@ var (
 
 	// ErrCancel is used as a return value when the container execution receives
 	// a cancellation signal from the context.
-	ErrCancel = errors.New("Cancelled")
+	ErrCancel = errors.New("Canceled")
 )
 
 // An ExitError reports an unsuccessful exit.

--- a/pipeline/frontend/yaml/container.go
+++ b/pipeline/frontend/yaml/container.go
@@ -62,7 +62,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (c *Containers) UnmarshalYAML(value *yaml.Node) error {
 	containers := map[string]Container{}
 	err := value.Decode(&containers)

--- a/pipeline/frontend/yaml/network.go
+++ b/pipeline/frontend/yaml/network.go
@@ -20,7 +20,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (n *Networks) UnmarshalYAML(value *yaml.Node) error {
 	networks := map[string]Network{}
 	err := value.Decode(&networks)

--- a/pipeline/frontend/yaml/secret.go
+++ b/pipeline/frontend/yaml/secret.go
@@ -15,7 +15,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (s *Secrets) UnmarshalYAML(value *yaml.Node) error {
 	y, _ := yaml.Marshal(value)
 

--- a/pipeline/frontend/yaml/types/types_yaml.go
+++ b/pipeline/frontend/yaml/types/types_yaml.go
@@ -13,7 +13,7 @@ import (
 // StringorInt represents a string or an integer.
 type StringorInt int64
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (s *StringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var intType int64
 	if err := unmarshal(&intType); err == nil {
@@ -39,7 +39,7 @@ func (s *StringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // the String supports notations like 10m for then Megabyte of memory
 type MemStringorInt int64
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (s *MemStringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var intType int64
 	if err := unmarshal(&intType); err == nil {
@@ -62,10 +62,10 @@ func (s *MemStringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error 
 }
 
 // Stringorslice represents
-// Using engine-api Strslice and augment it with YAML marshalling stuff. a string or an array of strings.
+// Using engine-api Strslice and augment it with YAML marshaling stuff. a string or an array of strings.
 type Stringorslice strslice.StrSlice
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (s *Stringorslice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var stringType string
 	if err := unmarshal(&stringType); err == nil {
@@ -89,7 +89,7 @@ func (s *Stringorslice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // SliceorMap represents a slice or a map of strings.
 type SliceorMap map[string]string
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (s *SliceorMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	var sliceType []interface{}

--- a/pipeline/frontend/yaml/types/ulimit.go
+++ b/pipeline/frontend/yaml/types/ulimit.go
@@ -21,7 +21,7 @@ func (u Ulimits) MarshalYAML() (interface{}, error) {
 	return ulimitMap, nil
 }
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (u *Ulimits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	ulimits := make(map[string]Ulimit)
 

--- a/pipeline/frontend/yaml/types/volume.go
+++ b/pipeline/frontend/yaml/types/volume.go
@@ -42,7 +42,7 @@ func (v Volumes) MarshalYAML() (interface{}, error) {
 	return vs, nil
 }
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (v *Volumes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var sliceType []interface{}
 	if err := unmarshal(&sliceType); err == nil {

--- a/pipeline/frontend/yaml/volume.go
+++ b/pipeline/frontend/yaml/volume.go
@@ -20,7 +20,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements the Unmarshaller interface.
+// UnmarshalYAML implements the Unmarshaler interface.
 func (v *Volumes) UnmarshalYAML(value *yaml.Node) error {
 	y, _ := yaml.Marshal(value)
 

--- a/pipeline/interrupt/interrupt.go
+++ b/pipeline/interrupt/interrupt.go
@@ -14,7 +14,7 @@ func WithContext(ctx context.Context) context.Context {
 	})
 }
 
-// WithContextFunc returns a copy of parent context that is cancelled when
+// WithContextFunc returns a copy of parent context that is canceled when
 // an os interrupt signal is received. The callback function f is invoked
 // before cancellation.
 func WithContextFunc(ctx context.Context, f func()) context.Context {

--- a/pipeline/rpc/peer.go
+++ b/pipeline/rpc/peer.go
@@ -6,8 +6,8 @@ import (
 	"github.com/woodpecker-ci/woodpecker/pipeline/backend"
 )
 
-// ErrCancelled signals the pipeline is cancelled.
-// var ErrCancelled = errors.New("cancelled")
+// ErrCanceled signals the pipeline is canceled.
+// var ErrCanceled = errors.New("canceled")
 
 type (
 	// Filter defines filters for fetching items from the queue.

--- a/pipeline/rpc/peer.go
+++ b/pipeline/rpc/peer.go
@@ -6,9 +6,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/pipeline/backend"
 )
 
-// ErrCanceled signals the pipeline is canceled.
-// var ErrCanceled = errors.New("canceled")
-
 type (
 	// Filter defines filters for fetching items from the queue.
 	Filter struct {

--- a/server/api/build.go
+++ b/server/api/build.go
@@ -251,7 +251,7 @@ func DeleteBuild(c *gin.Context) {
 			return
 		}
 		killedBuild.Procs = model.Tree(procs)
-		if err := publishToTopic(c, killedBuild, repo, model.Cancelled); err != nil {
+		if err := publishToTopic(c, killedBuild, repo, model.Canceled); err != nil {
 			log.Error().Err(err).Msg("publishToTopic")
 		}
 	}

--- a/server/model/event.go
+++ b/server/model/event.go
@@ -18,10 +18,10 @@ package model
 type EventType string
 
 const (
-	Enqueued  EventType = "enqueued"
-	Started   EventType = "started"
-	Finished  EventType = "finished"
-	Cancelled EventType = "cancelled"
+	Enqueued EventType = "enqueued"
+	Started  EventType = "started"
+	Finished EventType = "finished"
+	Canceled EventType = "canceled"
 )
 
 // Event represents a build event.

--- a/server/queue/fifo_test.go
+++ b/server/queue/fifo_test.go
@@ -411,13 +411,13 @@ func TestFifoCancel(t *testing.T) {
 	assert.NoError(t, q.PushAtOnce(noContext, []*Task{task2, task3, task1}))
 
 	_, _ = q.Poll(noContext, func(*Task) bool { return true })
-	assert.NoError(t, q.Error(noContext, task1.ID, fmt.Errorf("cancelled")))
-	assert.NoError(t, q.Error(noContext, task2.ID, fmt.Errorf("cancelled")))
-	assert.NoError(t, q.Error(noContext, task3.ID, fmt.Errorf("cancelled")))
+	assert.NoError(t, q.Error(noContext, task1.ID, fmt.Errorf("canceled")))
+	assert.NoError(t, q.Error(noContext, task2.ID, fmt.Errorf("canceled")))
+	assert.NoError(t, q.Error(noContext, task3.ID, fmt.Errorf("canceled")))
 
 	info := q.Info(noContext)
 	if len(info.Pending) != 0 {
-		t.Errorf("All pipelines should be cancelled")
+		t.Errorf("All pipelines should be canceled")
 		return
 	}
 }

--- a/server/queue/queue.go
+++ b/server/queue/queue.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	// ErrCancel indicates the task was cancelled.
-	ErrCancel = errors.New("queue: task cancelled")
+	// ErrCancel indicates the task was canceled.
+	ErrCancel = errors.New("queue: task canceled")
 
 	// ErrNotFound indicates the task was not found in the queue.
 	ErrNotFound = errors.New("queue: task not found")

--- a/server/swagger/files/swagger.yml
+++ b/server/swagger/files/swagger.yml
@@ -377,7 +377,7 @@ paths:
         - accessToken: []
       responses:
         200:
-          description: Successfully cancelled the Job
+          description: Successfully canceled the Job
         404:
           description: |
             Unable to find the Repository or Job


### PR DESCRIPTION
Uses `locale: US` to get more consistency and because there were fewer changes necessary compared to `locale: UK`.