### PR TITLE
add flag to set oauth redirect host in dev mode

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -79,12 +79,6 @@ var flags = []cli.Flag{
 		Name:    "quic",
 		Usage:   "enable quic",
 	},
-	&cli.StringFlag{
-		EnvVars: []string{"WOODPECKER_WWW_PROXY"},
-		Name:    "www-proxy",
-		Usage:   "serve the website by using a proxy (used for development)",
-		Hidden:  true,
-	},
 	&cli.StringSliceFlag{
 		EnvVars: []string{"WOODPECKER_ADMIN"},
 		Name:    "admin",
@@ -511,5 +505,19 @@ var flags = []cli.Flag{
 		EnvVars: []string{"WOODPECKER_KEEPALIVE_MIN_TIME"},
 		Name:    "keepalive-min-time",
 		Usage:   "server-side enforcement policy on the minimum amount of time a client should wait before sending a keepalive ping.",
+	},
+	// development flags
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_DEV_WWW_PROXY"},
+		Name:    "www-proxy",
+		Usage:   "serve the website by using a proxy (used for development)",
+		Hidden:  true,
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_DEV_OAUTH_HOST"},
+		Name:    "server-dev-oauth-host",
+		Usage:   "server fully qualified url (<scheme>://<host>) used for oauth redirect (used for development)",
+		Value:   "",
+		Hidden:  true,
 	},
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -287,6 +287,11 @@ func setupEvilGlobals(c *cli.Context, v store.Store, r remote.Remote) {
 	server.Config.Server.Key = c.String("server-key")
 	server.Config.Server.Pass = c.String("agent-secret")
 	server.Config.Server.Host = c.String("server-host")
+	if len(c.String("server-dev-oauth-host")) > 0 {
+		server.Config.Server.OAuthHost = c.String("server-dev-oauth-host")
+	} else {
+		server.Config.Server.OAuthHost = c.String("server-host")
+	}
 	server.Config.Server.Port = c.String("server-addr")
 	server.Config.Server.Docs = c.String("docs")
 	server.Config.Server.SessionExpires = c.Duration("session-expires")

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -287,7 +287,7 @@ func setupEvilGlobals(c *cli.Context, v store.Store, r remote.Remote) {
 	server.Config.Server.Key = c.String("server-key")
 	server.Config.Server.Pass = c.String("agent-secret")
 	server.Config.Server.Host = c.String("server-host")
-	if len(c.String("server-dev-oauth-host")) > 0 {
+	if c.IsSet("server-dev-oauth-host") {
 		server.Config.Server.OAuthHost = c.String("server-dev-oauth-host")
 	} else {
 		server.Config.Server.OAuthHost = c.String("server-host")

--- a/server/config.go
+++ b/server/config.go
@@ -52,6 +52,7 @@ var Config = struct {
 	Server struct {
 		Key            string
 		Cert           string
+		OAuthHost      string
 		Host           string
 		Port           string
 		Pass           string

--- a/server/remote/gitea/gitea.go
+++ b/server/remote/gitea/gitea.go
@@ -99,7 +99,7 @@ func (c *Gitea) Login(ctx context.Context, w http.ResponseWriter, req *http.Requ
 			AuthURL:  fmt.Sprintf(authorizeTokenURL, c.URL),
 			TokenURL: fmt.Sprintf(accessTokenURL, c.URL),
 		},
-		RedirectURL: fmt.Sprintf("%s/authorize", server.Config.Server.Host),
+		RedirectURL: fmt.Sprintf("%s/authorize", server.Config.Server.OAuthHost),
 	}
 
 	// get the OAuth errors

--- a/server/remote/github/github.go
+++ b/server/remote/github/github.go
@@ -338,9 +338,9 @@ func (c *client) newConfig(req *http.Request) *oauth2.Config {
 
 	intendedURL := req.URL.Query()["url"]
 	if len(intendedURL) > 0 {
-		redirect = fmt.Sprintf("%s/authorize?url=%s", server.Config.Server.Host, intendedURL[0])
+		redirect = fmt.Sprintf("%s/authorize?url=%s", server.Config.Server.OAuthHost, intendedURL[0])
 	} else {
-		redirect = fmt.Sprintf("%s/authorize", server.Config.Server.Host)
+		redirect = fmt.Sprintf("%s/authorize", server.Config.Server.OAuthHost)
 	}
 
 	return &oauth2.Config{

--- a/server/remote/gitlab/gitlab.go
+++ b/server/remote/gitlab/gitlab.go
@@ -96,7 +96,7 @@ func (g *Gitlab) Login(ctx context.Context, res http.ResponseWriter, req *http.R
 		Scope:        defaultScope,
 		AuthURL:      fmt.Sprintf("%s/oauth/authorize", g.URL),
 		TokenURL:     fmt.Sprintf("%s/oauth/token", g.URL),
-		RedirectURL:  fmt.Sprintf("%s/authorize", server.Config.Server.Host),
+		RedirectURL:  fmt.Sprintf("%s/authorize", server.Config.Server.OAuthHost),
 	}
 
 	// get the OAuth errors


### PR DESCRIPTION
This setting allows to set a special redirect host address (like `http://localhost:8000`) and still use `WOODPECKER_HOST` for the public address which is for example used for the webhooks.