### PR TITLE
Fix gRPC incomapatability in helm chart

### DIFF
--- a/charts/woodpecker-agent/templates/deployment.yaml
+++ b/charts/woodpecker-agent/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
                 name: {{ . }}
             {{- end }}
         - name: dind
-          image: "docker:19.03.5-dind"
+          image: "docker:20.10.12-dind"
           env:
           - name: DOCKER_DRIVER
             value: overlay2


### PR DESCRIPTION
Closes #600

I investigated the issue: The underlying issue was that the docker-in-docker (dind) image specified by the helm chart is >2 years old and thus is incompatible with gRPC v1.41 which the wooderpecker agent uses to communicate with it.

I tested the fix proposed in this PR in our AWS EKS cluster and it works, builds are being executed again (: 

Looking forward to your review.