### PR TITLE
Add linter revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - varcheck
     - ineffassign
     - unused
+    - revive
 
 run:
   timeout: 5m

--- a/cli/internal/util.go
+++ b/cli/internal/util.go
@@ -29,10 +29,10 @@ func NewClient(c *cli.Context) (woodpecker.Client, error) {
 	// if no server url is provided we can default
 	// to the hosted Woodpecker service.
 	if len(server) == 0 {
-		return nil, fmt.Errorf("Error: you must provide the Woodpecker server address.")
+		return nil, fmt.Errorf("Error: you must provide the Woodpecker server address")
 	}
 	if len(token) == 0 {
-		return nil, fmt.Errorf("Error: you must provide your Woodpecker access token.")
+		return nil, fmt.Errorf("Error: you must provide your Woodpecker access token")
 	}
 
 	// attempt to find system CA certs
@@ -77,7 +77,7 @@ func NewClient(c *cli.Context) (woodpecker.Client, error) {
 func ParseRepo(str string) (user, repo string, err error) {
 	var parts = strings.Split(str, "/")
 	if len(parts) != 2 {
-		err = fmt.Errorf("Error: Invalid or missing repository. eg octocat/hello-world.")
+		err = fmt.Errorf("Error: Invalid or missing repository. eg octocat/hello-world")
 		return
 	}
 	user = parts[0]

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -53,7 +53,7 @@ func lint(c *cli.Context) error {
 }
 
 func lintFile(file string) error {
-	err, configErrors := schema.Lint(file)
+	configErrors, err := schema.Lint(file)
 	if err != nil {
 		fmt.Println("❌ Config is invalid")
 		for _, configError := range configErrors {

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -166,9 +166,8 @@ func setupRegistryService(c *cli.Context, s store.Store) model.RegistryService {
 			registry.New(s),
 			registry.Filesystem(c.String("docker-config")),
 		)
-	} else {
-		return registry.New(s)
 	}
+	return registry.New(s)
 }
 
 func setupEnvironService(c *cli.Context, s store.Store) model.EnvironService {
@@ -301,7 +300,7 @@ func setupCoding(c *cli.Context) (remote.Remote, error) {
 	return coding.New(opts)
 }
 
-func setupMetrics(g *errgroup.Group, store_ store.Store) {
+func setupMetrics(g *errgroup.Group, _store store.Store) {
 	pendingJobs := promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "woodpecker",
 		Name:      "pending_jobs",
@@ -350,9 +349,9 @@ func setupMetrics(g *errgroup.Group, store_ store.Store) {
 	})
 	g.Go(func() error {
 		for {
-			repoCount, _ := store_.GetRepoCount()
-			userCount, _ := store_.GetUserCount()
-			buildCount, _ := store_.GetBuildCount()
+			repoCount, _ := _store.GetRepoCount()
+			userCount, _ := _store.GetUserCount()
+			buildCount, _ := _store.GetBuildCount()
 			builds.Set(float64(buildCount))
 			users.Set(float64(userCount))
 			repos.Set(float64(repoCount))

--- a/pipeline/backend/docker/convert.go
+++ b/pipeline/backend/docker/convert.go
@@ -170,7 +170,6 @@ func splitVolumeParts(volumeParts string) ([]string, error) {
 			}
 		}
 		return cleanResults, nil
-	} else {
-		return strings.Split(volumeParts, ":"), nil
 	}
+	return strings.Split(volumeParts, ":"), nil
 }

--- a/pipeline/frontend/yaml/compiler/convert.go
+++ b/pipeline/frontend/yaml/compiler/convert.go
@@ -16,13 +16,13 @@ func (c *Compiler) createProcess(name string, container *yaml.Container, section
 		detached   bool
 		workingdir string
 
-		workspace    = fmt.Sprintf("%s_default:%s", c.prefix, c.base)
-		privileged   = container.Privileged
-		entrypoint   = container.Entrypoint
-		command      = container.Command
-		image        = expandImage(container.Image)
-		network_mode = container.NetworkMode
-		ipc_mode     = container.IpcMode
+		workspace   = fmt.Sprintf("%s_default:%s", c.prefix, c.base)
+		privileged  = container.Privileged
+		entrypoint  = container.Entrypoint
+		command     = container.Command
+		image       = expandImage(container.Image)
+		networkMode = container.NetworkMode
+		ipcMode     = container.IpcMode
 		// network    = container.Network
 	)
 
@@ -176,7 +176,7 @@ func (c *Compiler) createProcess(name string, container *yaml.Container, section
 		OnFailure: (len(container.Constraints.Status.Include)+
 			len(container.Constraints.Status.Exclude) != 0) &&
 			container.Constraints.Status.Match("failure"),
-		NetworkMode: network_mode,
-		IpcMode:     ipc_mode,
+		NetworkMode: networkMode,
+		IpcMode:     ipcMode,
 	}
 }

--- a/pipeline/schema/schema.go
+++ b/pipeline/schema/schema.go
@@ -12,21 +12,21 @@ import (
 //go:embed schema.json
 var schemaDefinition []byte
 
-func Lint(file string) (error, []gojsonschema.ResultError) {
+func Lint(file string) ([]gojsonschema.ResultError, error) {
 	schemaLoader := gojsonschema.NewBytesLoader(schemaDefinition)
-	j, err := yml.LoadYmlFileAsJson(file)
+	j, err := yml.LoadYmlFileAsJSON(file)
 	if err != nil {
-		return fmt.Errorf("Failed to load yml file %w", err), nil
+		return nil, fmt.Errorf("Failed to load yml file %w", err)
 	}
 
 	documentLoader := gojsonschema.NewBytesLoader(j)
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
-		return fmt.Errorf("Validation failed %w", err), nil
+		return nil, fmt.Errorf("Validation failed %w", err)
 	}
 
 	if !result.Valid() {
-		return fmt.Errorf("Config not valid"), result.Errors()
+		return result.Errors(), fmt.Errorf("Config not valid")
 	}
 
 	return nil, nil

--- a/pipeline/schema/schema_test.go
+++ b/pipeline/schema/schema_test.go
@@ -78,7 +78,7 @@ func TestSchema(t *testing.T) {
 
 	for _, tt := range testTable {
 		t.Run(tt.name, func(t *testing.T) {
-			err, configErrors := schema.Lint(tt.testFile)
+			configErrors, err := schema.Lint(tt.testFile)
 			if tt.fail {
 				if len(configErrors) == 0 {
 					assert.Error(t, err, "Expected config errors but got none")

--- a/server/api/badge.go
+++ b/server/api/badge.go
@@ -38,8 +38,8 @@ var (
 )
 
 func GetBadge(c *gin.Context) {
-	store_ := store.FromContext(c)
-	repo, err := store_.GetRepoName(c.Param("owner") + "/" + c.Param("name"))
+	_store := store.FromContext(c)
+	repo, err := _store.GetRepoName(c.Param("owner") + "/" + c.Param("name"))
 	if err != nil {
 		c.AbortWithStatus(404)
 		return
@@ -57,7 +57,7 @@ func GetBadge(c *gin.Context) {
 		branch = repo.Branch
 	}
 
-	build, err := store_.GetBuildLast(repo, branch)
+	build, err := _store.GetBuildLast(repo, branch)
 	if err != nil {
 		log.Warn().Err(err).Msg("")
 		c.String(200, badgeNone)
@@ -79,14 +79,14 @@ func GetBadge(c *gin.Context) {
 }
 
 func GetCC(c *gin.Context) {
-	store_ := store.FromContext(c)
-	repo, err := store_.GetRepoName(c.Param("owner") + "/" + c.Param("name"))
+	_store := store.FromContext(c)
+	repo, err := _store.GetRepoName(c.Param("owner") + "/" + c.Param("name"))
 	if err != nil {
 		c.AbortWithStatus(404)
 		return
 	}
 
-	builds, err := store_.GetBuildList(repo, 1)
+	builds, err := _store.GetBuildList(repo, 1)
 	if err != nil || len(builds) == 0 {
 		c.AbortWithStatus(404)
 		return

--- a/server/api/build.go
+++ b/server/api/build.go
@@ -54,7 +54,7 @@ func GetBuilds(c *gin.Context) {
 }
 
 func GetBuild(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 	if c.Param("number") == "latest" {
 		GetBuildLast(c)
 		return
@@ -67,13 +67,13 @@ func GetBuild(c *gin.Context) {
 		return
 	}
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
-	files, _ := store_.FileList(build)
-	procs, _ := store_.ProcList(build)
+	files, _ := _store.FileList(build)
+	procs, _ := _store.ProcList(build)
 	build.Procs = model.Tree(procs)
 	build.Files = files
 
@@ -81,23 +81,23 @@ func GetBuild(c *gin.Context) {
 }
 
 func GetBuildLast(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 	repo := session.Repo(c)
 	branch := c.DefaultQuery("branch", repo.Branch)
 
-	build, err := store_.GetBuildLast(repo, branch)
+	build, err := _store.GetBuildLast(repo, branch)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	procs, _ := store_.ProcList(build)
+	procs, _ := _store.ProcList(build)
 	build.Procs = model.Tree(procs)
 	c.JSON(http.StatusOK, build)
 }
 
 func GetBuildLogs(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 	repo := session.Repo(c)
 
 	// parse the build number and job sequence number from
@@ -106,19 +106,19 @@ func GetBuildLogs(c *gin.Context) {
 	ppid, _ := strconv.Atoi(c.Params.ByName("pid"))
 	name := c.Params.ByName("proc")
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
 	}
 
-	proc, err := store_.ProcChild(build, ppid, name)
+	proc, err := _store.ProcChild(build, ppid, name)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
 	}
 
-	rc, err := store_.LogFind(proc)
+	rc, err := _store.LogFind(proc)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
@@ -133,7 +133,7 @@ func GetBuildLogs(c *gin.Context) {
 }
 
 func GetProcLogs(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 	repo := session.Repo(c)
 
 	// parse the build number and job sequence number from
@@ -141,19 +141,19 @@ func GetProcLogs(c *gin.Context) {
 	num, _ := strconv.ParseInt(c.Params.ByName("number"), 10, 64)
 	pid, _ := strconv.Atoi(c.Params.ByName("pid"))
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
 	}
 
-	proc, err := store_.ProcFind(build, pid)
+	proc, err := _store.ProcFind(build, pid)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
 	}
 
-	rc, err := store_.LogFind(proc)
+	rc, err := _store.LogFind(proc)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
@@ -169,17 +169,17 @@ func GetProcLogs(c *gin.Context) {
 
 // DeleteBuild cancels a build
 func DeleteBuild(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 	repo := session.Repo(c)
 	num, _ := strconv.ParseInt(c.Params.ByName("number"), 10, 64)
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
 	}
 
-	procs, err := store_.ProcList(build)
+	procs, err := _store.ProcList(build)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
@@ -225,18 +225,18 @@ func DeleteBuild(c *gin.Context) {
 	for _, proc := range procs {
 		if proc.State == model.StatusPending {
 			if proc.PPID != 0 {
-				if _, err = shared.UpdateProcToStatusSkipped(store_, *proc, 0); err != nil {
+				if _, err = shared.UpdateProcToStatusSkipped(_store, *proc, 0); err != nil {
 					log.Error().Msgf("error: done: cannot update proc_id %d state: %s", proc.ID, err)
 				}
 			} else {
-				if _, err = shared.UpdateProcToStatusKilled(store_, *proc); err != nil {
+				if _, err = shared.UpdateProcToStatusKilled(_store, *proc); err != nil {
 					log.Error().Msgf("error: done: cannot update proc_id %d state: %s", proc.ID, err)
 				}
 			}
 		}
 	}
 
-	killedBuild, err := shared.UpdateToStatusKilled(store_, *build)
+	killedBuild, err := shared.UpdateToStatusKilled(_store, *build)
 	if err != nil {
 		_ = c.AbortWithError(500, err)
 		return
@@ -245,7 +245,7 @@ func DeleteBuild(c *gin.Context) {
 	// For pending builds, we stream the UI the latest state.
 	// For running builds, the UI will be updated when the agents acknowledge the cancel
 	if build.Status == model.StatusPending {
-		procs, err = store_.ProcList(killedBuild)
+		procs, err = _store.ProcList(killedBuild)
 		if err != nil {
 			_ = c.AbortWithError(404, err)
 			return
@@ -261,14 +261,14 @@ func DeleteBuild(c *gin.Context) {
 
 func PostApproval(c *gin.Context) {
 	var (
-		remote_ = server.Config.Services.Remote
-		store_  = store.FromContext(c)
+		_remote = server.Config.Services.Remote
+		_store  = store.FromContext(c)
 		repo    = session.Repo(c)
 		user    = session.User(c)
 		num, _  = strconv.ParseInt(c.Params.ByName("number"), 10, 64)
 	)
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
@@ -286,13 +286,13 @@ func PostApproval(c *gin.Context) {
 		return
 	}
 
-	netrc, err := remote_.Netrc(user, repo)
+	netrc, err := _remote.Netrc(user, repo)
 	if err != nil {
 		c.String(500, "failed to generate netrc file. %s", err)
 		return
 	}
 
-	if build, err = shared.UpdateToStatusPending(store_, *build, user.Login); err != nil {
+	if build, err = shared.UpdateToStatusPending(_store, *build, user.Login); err != nil {
 		c.String(500, "error updating build. %s", err)
 		return
 	}
@@ -301,7 +301,7 @@ func PostApproval(c *gin.Context) {
 
 	// get the previous build so that we can send
 	// on status change notifications
-	last, _ := store_.GetBuildLastBefore(repo, build.Branch, build.ID)
+	last, _ := _store.GetBuildLastBefore(repo, build.Branch, build.ID)
 	secs, err := server.Config.Services.Secrets.SecretListBuild(repo, build)
 	if err != nil {
 		log.Debug().Msgf("Error getting secrets for %s#%d. %s", repo.FullName, build.Number, err)
@@ -336,14 +336,14 @@ func PostApproval(c *gin.Context) {
 	}
 	buildItems, err := b.Build()
 	if err != nil {
-		if _, err = shared.UpdateToStatusError(store_, *build, err); err != nil {
+		if _, err = shared.UpdateToStatusError(_store, *build, err); err != nil {
 			log.Error().Msgf("Error setting error status of build for %s#%d. %s", repo.FullName, build.Number, err)
 		}
 		return
 	}
 	build = shared.SetBuildStepsOnBuild(b.Curr, buildItems)
 
-	err = store_.ProcCreate(build.Procs)
+	err = _store.ProcCreate(build.Procs)
 	if err != nil {
 		log.Error().Msgf("error persisting procs %s/%d: %s", repo.FullName, build.Number, err)
 	}
@@ -352,9 +352,9 @@ func PostApproval(c *gin.Context) {
 		for _, item := range buildItems {
 			uri := fmt.Sprintf("%s/%s/%d", server.Config.Server.Host, repo.FullName, build.Number)
 			if len(buildItems) > 1 {
-				err = remote_.Status(c, user, repo, build, uri, item.Proc)
+				err = _remote.Status(c, user, repo, build, uri, item.Proc)
 			} else {
-				err = remote_.Status(c, user, repo, build, uri, nil)
+				err = _remote.Status(c, user, repo, build, uri, nil)
 			}
 			if err != nil {
 				log.Error().Msgf("error setting commit status for %s/%d: %v", repo.FullName, build.Number, err)
@@ -372,15 +372,15 @@ func PostApproval(c *gin.Context) {
 
 func PostDecline(c *gin.Context) {
 	var (
-		remote_ = server.Config.Services.Remote
-		store_  = store.FromContext(c)
+		_remote = server.Config.Services.Remote
+		_store  = store.FromContext(c)
 
 		repo   = session.Repo(c)
 		user   = session.User(c)
 		num, _ = strconv.ParseInt(c.Params.ByName("number"), 10, 64)
 	)
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
@@ -390,13 +390,13 @@ func PostDecline(c *gin.Context) {
 		return
 	}
 
-	if _, err = shared.UpdateToStatusDeclined(store_, *build, user.Login); err != nil {
+	if _, err = shared.UpdateToStatusDeclined(_store, *build, user.Login); err != nil {
 		c.String(500, "error updating build. %s", err)
 		return
 	}
 
 	uri := fmt.Sprintf("%s/%s/%d", server.Config.Server.Host, repo.FullName, build.Number)
-	err = remote_.Status(c, user, repo, build, uri, nil)
+	err = _remote.Status(c, user, repo, build, uri, nil)
 	if err != nil {
 		log.Error().Msgf("error setting commit status for %s/%d: %v", repo.FullName, build.Number, err)
 	}
@@ -415,8 +415,8 @@ func GetBuildQueue(c *gin.Context) {
 
 // PostBuild restarts a build
 func PostBuild(c *gin.Context) {
-	remote_ := server.Config.Services.Remote
-	store_ := store.FromContext(c)
+	_remote := server.Config.Services.Remote
+	_store := store.FromContext(c)
 	repo := session.Repo(c)
 
 	num, err := strconv.ParseInt(c.Param("number"), 10, 64)
@@ -425,14 +425,14 @@ func PostBuild(c *gin.Context) {
 		return
 	}
 
-	user, err := store_.GetUser(repo.UserID)
+	user, err := _store.GetUser(repo.UserID)
 	if err != nil {
 		log.Error().Msgf("failure to find repo owner %s. %s", repo.FullName, err)
 		_ = c.AbortWithError(500, err)
 		return
 	}
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		log.Error().Msgf("failure to get build %d. %s", num, err)
 		_ = c.AbortWithError(404, err)
@@ -449,12 +449,12 @@ func PostBuild(c *gin.Context) {
 	// if the remote has a refresh token, the current access token
 	// may be stale. Therefore, we should refresh prior to dispatching
 	// the job.
-	if refresher, ok := remote_.(remote.Refresher); ok {
+	if refresher, ok := _remote.(remote.Refresher); ok {
 		ok, err := refresher.Refresh(c, user)
 		if err != nil {
 			log.Error().Err(err).Msgf("refresh oauth token of user '%s' failed", user.Login)
 		} else if ok {
-			if err := store_.UpdateUser(user); err != nil {
+			if err := _store.UpdateUser(user); err != nil {
 				log.Error().Err(err).Msg("fail to save user to store after refresh oauth token")
 			}
 		}
@@ -468,7 +468,7 @@ func PostBuild(c *gin.Context) {
 		return
 	}
 
-	netrc, err := remote_.Netrc(user, repo)
+	netrc, err := _remote.Netrc(user, repo)
 	if err != nil {
 		log.Error().Msgf("failure to generate netrc for %s. %s", repo.FullName, err)
 		_ = c.AbortWithError(500, err)
@@ -493,7 +493,7 @@ func PostBuild(c *gin.Context) {
 		build.Event = event
 	}
 
-	err = store_.CreateBuild(build)
+	err = _store.CreateBuild(build)
 	if err != nil {
 		c.String(500, err.Error())
 		return
@@ -520,7 +520,7 @@ func PostBuild(c *gin.Context) {
 
 	// get the previous build so that we can send
 	// on status change notifications
-	last, _ := store_.GetBuildLastBefore(repo, build.Branch, build.ID)
+	last, _ := _store.GetBuildLastBefore(repo, build.Branch, build.ID)
 	secs, err := server.Config.Services.Secrets.SecretListBuild(repo, build)
 	if err != nil {
 		log.Debug().Msgf("Error getting secrets for %s#%d. %s", repo.FullName, build.Number, err)
@@ -563,7 +563,7 @@ func PostBuild(c *gin.Context) {
 	}
 	build = shared.SetBuildStepsOnBuild(b.Curr, buildItems)
 
-	err = store_.ProcCreate(build.Procs)
+	err = _store.ProcCreate(build.Procs)
 	if err != nil {
 		log.Error().Msgf("cannot restart %s#%d: %s", repo.FullName, build.Number, err)
 		build.Status = model.StatusError
@@ -584,19 +584,19 @@ func PostBuild(c *gin.Context) {
 }
 
 func DeleteBuildLogs(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 
 	repo := session.Repo(c)
 	user := session.User(c)
 	num, _ := strconv.ParseInt(c.Params.ByName("number"), 10, 64)
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
 	}
 
-	procs, err := store_.ProcList(build)
+	procs, err := _store.ProcList(build)
 	if err != nil {
 		_ = c.AbortWithError(404, err)
 		return
@@ -611,7 +611,7 @@ func DeleteBuildLogs(c *gin.Context) {
 	for _, proc := range procs {
 		t := time.Now().UTC()
 		buf := bytes.NewBufferString(fmt.Sprintf(deleteStr, proc.Name, user.Login, t.Format(time.UnixDate)))
-		lerr := store_.LogSave(proc, buf)
+		lerr := _store.LogSave(proc, buf)
 		if lerr != nil {
 			err = lerr
 		}

--- a/server/api/file.go
+++ b/server/api/file.go
@@ -29,7 +29,7 @@ import (
 
 // FileList gets a list file by build.
 func FileList(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 	num, err := strconv.ParseInt(c.Param("number"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
@@ -37,13 +37,13 @@ func FileList(c *gin.Context) {
 	}
 
 	repo := session.Repo(c)
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	files, err := store_.FileList(build)
+	files, err := _store.FileList(build)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return
@@ -55,7 +55,7 @@ func FileList(c *gin.Context) {
 // FileGet gets a file by process and name
 func FileGet(c *gin.Context) {
 	var (
-		store_ = store.FromContext(c)
+		_store = store.FromContext(c)
 
 		repo = session.Repo(c)
 		name = strings.TrimPrefix(c.Param("file"), "/")
@@ -76,19 +76,19 @@ func FileGet(c *gin.Context) {
 		return
 	}
 
-	build, err := store_.GetBuildNumber(repo, num)
+	build, err := _store.GetBuildNumber(repo, num)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	proc, err := store_.ProcFind(build, pid)
+	proc, err := _store.ProcFind(build, pid)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	file, err := store_.FileFind(proc, name)
+	file, err := _store.FileFind(proc, name)
 	if err != nil {
 		c.String(404, "Error getting file %q. %s", name, err)
 		return
@@ -99,7 +99,7 @@ func FileGet(c *gin.Context) {
 		return
 	}
 
-	rc, err := store_.FileRead(proc, file.Name)
+	rc, err := _store.FileRead(proc, file.Name)
 	if err != nil {
 		c.String(404, "Error getting file stream %q. %s", name, err)
 		return

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -76,10 +76,10 @@ func BlockTilQueueHasRunningItem(c *gin.Context) {
 }
 
 func PostHook(c *gin.Context) {
-	remote_ := server.Config.Services.Remote
-	store_ := store.FromContext(c)
+	_remote := server.Config.Services.Remote
+	_store := store.FromContext(c)
 
-	tmpRepo, build, err := remote_.Hook(c.Request)
+	tmpRepo, build, err := _remote.Hook(c.Request)
 	if err != nil {
 		log.Error().Msgf("failure to parse hook. %s", err)
 		_ = c.AbortWithError(400, err)
@@ -104,7 +104,7 @@ func PostHook(c *gin.Context) {
 		return
 	}
 
-	repo, err := store_.GetRepoName(tmpRepo.Owner + "/" + tmpRepo.Name)
+	repo, err := _store.GetRepoName(tmpRepo.Owner + "/" + tmpRepo.Name)
 	if err != nil {
 		log.Error().Msgf("failure to find repo %s/%s from hook. %s", tmpRepo.Owner, tmpRepo.Name, err)
 		_ = c.AbortWithError(404, err)
@@ -144,7 +144,7 @@ func PostHook(c *gin.Context) {
 		return
 	}
 
-	user, err := store_.GetUser(repo.UserID)
+	user, err := _store.GetUser(repo.UserID)
 	if err != nil {
 		log.Error().Msgf("failure to find repo owner %s. %s", repo.FullName, err)
 		_ = c.AbortWithError(500, err)
@@ -154,12 +154,12 @@ func PostHook(c *gin.Context) {
 	// if the remote has a refresh token, the current access token
 	// may be stale. Therefore, we should refresh prior to dispatching
 	// the build.
-	if refresher, ok := remote_.(remote.Refresher); ok {
+	if refresher, ok := _remote.(remote.Refresher); ok {
 		ok, err := refresher.Refresh(c, user)
 		if err != nil {
 			log.Error().Msgf("failed to refresh oauth2 token: %s", err)
 		} else if ok {
-			if err := store_.UpdateUser(user); err != nil {
+			if err := _store.UpdateUser(user); err != nil {
 				log.Error().Msgf("error while updating user: %s", err)
 				// move forward
 			}
@@ -167,7 +167,7 @@ func PostHook(c *gin.Context) {
 	}
 
 	// fetch the build file from the remote
-	configFetcher := shared.NewConfigFetcher(remote_, user, repo, build)
+	configFetcher := shared.NewConfigFetcher(_remote, user, repo, build)
 	remoteYamlConfigs, err := configFetcher.Fetch(c)
 	if err != nil {
 		log.Error().Msgf("error: %s: cannot find %s in %s: %s", repo.FullName, repo.Config, build.Ref, err)
@@ -199,7 +199,7 @@ func PostHook(c *gin.Context) {
 		build.Status = model.StatusBlocked
 	}
 
-	err = store_.CreateBuild(build, build.Procs...)
+	err = _store.CreateBuild(build, build.Procs...)
 	if err != nil {
 		log.Error().Msgf("failure to save commit for %s. %s", repo.FullName, err)
 		_ = c.AbortWithError(500, err)
@@ -222,7 +222,7 @@ func PostHook(c *gin.Context) {
 		return
 	}
 
-	netrc, err := remote_.Netrc(user, repo)
+	netrc, err := _remote.Netrc(user, repo)
 	if err != nil {
 		c.String(500, "Failed to generate netrc file. %s", err)
 		return
@@ -247,7 +247,7 @@ func PostHook(c *gin.Context) {
 	}
 
 	// get the previous build so that we can send status change notifications
-	last, _ := store_.GetBuildLastBefore(repo, build.Branch, build.ID)
+	last, _ := _store.GetBuildLastBefore(repo, build.Branch, build.ID)
 
 	b := shared.ProcBuilder{
 		Repo:  repo,
@@ -262,14 +262,14 @@ func PostHook(c *gin.Context) {
 	}
 	buildItems, err := b.Build()
 	if err != nil {
-		if _, err = shared.UpdateToStatusError(store_, *build, err); err != nil {
+		if _, err = shared.UpdateToStatusError(_store, *build, err); err != nil {
 			log.Error().Msgf("Error setting error status of build for %s#%d. %s", repo.FullName, build.Number, err)
 		}
 		return
 	}
 	build = shared.SetBuildStepsOnBuild(b.Curr, buildItems)
 
-	err = store_.ProcCreate(build.Procs)
+	err = _store.ProcCreate(build.Procs)
 	if err != nil {
 		log.Error().Msgf("error persisting procs %s/%d: %s", repo.FullName, build.Number, err)
 	}
@@ -278,9 +278,9 @@ func PostHook(c *gin.Context) {
 		for _, item := range buildItems {
 			uri := fmt.Sprintf("%s/%s/build/%d", server.Config.Server.Host, repo.FullName, build.Number)
 			if len(buildItems) > 1 {
-				err = remote_.Status(c, user, repo, build, uri, item.Proc)
+				err = _remote.Status(c, user, repo, build, uri, item.Proc)
 			} else {
-				err = remote_.Status(c, user, repo, build, uri, nil)
+				err = _remote.Status(c, user, repo, build, uri, nil)
 			}
 			if err != nil {
 				log.Error().Msgf("error setting commit status for %s/%d: %v", repo.FullName, build.Number, err)

--- a/server/api/login.go
+++ b/server/api/login.go
@@ -48,7 +48,7 @@ func HandleLogin(c *gin.Context) {
 }
 
 func HandleAuth(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 
 	// when dealing with redirects we may need to adjust the content type. I
 	// cannot, however, remember why, so need to revisit this line.
@@ -68,7 +68,7 @@ func HandleAuth(c *gin.Context) {
 	config := ToConfig(c)
 
 	// get the user from the database
-	u, err := store_.GetUserLogin(tmpuser.Login)
+	u, err := _store.GetUserLogin(tmpuser.Login)
 	if err != nil {
 		// if self-registration is disabled we should return a not authorized error
 		if !config.Open && !config.IsAdmin(tmpuser) {
@@ -101,7 +101,7 @@ func HandleAuth(c *gin.Context) {
 		}
 
 		// insert the user into the database
-		if err := store_.CreateUser(u); err != nil {
+		if err := _store.CreateUser(u); err != nil {
 			log.Error().Msgf("cannot insert %s. %s", u.Login, err)
 			c.Redirect(303, "/login?error=internal_error")
 			return
@@ -125,7 +125,7 @@ func HandleAuth(c *gin.Context) {
 		}
 	}
 
-	if err := store_.UpdateUser(u); err != nil {
+	if err := _store.UpdateUser(u); err != nil {
 		log.Error().Msgf("cannot update %s. %s", u.Login, err)
 		c.Redirect(303, "/login?error=internal_error")
 		return
@@ -156,7 +156,7 @@ func GetLogout(c *gin.Context) {
 }
 
 func GetLoginToken(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 
 	in := &tokenPayload{}
 	err := c.Bind(in)
@@ -171,7 +171,7 @@ func GetLoginToken(c *gin.Context) {
 		return
 	}
 
-	user, err := store_.GetUserLogin(login)
+	user, err := _store.GetUserLogin(login)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusNotFound, err)
 		return

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -37,7 +37,7 @@ const maxTimeout = defaultTimeout * 2
 
 func PostRepo(c *gin.Context) {
 	remote := server.Config.Services.Remote
-	store := store.FromContext(c)
+	_store := store.FromContext(c)
 	user := session.User(c)
 	repo := session.Repo(c)
 
@@ -94,7 +94,7 @@ func PostRepo(c *gin.Context) {
 		repo.Update(from)
 	}
 
-	err = store.UpdateRepo(repo)
+	err = _store.UpdateRepo(repo)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
@@ -104,7 +104,7 @@ func PostRepo(c *gin.Context) {
 }
 
 func PatchRepo(c *gin.Context) {
-	store := store.FromContext(c)
+	_store := store.FromContext(c)
 	repo := session.Repo(c)
 	user := session.User(c)
 
@@ -151,7 +151,7 @@ func PatchRepo(c *gin.Context) {
 		repo.Counter = *in.BuildCounter
 	}
 
-	err := store.UpdateRepo(repo)
+	err := _store.UpdateRepo(repo)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return
@@ -161,12 +161,12 @@ func PatchRepo(c *gin.Context) {
 }
 
 func ChownRepo(c *gin.Context) {
-	store := store.FromContext(c)
+	_store := store.FromContext(c)
 	repo := session.Repo(c)
 	user := session.User(c)
 	repo.UserID = user.ID
 
-	err := store.UpdateRepo(repo)
+	err := _store.UpdateRepo(repo)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/server/api/stream.go
+++ b/server/api/stream.go
@@ -138,20 +138,20 @@ func LogStreamSSE(c *gin.Context) {
 	flusher.Flush()
 
 	repo := session.Repo(c)
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 
 	// // parse the build number and job sequence number from
 	// // the repquest parameter.
 	buildn, _ := strconv.ParseInt(c.Param("build"), 10, 64)
 	jobn, _ := strconv.Atoi(c.Param("number"))
 
-	build, err := store_.GetBuildNumber(repo, buildn)
+	build, err := _store.GetBuildNumber(repo, buildn)
 	if err != nil {
 		log.Debug().Msgf("stream cannot get build number: %v", err)
 		logWriteStringErr(io.WriteString(rw, "event: error\ndata: build not found\n\n"))
 		return
 	}
-	proc, err := store_.ProcFind(build, jobn)
+	proc, err := _store.ProcFind(build, jobn)
 	if err != nil {
 		log.Debug().Msgf("stream cannot get proc number: %v", err)
 		logWriteStringErr(io.WriteString(rw, "event: error\ndata: process not found\n\n"))

--- a/server/api/user.go
+++ b/server/api/user.go
@@ -37,8 +37,8 @@ func GetSelf(c *gin.Context) {
 }
 
 func GetFeed(c *gin.Context) {
-	store_ := store.FromContext(c)
-	remote_ := server.Config.Services.Remote
+	_store := store.FromContext(c)
+	remote := server.Config.Services.Remote
 
 	user := session.User(c)
 	latest, _ := strconv.ParseBool(c.Query("latest"))
@@ -47,7 +47,7 @@ func GetFeed(c *gin.Context) {
 		log.Debug().Msgf("sync begin: %s", user.Login)
 
 		user.Synced = time.Now().Unix()
-		if err := store_.UpdateUser(user); err != nil {
+		if err := _store.UpdateUser(user); err != nil {
 			log.Error().Err(err).Msg("UpdateUser")
 			return
 		}
@@ -55,9 +55,9 @@ func GetFeed(c *gin.Context) {
 		config := ToConfig(c)
 
 		sync := shared.Syncer{
-			Remote: remote_,
-			Store:  store_,
-			Perms:  store_,
+			Remote: remote,
+			Store:  _store,
+			Perms:  _store,
 			Match:  shared.NamespaceFilter(config.OwnersWhitelist),
 		}
 		if err := sync.Sync(c, user); err != nil {
@@ -68,7 +68,7 @@ func GetFeed(c *gin.Context) {
 	}
 
 	if latest {
-		feed, err := store_.RepoListLatest(user)
+		feed, err := _store.RepoListLatest(user)
 		if err != nil {
 			c.String(500, "Error fetching feed. %s", err)
 		} else {
@@ -77,7 +77,7 @@ func GetFeed(c *gin.Context) {
 		return
 	}
 
-	feed, err := store_.UserFeed(user)
+	feed, err := _store.UserFeed(user)
 	if err != nil {
 		c.String(500, "Error fetching user feed. %s", err)
 		return
@@ -86,8 +86,8 @@ func GetFeed(c *gin.Context) {
 }
 
 func GetRepos(c *gin.Context) {
-	store_ := store.FromContext(c)
-	remote_ := server.Config.Services.Remote
+	_store := store.FromContext(c)
+	remote := server.Config.Services.Remote
 
 	user := session.User(c)
 	all, _ := strconv.ParseBool(c.Query("all"))
@@ -96,7 +96,7 @@ func GetRepos(c *gin.Context) {
 	if flush || time.Unix(user.Synced, 0).Add(time.Hour*72).Before(time.Now()) {
 		log.Debug().Msgf("sync begin: %s", user.Login)
 		user.Synced = time.Now().Unix()
-		if err := store_.UpdateUser(user); err != nil {
+		if err := _store.UpdateUser(user); err != nil {
 			log.Err(err).Msgf("update user '%s'", user.Login)
 			return
 		}
@@ -104,9 +104,9 @@ func GetRepos(c *gin.Context) {
 		config := ToConfig(c)
 
 		sync := shared.Syncer{
-			Remote: remote_,
-			Store:  store_,
-			Perms:  store_,
+			Remote: remote,
+			Store:  _store,
+			Perms:  _store,
 			Match:  shared.NamespaceFilter(config.OwnersWhitelist),
 		}
 
@@ -117,7 +117,7 @@ func GetRepos(c *gin.Context) {
 		}
 	}
 
-	repos, err := store_.RepoList(user, true)
+	repos, err := _store.RepoList(user, true)
 	if err != nil {
 		c.String(500, "Error fetching repository list. %s", err)
 		return
@@ -148,13 +148,13 @@ func PostToken(c *gin.Context) {
 }
 
 func DeleteToken(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 
 	user := session.User(c)
 	user.Hash = base32.StdEncoding.EncodeToString(
 		securecookie.GenerateRandomKey(32),
 	)
-	if err := store_.UpdateUser(user); err != nil {
+	if err := _store.UpdateUser(user); err != nil {
 		c.String(500, "Error revoking tokens. %s", err)
 		return
 	}

--- a/server/api/users.go
+++ b/server/api/users.go
@@ -44,7 +44,7 @@ func GetUser(c *gin.Context) {
 }
 
 func PatchUser(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 
 	in := &model.User{}
 	err := c.Bind(in)
@@ -53,14 +53,14 @@ func PatchUser(c *gin.Context) {
 		return
 	}
 
-	user, err := store_.GetUserLogin(c.Param("login"))
+	user, err := _store.GetUserLogin(c.Param("login"))
 	if err != nil {
 		c.AbortWithStatus(http.StatusNotFound)
 		return
 	}
 	user.Active = in.Active
 
-	err = store_.UpdateUser(user)
+	err = _store.UpdateUser(user)
 	if err != nil {
 		c.AbortWithStatus(http.StatusConflict)
 		return
@@ -97,14 +97,14 @@ func PostUser(c *gin.Context) {
 }
 
 func DeleteUser(c *gin.Context) {
-	store_ := store.FromContext(c)
+	_store := store.FromContext(c)
 
-	user, err := store_.GetUserLogin(c.Param("login"))
+	user, err := _store.GetUserLogin(c.Param("login"))
 	if err != nil {
 		c.String(404, "Cannot find user. %s", err)
 		return
 	}
-	if err = store_.DeleteUser(user); err != nil {
+	if err = _store.DeleteUser(user); err != nil {
 		c.String(500, "Error deleting user. %s", err)
 		return
 	}

--- a/server/grpc/rpc.go
+++ b/server/grpc/rpc.go
@@ -80,10 +80,9 @@ func (s *RPC) Next(c context.Context, filter rpc.Filter) (*rpc.Pipeline, error) 
 			pipeline := new(rpc.Pipeline)
 			err = json.Unmarshal(task.Data, pipeline)
 			return pipeline, err
-		} else {
-			if err := s.Done(c, task.ID, rpc.State{}); err != nil {
-				log.Error().Err(err).Msgf("mark task '%s' done failed", task.ID)
-			}
+		}
+		if err := s.Done(c, task.ID, rpc.State{}); err != nil {
+			log.Error().Err(err).Msgf("mark task '%s' done failed", task.ID)
 		}
 	}
 }

--- a/server/model/cc_test.go
+++ b/server/model/cc_test.go
@@ -26,7 +26,7 @@ func TestCC(t *testing.T) {
 	g.Describe("CC", func() {
 		g.It("Should create a project", func() {
 			now := time.Now().Unix()
-			now_fmt := time.Unix(now, 0).Format(time.RFC3339)
+			nowFmt := time.Unix(now, 0).Format(time.RFC3339)
 			r := &Repo{
 				FullName: "foo/bar",
 			}
@@ -41,7 +41,7 @@ func TestCC(t *testing.T) {
 			g.Assert(cc.Project.Activity).Equal("Sleeping")
 			g.Assert(cc.Project.LastBuildStatus).Equal("Success")
 			g.Assert(cc.Project.LastBuildLabel).Equal("1")
-			g.Assert(cc.Project.LastBuildTime).Equal(now_fmt)
+			g.Assert(cc.Project.LastBuildTime).Equal(nowFmt)
 			g.Assert(cc.Project.WebURL).Equal("http://localhost/foo/bar/1")
 		})
 

--- a/server/model/repo.go
+++ b/server/model/repo.go
@@ -65,7 +65,7 @@ func (r *Repo) ResetVisibility() {
 func ParseRepo(str string) (user, repo string, err error) {
 	var parts = strings.Split(str, "/")
 	if len(parts) != 2 {
-		err = fmt.Errorf("Error: Invalid or missing repository. eg octocat/hello-world.")
+		err = fmt.Errorf("Error: Invalid or missing repository. eg octocat/hello-world")
 		return
 	}
 	user = parts[0]

--- a/server/queue/fifo_test.go
+++ b/server/queue/fifo_test.go
@@ -291,32 +291,30 @@ func TestFifoErrorsMultiThread(t *testing.T) {
 				if got != task1 {
 					t.Errorf("expect task1 returned from queue as task2 and task3 depends on it")
 					return
-				} else {
-					task1Processed = true
-					assert.NoError(t, q.Error(noContext, got.ID, fmt.Errorf("exitcode 1, there was an error")))
-					go func() {
-						for {
-							fmt.Printf("Worker spawned\n")
-							got, _ := q.Poll(noContext, func(*Task) bool { return true })
-							obtainedWorkCh <- got
-						}
-					}()
 				}
+				task1Processed = true
+				assert.NoError(t, q.Error(noContext, got.ID, fmt.Errorf("exitcode 1, there was an error")))
+				go func() {
+					for {
+						fmt.Printf("Worker spawned\n")
+						got, _ := q.Poll(noContext, func(*Task) bool { return true })
+						obtainedWorkCh <- got
+					}
+				}()
 			} else if !task2Processed {
 				if got != task2 {
 					t.Errorf("expect task2 returned from queue")
 					return
-				} else {
-					task2Processed = true
-					assert.NoError(t, q.Done(noContext, got.ID, StatusSuccess))
-					go func() {
-						for {
-							fmt.Printf("Worker spawned\n")
-							got, _ := q.Poll(noContext, func(*Task) bool { return true })
-							obtainedWorkCh <- got
-						}
-					}()
 				}
+				task2Processed = true
+				assert.NoError(t, q.Done(noContext, got.ID, StatusSuccess))
+				go func() {
+					for {
+						fmt.Printf("Worker spawned\n")
+						got, _ := q.Poll(noContext, func(*Task) bool { return true })
+						obtainedWorkCh <- got
+					}
+				}()
 			} else {
 				if got != task3 {
 					t.Errorf("expect task3 returned from queue")
@@ -326,9 +324,8 @@ func TestFifoErrorsMultiThread(t *testing.T) {
 				if got.ShouldRun() {
 					t.Errorf("expect task3 should not run, task1 succeeded but task2 failed")
 					return
-				} else {
-					return
 				}
+				return
 			}
 
 		case <-time.After(5 * time.Second):

--- a/server/remote/bitbucket/bitbucket.go
+++ b/server/remote/bitbucket/bitbucket.go
@@ -226,7 +226,7 @@ func (c *config) Status(ctx context.Context, u *model.User, r *model.Repo, b *mo
 		State: convertStatus(b.Status),
 		Desc:  convertDesc(b.Status),
 		Key:   "Woodpecker",
-		Url:   link,
+		URL:   link,
 	}
 	return c.newClient(ctx, u).CreateStatus(r.Owner, r.Name, b.Commit, &status)
 }
@@ -245,7 +245,7 @@ func (c *config) Activate(ctx context.Context, u *model.User, r *model.Repo, lin
 		Active: true,
 		Desc:   rawurl.Host,
 		Events: []string{"repo:push"},
-		Url:    link,
+		URL:    link,
 	})
 }
 
@@ -260,7 +260,7 @@ func (c *config) Deactivate(ctx context.Context, u *model.User, r *model.Repo, l
 	}
 	hook := matchingHooks(hooks.Values, link)
 	if hook != nil {
-		return client.DeleteHook(r.Owner, r.Name, hook.Uuid)
+		return client.DeleteHook(r.Owner, r.Name, hook.UUID)
 	}
 	return nil
 }
@@ -326,7 +326,7 @@ func matchingHooks(hooks []*internal.Hook, rawurl string) *internal.Hook {
 		return nil
 	}
 	for _, hook := range hooks {
-		hookurl, err := url.Parse(hook.Url)
+		hookurl, err := url.Parse(hook.URL)
 		if err == nil && hookurl.Host == link.Host {
 			return hook
 		}

--- a/server/remote/bitbucket/bitbucket_test.go
+++ b/server/remote/bitbucket/bitbucket_test.go
@@ -234,14 +234,14 @@ func Test_bitbucket(t *testing.T) {
 		g.Describe("Given a list of hooks", func() {
 			g.It("Should return the matching hook", func() {
 				hooks := []*internal.Hook{
-					{Url: "http://127.0.0.1/hook"},
+					{URL: "http://127.0.0.1/hook"},
 				}
 				hook := matchingHooks(hooks, "http://127.0.0.1/")
 				g.Assert(hook).Equal(hooks[0])
 			})
 			g.It("Should handle no matches", func() {
 				hooks := []*internal.Hook{
-					{Url: "http://localhost/hook"},
+					{URL: "http://localhost/hook"},
 				}
 				hook := matchingHooks(hooks, "http://127.0.0.1/")
 				g.Assert(hook).IsNil()

--- a/server/remote/bitbucket/convert.go
+++ b/server/remote/bitbucket/convert.go
@@ -81,7 +81,7 @@ func convertRepo(from *internal.Repo) *model.Repo {
 		Owner:        strings.Split(from.FullName, "/")[0],
 		Name:         strings.Split(from.FullName, "/")[1],
 		FullName:     from.FullName,
-		Link:         from.Links.Html.Href,
+		Link:         from.Links.HTML.Href,
 		IsSCMPrivate: from.IsPrivate,
 		Avatar:       from.Owner.Links.Avatar.Href,
 		SCMKind:      model.SCMKind(from.Scm),
@@ -110,7 +110,7 @@ func cloneLink(repo *internal.Repo) string {
 	// if no repository name is provided, we use the Html link. this excludes the
 	// .git suffix, but will still clone the repo.
 	if len(clone) == 0 {
-		clone = repo.Links.Html.Href
+		clone = repo.Links.HTML.Href
 	}
 
 	// if bitbucket tries to automatically populate the user in the url we must
@@ -167,7 +167,7 @@ func convertPullHook(from *internal.PullRequestHook) *model.Build {
 			from.PullRequest.Dest.Branch.Name,
 		),
 		Remote:    fmt.Sprintf("https://bitbucket.org/%s", from.PullRequest.Source.Repo.FullName),
-		Link:      from.PullRequest.Links.Html.Href,
+		Link:      from.PullRequest.Links.HTML.Href,
 		Branch:    from.PullRequest.Dest.Branch.Name,
 		Message:   from.PullRequest.Desc,
 		Avatar:    from.Actor.Links.Avatar.Href,
@@ -182,7 +182,7 @@ func convertPullHook(from *internal.PullRequestHook) *model.Build {
 func convertPushHook(hook *internal.PushHook, change *internal.Change) *model.Build {
 	build := &model.Build{
 		Commit:    change.New.Target.Hash,
-		Link:      change.New.Target.Links.Html.Href,
+		Link:      change.New.Target.Links.HTML.Href,
 		Branch:    change.New.Name,
 		Message:   change.New.Target.Message,
 		Avatar:    hook.Actor.Links.Avatar.Href,

--- a/server/remote/bitbucket/convert_test.go
+++ b/server/remote/bitbucket/convert_test.go
@@ -68,7 +68,7 @@ func Test_helper(t *testing.T) {
 				Scm:       "hg",
 			}
 			from.Owner.Links.Avatar.Href = "http://..."
-			from.Links.Html.Href = "https://bitbucket.org/foo/bar"
+			from.Links.HTML.Href = "https://bitbucket.org/foo/bar"
 
 			to := convertRepo(from)
 			g.Assert(to.Avatar).Equal(from.Owner.Links.Avatar.Href)
@@ -78,8 +78,8 @@ func Test_helper(t *testing.T) {
 			g.Assert(to.Branch).Equal("default")
 			g.Assert(string(to.SCMKind)).Equal(from.Scm)
 			g.Assert(to.IsSCMPrivate).Equal(from.IsPrivate)
-			g.Assert(to.Clone).Equal(from.Links.Html.Href)
-			g.Assert(to.Link).Equal(from.Links.Html.Href)
+			g.Assert(to.Clone).Equal(from.Links.HTML.Href)
+			g.Assert(to.Link).Equal(from.Links.HTML.Href)
 		})
 
 		g.It("should convert team", func() {
@@ -127,7 +127,7 @@ func Test_helper(t *testing.T) {
 
 		g.It("should build clone url", func() {
 			repo := &internal.Repo{}
-			repo.Links.Html.Href = "https://foo:bar@bitbucket.org/foo/bar.git"
+			repo.Links.HTML.Href = "https://foo:bar@bitbucket.org/foo/bar.git"
 			link := cloneLink(repo)
 			g.Assert(link).Equal("https://bitbucket.org/foo/bar.git")
 		})
@@ -138,10 +138,10 @@ func Test_helper(t *testing.T) {
 			hook.Actor.Links.Avatar.Href = "https://..."
 			hook.PullRequest.Dest.Commit.Hash = "73f9c44d"
 			hook.PullRequest.Dest.Branch.Name = "master"
-			hook.PullRequest.Dest.Repo.Links.Html.Href = "https://bitbucket.org/foo/bar"
+			hook.PullRequest.Dest.Repo.Links.HTML.Href = "https://bitbucket.org/foo/bar"
 			hook.PullRequest.Source.Branch.Name = "change"
 			hook.PullRequest.Source.Repo.FullName = "baz/bar"
-			hook.PullRequest.Links.Html.Href = "https://bitbucket.org/foo/bar/pulls/5"
+			hook.PullRequest.Links.HTML.Href = "https://bitbucket.org/foo/bar/pulls/5"
 			hook.PullRequest.Desc = "updated README"
 			hook.PullRequest.Updated = time.Now()
 
@@ -151,7 +151,7 @@ func Test_helper(t *testing.T) {
 			g.Assert(build.Avatar).Equal(hook.Actor.Links.Avatar.Href)
 			g.Assert(build.Commit).Equal(hook.PullRequest.Dest.Commit.Hash)
 			g.Assert(build.Branch).Equal(hook.PullRequest.Dest.Branch.Name)
-			g.Assert(build.Link).Equal(hook.PullRequest.Links.Html.Href)
+			g.Assert(build.Link).Equal(hook.PullRequest.Links.HTML.Href)
 			g.Assert(build.Ref).Equal("refs/heads/master")
 			g.Assert(build.Refspec).Equal("change:master")
 			g.Assert(build.Remote).Equal("https://bitbucket.org/baz/bar")
@@ -163,7 +163,7 @@ func Test_helper(t *testing.T) {
 			change := internal.Change{}
 			change.New.Target.Hash = "73f9c44d"
 			change.New.Name = "master"
-			change.New.Target.Links.Html.Href = "https://bitbucket.org/foo/bar/commits/73f9c44d"
+			change.New.Target.Links.HTML.Href = "https://bitbucket.org/foo/bar/commits/73f9c44d"
 			change.New.Target.Message = "updated README"
 			change.New.Target.Date = time.Now()
 			change.New.Target.Author.Raw = "Test <test@domain.tld>"
@@ -179,7 +179,7 @@ func Test_helper(t *testing.T) {
 			g.Assert(build.Avatar).Equal(hook.Actor.Links.Avatar.Href)
 			g.Assert(build.Commit).Equal(change.New.Target.Hash)
 			g.Assert(build.Branch).Equal(change.New.Name)
-			g.Assert(build.Link).Equal(change.New.Target.Links.Html.Href)
+			g.Assert(build.Link).Equal(change.New.Target.Links.HTML.Href)
 			g.Assert(build.Ref).Equal("refs/heads/master")
 			g.Assert(build.Message).Equal(change.New.Target.Message)
 			g.Assert(build.Timestamp).Equal(change.New.Target.Date.Unix())

--- a/server/remote/bitbucket/internal/client.go
+++ b/server/remote/bitbucket/internal/client.go
@@ -171,9 +171,8 @@ func (c *Client) GetPermission(fullName string) (*RepoPerm, error) {
 
 	if len(out.Values) == 0 {
 		return nil, fmt.Errorf("no permissions in repository %s", fullName)
-	} else {
-		return out.Values[0], nil
 	}
+	return out.Values[0], nil
 }
 
 func (c *Client) do(rawurl, method string, in, out interface{}) (*string, error) {

--- a/server/remote/bitbucket/internal/types.go
+++ b/server/remote/bitbucket/internal/types.go
@@ -39,7 +39,7 @@ type BuildStatus struct {
 	State string `json:"state"`
 	Key   string `json:"key"`
 	Name  string `json:"name,omitempty"`
-	Url   string `json:"url"`
+	URL   string `json:"url"`
 	Desc  string `json:"description,omitempty"`
 }
 
@@ -58,9 +58,9 @@ type EmailResp struct {
 }
 
 type Hook struct {
-	Uuid   string   `json:"uuid,omitempty"`
+	UUID   string   `json:"uuid,omitempty"`
 	Desc   string   `json:"description"`
-	Url    string   `json:"url"`
+	URL    string   `json:"url"`
 	Events []string `json:"events"`
 	Active bool     `json:"active"`
 }
@@ -75,7 +75,7 @@ type HookResp struct {
 
 type Links struct {
 	Avatar Link   `json:"avatar"`
-	Html   Link   `json:"html"`
+	HTML   Link   `json:"html"`
 	Clone  []Link `json:"clone"`
 }
 

--- a/server/remote/bitbucketserver/bitbucketserver.go
+++ b/server/remote/bitbucketserver/bitbucketserver.go
@@ -191,7 +191,7 @@ func (c *Config) Status(ctx context.Context, u *model.User, r *model.Repo, b *mo
 		Desc:  convertDesc(b.Status),
 		Name:  fmt.Sprintf("Woodpecker #%d - %s", b.Number, b.Branch),
 		Key:   "Woodpecker",
-		Url:   link,
+		URL:   link,
 	}
 
 	client := internal.NewClientWithToken(ctx, c.URL, c.Consumer, u.Token)

--- a/server/remote/bitbucketserver/internal/client.go
+++ b/server/remote/bitbucketserver/internal/client.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	currentUserId    = "%s/plugins/servlet/applinks/whoami"
+	currentUserID    = "%s/plugins/servlet/applinks/whoami"
 	pathUser         = "%s/rest/api/1.0/users/%s"
 	pathRepo         = "%s/rest/api/1.0/projects/%s/repos/%s"
 	pathRepos        = "%s/rest/api/1.0/repos?start=%s&limit=%s"
@@ -69,15 +69,15 @@ func NewClientWithToken(ctx context.Context, url string, consumer *oauth.Consume
 }
 
 func (c *Client) FindCurrentUser() (*User, error) {
-	CurrentUserIdResponse, err := c.doGet(fmt.Sprintf(currentUserId, c.base))
-	if CurrentUserIdResponse != nil {
-		defer CurrentUserIdResponse.Body.Close()
+	CurrentUserIDResponse, err := c.doGet(fmt.Sprintf(currentUserID, c.base))
+	if CurrentUserIDResponse != nil {
+		defer CurrentUserIDResponse.Body.Close()
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	bits, err := ioutil.ReadAll(CurrentUserIdResponse.Body)
+	bits, err := ioutil.ReadAll(CurrentUserIDResponse.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -299,8 +299,8 @@ func (c *Client) doPost(url string, status *BuildStatus) error {
 //Helper function to get repos paginated
 func (c *Client) paginatedRepos(start int) ([]*Repo, error) {
 	limit := 1000
-	requestUrl := fmt.Sprintf(pathRepos, c.base, strconv.Itoa(start), strconv.Itoa(limit))
-	response, err := c.doGet(requestUrl)
+	requestURL := fmt.Sprintf(pathRepos, c.base, strconv.Itoa(start), strconv.Itoa(limit))
+	response, err := c.doGet(requestURL)
 	if response != nil {
 		defer response.Body.Close()
 	}

--- a/server/remote/bitbucketserver/internal/types.go
+++ b/server/remote/bitbucketserver/internal/types.go
@@ -42,7 +42,7 @@ type BuildStatus struct {
 	State string `json:"state"`
 	Key   string `json:"key"`
 	Name  string `json:"name,omitempty"`
-	Url   string `json:"url"`
+	URL   string `json:"url"`
 	Desc  string `json:"description,omitempty"`
 }
 

--- a/server/remote/coding/coding.go
+++ b/server/remote/coding/coding.go
@@ -175,7 +175,7 @@ func (c *Coding) Repo(ctx context.Context, u *model.User, owner, name string) (*
 		Avatar:       c.resourceLink(project.Icon),
 		Link:         c.resourceLink(project.DepotPath),
 		SCMKind:      model.RepoGit,
-		Clone:        project.HttpsURL,
+		Clone:        project.HTTPSURL,
 		Branch:       depot.DefaultBranch,
 		IsSCMPrivate: !project.IsPublic,
 	}, nil
@@ -202,7 +202,7 @@ func (c *Coding) Repos(ctx context.Context, u *model.User) ([]*model.Repo, error
 			Avatar:       c.resourceLink(project.Icon),
 			Link:         c.resourceLink(project.DepotPath),
 			SCMKind:      model.RepoGit,
-			Clone:        project.HttpsURL,
+			Clone:        project.HTTPSURL,
 			Branch:       depot.DefaultBranch,
 			IsSCMPrivate: !project.IsPublic,
 		}

--- a/server/remote/coding/hook.go
+++ b/server/remote/coding/hook.go
@@ -39,8 +39,8 @@ type User struct {
 
 type Repository struct {
 	Name     string `json:"name"`
-	HttpsURL string `json:"https_url"`
-	SshURL   string `json:"ssh_url"`
+	HTTPSURL string `json:"https_url"`
+	SSHURL   string `json:"ssh_url"`
 	WebURL   string `json:"web_url"`
 	Owner    *User  `json:"owner"`
 }
@@ -131,9 +131,9 @@ func findLastCommit(commits []*Commit, sha string) *Commit {
 func convertRepository(repo *Repository) (*model.Repo, error) {
 	// tricky stuff for a team project without a team owner instead of a user owner
 	re := regexp.MustCompile(`git@.+:([^/]+)/.+\.git`)
-	matches := re.FindStringSubmatch(repo.SshURL)
+	matches := re.FindStringSubmatch(repo.SSHURL)
 	if len(matches) != 2 {
-		return nil, fmt.Errorf("Unable to resolve owner from ssh url %q", repo.SshURL)
+		return nil, fmt.Errorf("Unable to resolve owner from ssh url %q", repo.SSHURL)
 	}
 
 	return &model.Repo{
@@ -173,7 +173,7 @@ func parsePushHook(raw []byte) (*model.Repo, *model.Build, error) {
 		Email:   lastCommit.Committer.Email,
 		Avatar:  hook.User.Avatar,
 		Author:  hook.User.GlobalKey,
-		Remote:  hook.Repository.HttpsURL,
+		Remote:  hook.Repository.HTTPSURL,
 	}
 	return repo, build, nil
 }
@@ -203,7 +203,7 @@ func parsePullRequestHook(raw []byte) (*model.Repo, *model.Build, error) {
 		Author:  hook.PullRequest.User.GlobalKey,
 		Avatar:  hook.PullRequest.User.Avatar,
 		Title:   hook.PullRequest.Title,
-		Remote:  hook.Repository.HttpsURL,
+		Remote:  hook.Repository.HTTPSURL,
 		Refspec: fmt.Sprintf("%s:%s", hook.PullRequest.SourceBranch, hook.PullRequest.TargetBranch),
 	}
 
@@ -236,7 +236,7 @@ func parseMergeReuqestHook(raw []byte) (*model.Repo, *model.Build, error) {
 		Author:  hook.MergeRequest.User.GlobalKey,
 		Avatar:  hook.MergeRequest.User.Avatar,
 		Title:   hook.MergeRequest.Title,
-		Remote:  hook.Repository.HttpsURL,
+		Remote:  hook.Repository.HTTPSURL,
 		Refspec: fmt.Sprintf("%s:%s", hook.MergeRequest.SourceBranch, hook.MergeRequest.TargetBranch),
 	}
 	return repo, build, nil

--- a/server/remote/coding/hook_test.go
+++ b/server/remote/coding/hook_test.go
@@ -83,8 +83,8 @@ func Test_hook(t *testing.T) {
 		g.It("Should convert repository", func() {
 			repository := &Repository{
 				Name:     "test_project",
-				HttpsURL: "https://git.coding.net/kelvin/test_project.git",
-				SshURL:   "git@git.coding.net:kelvin/test_project.git",
+				HTTPSURL: "https://git.coding.net/kelvin/test_project.git",
+				SSHURL:   "git@git.coding.net:kelvin/test_project.git",
 				WebURL:   "https://coding.net/u/kelvin/p/test_project",
 				Owner: &User{
 					GlobalKey: "kelvin",

--- a/server/remote/coding/internal/project.go
+++ b/server/remote/coding/internal/project.go
@@ -24,7 +24,7 @@ type Project struct {
 	Owner     string `json:"owner_user_name"`
 	Name      string `json:"name"`
 	DepotPath string `json:"depot_path"`
-	HttpsURL  string `json:"https_url"`
+	HTTPSURL  string `json:"https_url"`
 	IsPublic  bool   `json:"is_public"`
 	Icon      string `json:"icon"`
 	Role      string `json:"current_user_role"`

--- a/server/remote/coding/internal/webhook.go
+++ b/server/remote/coding/internal/webhook.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Webhook struct {
-	Id      int    `json:"id"`
+	ID      int    `json:"id"`
 	HookURL string `json:"hook_url"`
 }
 
@@ -46,7 +46,7 @@ func (c *Client) AddWebhook(globalKey, projectName, link string) error {
 	}
 	webhook := matchingHooks(webhooks, link)
 	if webhook != nil {
-		u := fmt.Sprintf("/user/%s/project/%s/git/hook/%d", globalKey, projectName, webhook.Id)
+		u := fmt.Sprintf("/user/%s/project/%s/git/hook/%d", globalKey, projectName, webhook.ID)
 		params := url.Values{}
 		params.Set("hook_url", link)
 		params.Set("type_pust", "true")
@@ -82,7 +82,7 @@ func (c *Client) RemoveWebhook(globalKey, projectName, link string) error {
 		return nil
 	}
 
-	u := fmt.Sprintf("/user/%s/project/%s/git/hook/%d", globalKey, projectName, webhook.Id)
+	u := fmt.Sprintf("/user/%s/project/%s/git/hook/%d", globalKey, projectName, webhook.ID)
 	_, err = c.Do("DELETE", u, nil)
 	if err != nil {
 		return APIClientErr{"fail to remove webhook", u, err}

--- a/server/remote/gitlab/convert.go
+++ b/server/remote/gitlab/convert.go
@@ -26,20 +26,20 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server/model"
 )
 
-func (g *Gitlab) convertGitlabRepo(repo_ *gitlab.Project) (*model.Repo, error) {
-	parts := strings.Split(repo_.PathWithNamespace, "/")
+func (g *Gitlab) convertGitlabRepo(_repo *gitlab.Project) (*model.Repo, error) {
+	parts := strings.Split(_repo.PathWithNamespace, "/")
 	// TODO: save repo id (support nested repos)
 	var owner = parts[0]
 	var name = parts[1]
 	repo := &model.Repo{
 		Owner:      owner,
 		Name:       name,
-		FullName:   repo_.PathWithNamespace,
-		Avatar:     repo_.AvatarURL,
-		Link:       repo_.WebURL,
-		Clone:      repo_.HTTPURLToRepo,
-		Branch:     repo_.DefaultBranch,
-		Visibility: model.RepoVisibly(repo_.Visibility),
+		FullName:   _repo.PathWithNamespace,
+		Avatar:     _repo.AvatarURL,
+		Link:       _repo.WebURL,
+		Clone:      _repo.HTTPURLToRepo,
+		Branch:     _repo.DefaultBranch,
+		Visibility: model.RepoVisibly(_repo.Visibility),
 	}
 
 	if len(repo.Branch) == 0 { // TODO: do we need that?
@@ -53,7 +53,7 @@ func (g *Gitlab) convertGitlabRepo(repo_ *gitlab.Project) (*model.Repo, error) {
 	if g.PrivateMode {
 		repo.IsSCMPrivate = true
 	} else {
-		repo.IsSCMPrivate = !repo_.Public
+		repo.IsSCMPrivate = !_repo.Public
 	}
 
 	return repo, nil

--- a/server/remote/gitlab/gitlab.go
+++ b/server/remote/gitlab/gitlab.go
@@ -119,12 +119,12 @@ func (g *Gitlab) Login(ctx context.Context, res http.ResponseWriter, req *http.R
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: g.SkipVerify},
 		Proxy:           http.ProxyFromEnvironment,
 	}}
-	var _token, err = trans.Exchange(code)
+	var token, err = trans.Exchange(code)
 	if err != nil {
 		return nil, fmt.Errorf("Error exchanging token. %s", err)
 	}
 
-	client, err := newClient(g.URL, _token.AccessToken, g.SkipVerify)
+	client, err := newClient(g.URL, token.AccessToken, g.SkipVerify)
 	if err != nil {
 		return nil, err
 	}
@@ -138,8 +138,8 @@ func (g *Gitlab) Login(ctx context.Context, res http.ResponseWriter, req *http.R
 		Login:  login.Username,
 		Email:  login.Email,
 		Avatar: login.AvatarURL,
-		Token:  _token.AccessToken,
-		Secret: _token.RefreshToken,
+		Token:  token.AccessToken,
+		Secret: token.RefreshToken,
 	}
 	if !strings.HasPrefix(user.Avatar, "http") {
 		user.Avatar = g.URL + "/" + login.AvatarURL

--- a/server/remote/gitlab/gitlab.go
+++ b/server/remote/gitlab/gitlab.go
@@ -91,7 +91,7 @@ func New(opts Opts) (remote.Remote, error) {
 // remote user details.
 func (g *Gitlab) Login(ctx context.Context, res http.ResponseWriter, req *http.Request) (*model.User, error) {
 	var config = &oauth2.Config{
-		ClientId:     g.ClientID,
+		ClientID:     g.ClientID,
 		ClientSecret: g.ClientSecret,
 		Scope:        defaultScope,
 		AuthURL:      fmt.Sprintf("%s/oauth/authorize", g.URL),
@@ -119,12 +119,12 @@ func (g *Gitlab) Login(ctx context.Context, res http.ResponseWriter, req *http.R
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: g.SkipVerify},
 		Proxy:           http.ProxyFromEnvironment,
 	}}
-	var token_, err = trans.Exchange(code)
+	var _token, err = trans.Exchange(code)
 	if err != nil {
 		return nil, fmt.Errorf("Error exchanging token. %s", err)
 	}
 
-	client, err := newClient(g.URL, token_.AccessToken, g.SkipVerify)
+	client, err := newClient(g.URL, _token.AccessToken, g.SkipVerify)
 	if err != nil {
 		return nil, err
 	}
@@ -138,8 +138,8 @@ func (g *Gitlab) Login(ctx context.Context, res http.ResponseWriter, req *http.R
 		Login:  login.Username,
 		Email:  login.Email,
 		Avatar: login.AvatarURL,
-		Token:  token_.AccessToken,
-		Secret: token_.RefreshToken,
+		Token:  _token.AccessToken,
+		Secret: _token.RefreshToken,
 	}
 	if !strings.HasPrefix(user.Avatar, "http") {
 		user.Avatar = g.URL + "/" + login.AvatarURL
@@ -214,12 +214,12 @@ func (g *Gitlab) Repo(ctx context.Context, user *model.User, owner, name string)
 		return nil, err
 	}
 
-	repo_, err := g.getProject(ctx, client, owner, name)
+	_repo, err := g.getProject(ctx, client, owner, name)
 	if err != nil {
 		return nil, err
 	}
 
-	return g.convertGitlabRepo(repo_)
+	return g.convertGitlabRepo(_repo)
 }
 
 // Repos fetches a list of repos from the remote system.
@@ -291,11 +291,11 @@ func (g *Gitlab) File(ctx context.Context, user *model.User, repo *model.Repo, b
 	if err != nil {
 		return nil, err
 	}
-	repo_, err := g.getProject(ctx, client, repo.Owner, repo.Name)
+	_repo, err := g.getProject(ctx, client, repo.Owner, repo.Name)
 	if err != nil {
 		return nil, err
 	}
-	file, _, err := client.RepositoryFiles.GetRawFile(repo_.ID, fileName, &gitlab.GetRawFileOptions{Ref: &build.Commit}, gitlab.WithContext(ctx))
+	file, _, err := client.RepositoryFiles.GetRawFile(_repo.ID, fileName, &gitlab.GetRawFileOptions{Ref: &build.Commit}, gitlab.WithContext(ctx))
 	return file, err
 }
 
@@ -307,7 +307,7 @@ func (g *Gitlab) Dir(ctx context.Context, user *model.User, repo *model.Repo, bu
 	}
 
 	files := make([]*remote.FileMeta, 0, perPage)
-	repo_, err := g.getProject(ctx, client, repo.Owner, repo.Name)
+	_repo, err := g.getProject(ctx, client, repo.Owner, repo.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (g *Gitlab) Dir(ctx context.Context, user *model.User, repo *model.Repo, bu
 
 	for i := 1; true; i++ {
 		opts.Page = 1
-		batch, _, err := client.Repositories.ListTree(repo_.ID, opts, gitlab.WithContext(ctx))
+		batch, _, err := client.Repositories.ListTree(_repo.ID, opts, gitlab.WithContext(ctx))
 		if err != nil {
 			return nil, err
 		}
@@ -354,12 +354,12 @@ func (g *Gitlab) Status(ctx context.Context, user *model.User, repo *model.Repo,
 		return err
 	}
 
-	repo_, err := g.getProject(ctx, client, repo.Owner, repo.Name)
+	_repo, err := g.getProject(ctx, client, repo.Owner, repo.Name)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = client.Commits.SetCommitStatus(repo_.ID, build.Commit, &gitlab.SetCommitStatusOptions{
+	_, _, err = client.Commits.SetCommitStatus(_repo.ID, build.Commit, &gitlab.SetCommitStatusOptions{
 		Ref:         gitlab.String(strings.ReplaceAll(build.Ref, "refs/heads/", "")),
 		State:       getStatus(build.Status),
 		Description: gitlab.String(getDesc(build.Status)),
@@ -401,16 +401,16 @@ func (g *Gitlab) Activate(ctx context.Context, user *model.User, repo *model.Rep
 		return err
 	}
 	token := uri.Query().Get("access_token")
-	webUrl := fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)
+	webURL := fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)
 
-	repo_, err := g.getProject(ctx, client, repo.Owner, repo.Name)
+	_repo, err := g.getProject(ctx, client, repo.Owner, repo.Name)
 	if err != nil {
 		return err
 	}
 	// TODO: "WoodpeckerCIService"
-	_, err = client.Services.SetDroneCIService(repo_.ID, &gitlab.SetDroneCIServiceOptions{
+	_, err = client.Services.SetDroneCIService(_repo.ID, &gitlab.SetDroneCIServiceOptions{
 		Token:                 &token,
-		DroneURL:              &webUrl,
+		DroneURL:              &webURL,
 		EnableSSLVerification: gitlab.Bool(!g.SkipVerify),
 	}, gitlab.WithContext(ctx))
 	return err
@@ -424,12 +424,12 @@ func (g *Gitlab) Deactivate(ctx context.Context, user *model.User, repo *model.R
 		return err
 	}
 
-	repo_, err := g.getProject(ctx, client, repo.Owner, repo.Name)
+	_repo, err := g.getProject(ctx, client, repo.Owner, repo.Name)
 	if err != nil {
 		return err
 	}
 	// TODO: "WoodpeckerCIService"
-	_, err = client.Services.DeleteDroneCIService(repo_.ID, gitlab.WithContext(ctx))
+	_, err = client.Services.DeleteDroneCIService(_repo.ID, gitlab.WithContext(ctx))
 
 	return err
 }
@@ -441,12 +441,12 @@ func (g *Gitlab) Branches(ctx context.Context, user *model.User, repo *model.Rep
 		return nil, err
 	}
 
-	repo_, err := g.getProject(ctx, client, repo.Owner, repo.Name)
+	_repo, err := g.getProject(ctx, client, repo.Owner, repo.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	gitlabBranches, _, err := client.Branches.ListBranches(repo_.ID, &gitlab.ListBranchesOptions{}, gitlab.WithContext(ctx))
+	gitlabBranches, _, err := client.Branches.ListBranches(_repo.ID, &gitlab.ListBranchesOptions{}, gitlab.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote/gitlab/gitlab_test.go
+++ b/server/remote/gitlab/gitlab_test.go
@@ -30,15 +30,15 @@ import (
 )
 
 func load(config string) *Gitlab {
-	url_, err := url.Parse(config)
+	_url, err := url.Parse(config)
 	if err != nil {
 		panic(err)
 	}
-	params := url_.Query()
-	url_.RawQuery = ""
+	params := _url.Query()
+	_url.RawQuery = ""
 
 	gitlab := Gitlab{}
-	gitlab.URL = url_.String()
+	gitlab.URL = _url.String()
 	gitlab.ClientID = params.Get("client_id")
 	gitlab.ClientSecret = params.Get("client_secret")
 	gitlab.SkipVerify, _ = strconv.ParseBool(params.Get("skip_verify"))

--- a/server/router/middleware/session/repo.go
+++ b/server/router/middleware/session/repo.go
@@ -41,13 +41,13 @@ func Repo(c *gin.Context) *model.Repo {
 func SetRepo() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
-			store_ = store.FromContext(c)
+			_store = store.FromContext(c)
 			owner  = c.Param("owner")
 			name   = c.Param("name")
 			user   = User(c)
 		)
 
-		repo, err := store_.GetRepoName(owner + "/" + name)
+		repo, err := _store.GetRepoName(owner + "/" + name)
 		if err == nil {
 			c.Set("repo", repo)
 			c.Next()
@@ -83,7 +83,7 @@ func Perm(c *gin.Context) *model.Perm {
 
 func SetPerm() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		store_ := store.FromContext(c)
+		_store := store.FromContext(c)
 		user := User(c)
 		repo := Repo(c)
 		perm := new(model.Perm)
@@ -91,7 +91,7 @@ func SetPerm() gin.HandlerFunc {
 		switch {
 		case user != nil:
 			var err error
-			perm, err = store_.PermFind(user, repo)
+			perm, err = _store.PermFind(user, repo)
 			if err != nil {
 				log.Error().Msgf("Error fetching permission for %s %s. %s",
 					user.Login, repo.FullName, err)
@@ -103,7 +103,7 @@ func SetPerm() gin.HandlerFunc {
 					perm.Repo = repo.FullName
 					perm.UserID = user.ID
 					perm.Synced = time.Now().Unix()
-					if err := store_.PermUpsert(perm); err != nil {
+					if err := _store.PermUpsert(perm); err != nil {
 						_ = c.AbortWithError(http.StatusInternalServerError, err)
 						return
 					}

--- a/server/router/middleware/token/token.go
+++ b/server/router/middleware/token/token.go
@@ -36,8 +36,8 @@ func Refresh(c *gin.Context) {
 
 	// check if the remote includes the ability to
 	// refresh the user token.
-	remote_ := server.Config.Services.Remote
-	refresher, ok := remote_.(remote.Refresher)
+	_remote := server.Config.Services.Remote
+	refresher, ok := _remote.(remote.Refresher)
 	if !ok {
 		c.Next()
 		return

--- a/server/shared/buildStatus_test.go
+++ b/server/shared/buildStatus_test.go
@@ -50,7 +50,7 @@ func TestUpdateToStatusPending(t *testing.T) {
 
 	if model.StatusPending != build.Status {
 		t.Errorf("Build status not equals '%s' != '%s'", model.StatusPending, build.Status)
-	} else if "Reviewer" != build.Reviewer {
+	} else if build.Reviewer != "Reviewer" {
 		t.Errorf("Reviewer not equals 'Reviewer' != '%s'", build.Reviewer)
 	} else if now > build.Reviewed {
 		t.Errorf("Reviewed not updated %d !< %d", now, build.Reviewed)
@@ -66,7 +66,7 @@ func TestUpdateToStatusDeclined(t *testing.T) {
 
 	if model.StatusDeclined != build.Status {
 		t.Errorf("Build status not equals '%s' != '%s'", model.StatusDeclined, build.Status)
-	} else if "Reviewer" != build.Reviewer {
+	} else if build.Reviewer != "Reviewer" {
 		t.Errorf("Reviewer not equals 'Reviewer' != '%s'", build.Reviewer)
 	} else if now > build.Reviewed {
 		t.Errorf("Reviewed not updated %d !< %d", now, build.Reviewed)
@@ -78,7 +78,7 @@ func TestUpdateToStatusToDone(t *testing.T) {
 
 	build, _ := UpdateStatusToDone(&mockUpdateBuildStore{}, model.Build{}, "status", int64(1))
 
-	if "status" != build.Status {
+	if build.Status != "status" {
 		t.Errorf("Build status not equals 'status' != '%s'", build.Status)
 	} else if int64(1) != build.Finished {
 		t.Errorf("Build finished not equals 1 != %d", build.Finished)
@@ -92,7 +92,7 @@ func TestUpdateToStatusError(t *testing.T) {
 
 	build, _ := UpdateToStatusError(&mockUpdateBuildStore{}, model.Build{}, errors.New("error"))
 
-	if "error" != build.Error {
+	if build.Error != "error" {
 		t.Errorf("Build error not equals 'error' != '%s'", build.Error)
 	} else if model.StatusError != build.Status {
 		t.Errorf("Build status not equals '%s' != '%s'", model.StatusError, build.Status)

--- a/server/shared/procBuilder.go
+++ b/server/shared/procBuilder.go
@@ -88,7 +88,7 @@ func (b *ProcBuilder) Build() ([]*BuildItem, error) {
 			environ := b.environmentVariables(metadata, axis)
 
 			// substitute vars
-			substituted, err := b._envsubst(string(y.Data), environ)
+			substituted, err := b.envsubst(string(y.Data), environ)
 			if err != nil {
 				return nil, err
 			}
@@ -175,7 +175,7 @@ func containsItemWithName(name string, items []*BuildItem) bool {
 	return false
 }
 
-func (b *ProcBuilder) _envsubst(y string, environ map[string]string) (string, error) {
+func (b *ProcBuilder) envsubst(y string, environ map[string]string) (string, error) {
 	return envsubst.Eval(y, func(name string) string {
 		env := environ[name]
 		if strings.Contains(env, "\n") {

--- a/server/shared/procBuilder.go
+++ b/server/shared/procBuilder.go
@@ -88,7 +88,7 @@ func (b *ProcBuilder) Build() ([]*BuildItem, error) {
 			environ := b.environmentVariables(metadata, axis)
 
 			// substitute vars
-			substituted, err := b.envsubst_(string(y.Data), environ)
+			substituted, err := b._envsubst(string(y.Data), environ)
 			if err != nil {
 				return nil, err
 			}
@@ -175,7 +175,7 @@ func containsItemWithName(name string, items []*BuildItem) bool {
 	return false
 }
 
-func (b *ProcBuilder) envsubst_(y string, environ map[string]string) (string, error) {
+func (b *ProcBuilder) _envsubst(y string, environ map[string]string) (string, error) {
 	return envsubst.Eval(y, func(name string) string {
 		env := environ[name]
 		if strings.Contains(env, "\n") {

--- a/server/shared/procBuilder_test.go
+++ b/server/shared/procBuilder_test.go
@@ -332,7 +332,7 @@ depends_on: [ zerostep ]
 	if len(buildItems) != 1 {
 		t.Fatal("Zerostep and the step that depends on it should not generate a build item")
 	}
-	if "justastep" != buildItems[0].Proc.Name {
+	if buildItems[0].Proc.Name != "justastep" {
 		t.Fatal("justastep should have been generated")
 	}
 }
@@ -386,7 +386,7 @@ depends_on: [ shouldbefiltered ]
 	if len(buildItems) != 1 {
 		t.Fatal("Zerostep and the step that depends on it, and the one depending on it should not generate a build item")
 	}
-	if "justastep" != buildItems[0].Proc.Name {
+	if buildItems[0].Proc.Name != "justastep" {
 		t.Fatal("justastep should have been generated")
 	}
 }

--- a/server/shared/userSyncer.go
+++ b/server/shared/userSyncer.go
@@ -45,11 +45,7 @@ func NamespaceFilter(namespaces map[string]bool) FilterFunc {
 		return noopFilter
 	}
 	return func(repo *model.Repo) bool {
-		if namespaces[repo.Owner] {
-			return true
-		} else {
-			return false
-		}
+		return namespaces[repo.Owner]
 	}
 }
 

--- a/server/store/datastore/init_cgo.go
+++ b/server/store/datastore/init_cgo.go
@@ -18,6 +18,7 @@
 package datastore
 
 import (
+	// blank imports to register the sql drivers
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"

--- a/server/store/datastore/permission.go
+++ b/server/store/datastore/permission.go
@@ -51,11 +51,11 @@ func (s storage) permUpsert(sess *xorm.Session, perm *model.Perm) error {
 
 	// lookup repo based on name if possible
 	if perm.RepoID == 0 && len(perm.Repo) != 0 {
-		if r, err := s.getRepoName(sess, perm.Repo); err != nil {
+		r, err := s.getRepoName(sess, perm.Repo)
+		if err != nil {
 			return err
-		} else {
-			perm.RepoID = r.ID
 		}
+		perm.RepoID = r.ID
 	}
 
 	exist, err := sess.Where("perm_user_id = ? AND perm_repo_id = ?", perm.UserID, perm.RepoID).

--- a/server/web/web.go
+++ b/server/web/web.go
@@ -36,7 +36,7 @@ func New() *gin.Engine {
 
 	e.Use(setupCache)
 
-	h := http.FileServer(web.HttpFS())
+	h := http.FileServer(web.HTTPFS())
 	e.GET("/favicon.svg", gin.WrapH(h))
 	e.GET("/assets/*filepath", gin.WrapH(h))
 

--- a/shared/httputil/httputil.go
+++ b/shared/httputil/httputil.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 )
 
-// IsHttps is a helper function that evaluates the http.Request
+// IsHTTPS is a helper function that evaluates the http.Request
 // and returns True if the Request uses HTTPS. It is able to detect,
 // using the X-Forwarded-Proto, if the original request was HTTPS and
 // routed through a reverse proxy with SSL termination.
-func IsHttps(r *http.Request) bool {
+func IsHTTPS(r *http.Request) bool {
 	switch {
 	case r.URL.Scheme == "https":
 		return true
@@ -46,7 +46,7 @@ func SetCookie(w http.ResponseWriter, r *http.Request, name, value string) {
 		Path:     "/",
 		Domain:   r.URL.Host,
 		HttpOnly: true,
-		Secure:   IsHttps(r),
+		Secure:   IsHTTPS(r),
 		MaxAge:   2147483647, // the cooke value (token) is responsible for expiration
 	}
 

--- a/shared/yml/yml.go
+++ b/shared/yml/yml.go
@@ -50,7 +50,7 @@ func convertMapI2MapS(v interface{}) interface{} {
 	return v
 }
 
-func LoadYmlFileAsJson(path string) ([]byte, error) {
+func LoadYmlFileAsJSON(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/vendor/golang.org/x/oauth2/oauth2.go
+++ b/vendor/golang.org/x/oauth2/oauth2.go
@@ -111,13 +111,13 @@ var (
 	// result in your application obtaining a refresh token the
 	// first time your application exchanges an authorization
 	// code for a user.
-	AccessTypeOnline  AuthCodeOption = SetAuthURLParam("access_type", "online")
-	AccessTypeOffline AuthCodeOption = SetAuthURLParam("access_type", "offline")
+	AccessTypeOnline  = SetAuthURLParam("access_type", "online")
+	AccessTypeOffline = SetAuthURLParam("access_type", "offline")
 
 	// ApprovalForce forces the users to view the consent dialog
 	// and confirm the permissions request at the URL returned
 	// from AuthCodeURL, even if they've already done so.
-	ApprovalForce AuthCodeOption = SetAuthURLParam("prompt", "consent")
+	ApprovalForce = SetAuthURLParam("prompt", "consent")
 )
 
 // An AuthCodeOption is passed to Config.AuthCodeURL.

--- a/vendor/golang.org/x/oauth2/oauth2.go
+++ b/vendor/golang.org/x/oauth2/oauth2.go
@@ -111,13 +111,13 @@ var (
 	// result in your application obtaining a refresh token the
 	// first time your application exchanges an authorization
 	// code for a user.
-	AccessTypeOnline  = SetAuthURLParam("access_type", "online")
-	AccessTypeOffline = SetAuthURLParam("access_type", "offline")
+	AccessTypeOnline  AuthCodeOption = SetAuthURLParam("access_type", "online")
+	AccessTypeOffline AuthCodeOption = SetAuthURLParam("access_type", "offline")
 
 	// ApprovalForce forces the users to view the consent dialog
 	// and confirm the permissions request at the URL returned
 	// from AuthCodeURL, even if they've already done so.
-	ApprovalForce = SetAuthURLParam("prompt", "consent")
+	ApprovalForce AuthCodeOption = SetAuthURLParam("prompt", "consent")
 )
 
 // An AuthCodeOption is passed to Config.AuthCodeURL.

--- a/web/web.go
+++ b/web/web.go
@@ -10,7 +10,7 @@ import (
 //go:embed dist/*
 var webFiles embed.FS
 
-func HttpFS() http.FileSystem {
+func HTTPFS() http.FileSystem {
 	httpFS, err := fs.Sub(webFiles, "dist")
 	if err != nil {
 		panic(err)
@@ -20,7 +20,7 @@ func HttpFS() http.FileSystem {
 }
 
 func Lookup(path string) (buf []byte, err error) {
-	file, err := HttpFS().Open(path)
+	file, err := HTTPFS().Open(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Part of #435 

## Summary of fixes

- remove underscores from variable names (replace trailing with leading underscore to avoid shadowing)
- capitalize e.g. `URL`, `HTTP`, `ID` in variable names
- remove `else` after `return`
- comment for blank imports
- remove trailing punctuation in error messages
- make `error` the last return value