### PR TITLE
Get secrets in settings

### DIFF
--- a/docs/docs/20-usage/40-secrets.md
+++ b/docs/docs/20-usage/40-secrets.md
@@ -14,6 +14,21 @@ pipeline:
 +   secrets: [ docker_username, docker_password ]
 ```
 
+Alternatively, you can get a `setting` from secrets using the `from_secret` syntax.  
+In this example, the secret named `secret_token` would be passed to the pipeline as `PLUGIN_TOKEN`.
+
+**NOTE:** the `from_secret` syntax only works with the newer `settings` block.
+
+```diff
+pipeline:
+  docker:
+    image: my-plugin
+    settings:
++     token:
++       from_secret: secret_token
+```
+
+
 Please note parameter expressions are subject to pre-processing. When using secrets in parameter expressions they should be escaped.
 
 ```diff

--- a/pipeline/frontend/yaml/compiler/convert.go
+++ b/pipeline/frontend/yaml/compiler/convert.go
@@ -72,7 +72,7 @@ func (c *Compiler) createProcess(name string, container *yaml.Container, section
 	}
 
 	if !detached {
-		if err := paramsToEnv(container.Settings, environment); err != nil {
+		if err := paramsToEnv(container.Settings, environment, c.secrets); err != nil {
 			log.Error().Err(err).Msg("paramsToEnv")
 		}
 	}

--- a/pipeline/frontend/yaml/compiler/params_test.go
+++ b/pipeline/frontend/yaml/compiler/params_test.go
@@ -57,7 +57,6 @@ my_secret:
 `)
 	var from map[string]interface{}
 	err := yaml.Unmarshal(fromYAML, &from)
-	t.Logf("%T", from["my_secret"])
 	assert.NoError(t, err)
 
 	want := map[string]string{
@@ -74,6 +73,19 @@ my_secret:
 	got := map[string]string{}
 	assert.NoError(t, paramsToEnv(from, got, secrets))
 	assert.EqualValues(t, want, got, "Problem converting plugin parameters to environment variables")
+}
+
+func TestYAMLToParamsToEnvError(t *testing.T) {
+	fromYAML := []byte(`my_secret:
+  from_secret: not_a_secret
+`)
+	var from map[string]interface{}
+	err := yaml.Unmarshal(fromYAML, &from)
+	assert.NoError(t, err)
+	secrets := map[string]Secret{
+		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},
+	}
+	assert.Error(t, paramsToEnv(from, make(map[string]string), secrets))
 }
 
 func stringsToInterface(val ...string) []interface{} {

--- a/pipeline/frontend/yaml/compiler/params_test.go
+++ b/pipeline/frontend/yaml/compiler/params_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParamsToEnv(t *testing.T) {
@@ -20,6 +21,7 @@ func TestParamsToEnv(t *testing.T) {
 		"from.address": "noreply@example.com",
 		"tags":         stringsToInterface("next", "latest"),
 		"tag":          stringsToInterface("next"),
+		"my_secret":    map[string]interface{}{"from_secret": "secret_token"},
 	}
 	want := map[string]string{
 		"PLUGIN_STRING":       "stringz",
@@ -33,9 +35,44 @@ func TestParamsToEnv(t *testing.T) {
 		"PLUGIN_FROM_ADDRESS": "noreply@example.com",
 		"PLUGIN_TAG":          "next",
 		"PLUGIN_TAGS":         "next,latest",
+		"PLUGIN_MY_SECRET":    "FooBar",
+	}
+	secrets := map[string]Secret{
+		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},
 	}
 	got := map[string]string{}
-	assert.NoError(t, paramsToEnv(from, got))
+	assert.NoError(t, paramsToEnv(from, got, secrets))
+	assert.EqualValues(t, want, got, "Problem converting plugin parameters to environment variables")
+}
+
+func TestYAMLToParamsToEnv(t *testing.T) {
+	fromYAML := []byte(`skip: ~
+string: stringz
+int: 1
+float: 1.2
+bool: true
+slice: [1, 2, 3]
+my_secret:
+  from_secret: secret_token
+`)
+	var from map[string]interface{}
+	err := yaml.Unmarshal(fromYAML, &from)
+	t.Logf("%T", from["my_secret"])
+	assert.NoError(t, err)
+
+	want := map[string]string{
+		"PLUGIN_STRING":    "stringz",
+		"PLUGIN_INT":       "1",
+		"PLUGIN_FLOAT":     "1.2",
+		"PLUGIN_BOOL":      "true",
+		"PLUGIN_SLICE":     "1,2,3",
+		"PLUGIN_MY_SECRET": "FooBar",
+	}
+	secrets := map[string]Secret{
+		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},
+	}
+	got := map[string]string{}
+	assert.NoError(t, paramsToEnv(from, got, secrets))
 	assert.EqualValues(t, want, got, "Problem converting plugin parameters to environment variables")
 }
 


### PR DESCRIPTION
This PR adds the ability to get a `setting` from a `secret`. 
I've opted to follow the format Drone does to ease migration for users, let me know if we want to go another route.

```yaml
settings:
  my_secret:
    from_secret: secret_name
```

-----

I'm not a huge fan of the hadoken logic, but with our current YAML unmarshaling I think it's the best we can do.