### PR TITLE
Make cancel pipeline work again

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -64,6 +64,9 @@ func loop(c *cli.Context) error {
 		}
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
+	if zerolog.GlobalLevel() <= zerolog.DebugLevel {
+		log.Logger = log.With().Caller().Logger()
+	}
 
 	if c.IsSet("log-level") {
 		logLevelFlag := c.String("log-level")

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -74,6 +74,9 @@ func run(c *cli.Context) error {
 		}
 		zerolog.SetGlobalLevel(lvl)
 	}
+	if zerolog.GlobalLevel() <= zerolog.DebugLevel {
+		log.Logger = log.With().Caller().Logger()
+	}
 	log.Log().Msgf("LogLevel = %s", zerolog.GlobalLevel().String())
 
 	if c.String("server-host") == "" {

--- a/server/api/build.go
+++ b/server/api/build.go
@@ -210,20 +210,14 @@ func DeleteBuild(c *gin.Context) {
 	if len(procToEvict) != 0 {
 		if err := server.Config.Services.Queue.EvictAtOnce(c, procToEvict); err != nil {
 			log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToEvict)
-			_ = c.AbortWithError(http.StatusInternalServerError, err)
-			return
 		}
 		if err := server.Config.Services.Queue.ErrorAtOnce(c, procToEvict, queue.ErrCancel); err != nil {
 			log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToEvict)
-			_ = c.AbortWithError(http.StatusInternalServerError, err)
-			return
 		}
 	}
 	if len(procToCancel) != 0 {
 		if err := server.Config.Services.Queue.ErrorAtOnce(c, procToCancel, queue.ErrCancel); err != nil {
 			log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToCancel)
-			_ = c.AbortWithError(http.StatusInternalServerError, err)
-			return
 		}
 	}
 

--- a/server/api/build.go
+++ b/server/api/build.go
@@ -207,20 +207,24 @@ func DeleteBuild(c *gin.Context) {
 		}
 	}
 
-	if err := server.Config.Services.Queue.EvictAtOnce(c, procToEvict); err != nil {
-		log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToEvict)
-		_ = c.AbortWithError(http.StatusInternalServerError, err)
-		return
+	if len(procToEvict) != 0 {
+		if err := server.Config.Services.Queue.EvictAtOnce(c, procToEvict); err != nil {
+			log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToEvict)
+			_ = c.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
+		if err := server.Config.Services.Queue.ErrorAtOnce(c, procToEvict, queue.ErrCancel); err != nil {
+			log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToEvict)
+			_ = c.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
 	}
-	if err := server.Config.Services.Queue.ErrorAtOnce(c, procToEvict, queue.ErrCancel); err != nil {
-		log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToEvict)
-		_ = c.AbortWithError(http.StatusInternalServerError, err)
-		return
-	}
-	if err := server.Config.Services.Queue.ErrorAtOnce(c, procToCancel, queue.ErrCancel); err != nil {
-		log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToEvict)
-		_ = c.AbortWithError(http.StatusInternalServerError, err)
-		return
+	if len(procToCancel) != 0 {
+		if err := server.Config.Services.Queue.ErrorAtOnce(c, procToCancel, queue.ErrCancel); err != nil {
+			log.Error().Err(err).Msgf("queue: evict_at_once: %v", procToCancel)
+			_ = c.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
 	}
 
 	// Then update the DB status for pending builds


### PR DESCRIPTION
we previously did not check if we had procToEvict it it was empty the queue throw an error we just ignored.
since we do not ignore errors anymore we could not cancel if procToEvict was empty.

now we do it properly by checking procToEvict first!