### PR TITLE
fix sqlite migration on column drop of abnormal schemas

### DIFF
--- a/server/store/datastore/migration/common.go
+++ b/server/store/datastore/migration/common.go
@@ -223,8 +223,11 @@ func removeColumnFromSQLITETableSchema(schema string, names ...string) string {
 		if len(names[i]) == 0 {
 			continue
 		}
-		schema = regexp.MustCompile(`\s`+regexp.QuoteMeta("`"+names[i]+"`")+"[^`,)]*?[,)]").ReplaceAllString(schema, "")
-		schema = regexp.MustCompile(`\s`+regexp.QuoteMeta(names[i])+"[^`,)]*?[,)]").ReplaceAllString(schema, "")
+		schema = regexp.MustCompile(`\s(`+
+			regexp.QuoteMeta("`"+names[i]+"`")+
+			"|"+
+			regexp.QuoteMeta(names[i])+
+			")[^`,)]*?[,)]").ReplaceAllString(schema, "")
 	}
 	return schema
 }

--- a/server/store/datastore/migration/common.go
+++ b/server/store/datastore/migration/common.go
@@ -92,7 +92,7 @@ func dropTableColumns(sess *xorm.Session, tableName string, columnNames ...strin
 		// Remove the required columnNames
 		for _, name := range columnNames {
 			tableSQL = regexp.MustCompile(regexp.QuoteMeta("`"+name+"`")+"[^`,)]*?[,)]").ReplaceAllString(tableSQL, "")
-			tableSQL = regexp.MustCompile(regexp.QuoteMeta("name")+"[^`,)]*?[,)]").ReplaceAllString(tableSQL, "")
+			tableSQL = regexp.MustCompile(regexp.QuoteMeta(name)+"[^`,)]*?[,)]").ReplaceAllString(tableSQL, "")
 			tableSQL = whitespaces.ReplaceAllString(strings.ReplaceAll(tableSQL, "\n", " "), " ")
 		}
 

--- a/server/store/datastore/migration/common.go
+++ b/server/store/datastore/migration/common.go
@@ -106,7 +106,16 @@ func dropTableColumns(sess *xorm.Session, tableName string, columnNames ...strin
 		}
 
 		// Find all the columns in the table
-		columns := regexp.MustCompile("`([^`]*)`").FindAllString(tableSQL, -1)
+		var columns []string
+		for _, rawColumn := range strings.Split(strings.ReplaceAll(tableSQL[1:len(tableSQL)-1], ", ", ",\n"), "\n") {
+			if strings.ContainsAny(rawColumn, "()") {
+				continue
+			}
+			rawColumn = strings.TrimSpace(rawColumn)
+			columns = append(columns,
+				strings.ReplaceAll(rawColumn[0:strings.Index(rawColumn, " ")], "`", ""),
+			)
+		}
 
 		tableSQL = fmt.Sprintf("CREATE TABLE `new_%s_new` ", tableName) + tableSQL
 		if _, err := sess.Exec(tableSQL); err != nil {

--- a/server/store/datastore/migration/common.go
+++ b/server/store/datastore/migration/common.go
@@ -37,6 +37,8 @@ func renameTable(sess *xorm.Session, old, new string) error {
 	}
 }
 
+var whitespaces = regexp.MustCompile(`\s+`)
+
 // WARNING: YOU MUST COMMIT THE SESSION AT THE END
 func dropTableColumns(sess *xorm.Session, tableName string, columnNames ...string) (err error) {
 	// Copyright 2017 The Gitea Authors. All rights reserved.
@@ -90,6 +92,8 @@ func dropTableColumns(sess *xorm.Session, tableName string, columnNames ...strin
 		// Remove the required columnNames
 		for _, name := range columnNames {
 			tableSQL = regexp.MustCompile(regexp.QuoteMeta("`"+name+"`")+"[^`,)]*?[,)]").ReplaceAllString(tableSQL, "")
+			tableSQL = regexp.MustCompile(regexp.QuoteMeta("name")+"[^`,)]*?[,)]").ReplaceAllString(tableSQL, "")
+			tableSQL = whitespaces.ReplaceAllString(strings.ReplaceAll(tableSQL, "\n", " "), " ")
 		}
 
 		// Ensure the query is ended properly

--- a/server/store/datastore/migration/common_test.go
+++ b/server/store/datastore/migration/common_test.go
@@ -6,10 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMigrate(t *testing.T) {
-
-}
-
 func TestRemoveColumnFromSQLITETableSchema(t *testing.T) {
 	schema := "CREATE TABLE repos ( repo_id INTEGER PRIMARY KEY AUTOINCREMENT, repo_user_id INTEGER, repo_owner TEXT, " +
 		"repo_name TEXT, repo_full_name TEXT, `repo_avatar` TEXT, repo_branch TEXT, repo_timeout INTEGER, " +

--- a/server/store/datastore/migration/common_test.go
+++ b/server/store/datastore/migration/common_test.go
@@ -1,0 +1,55 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMigrate(t *testing.T) {
+
+}
+
+func TestRemoveColumnFromSQLITETableSchema(t *testing.T) {
+	schema := "CREATE TABLE repos ( repo_id INTEGER PRIMARY KEY AUTOINCREMENT, repo_user_id INTEGER, repo_owner TEXT, " +
+		"repo_name TEXT, repo_full_name TEXT, `repo_avatar` TEXT, repo_branch TEXT, repo_timeout INTEGER, " +
+		"repo_allow_pr BOOLEAN, repo_config_path TEXT, repo_visibility TEXT, repo_counter INTEGER, repo_active BOOLEAN, " +
+		"repo_fallback BOOLEAN, UNIQUE(repo_full_name) )"
+
+	assert.EqualValues(t, schema, removeColumnFromSQLITETableSchema(schema, ""))
+
+	assert.EqualValues(t, "CREATE TABLE repos ( repo_id INTEGER PRIMARY KEY AUTOINCREMENT, repo_user_id INTEGER, repo_owner TEXT, "+
+		"repo_name TEXT, repo_full_name TEXT, repo_branch TEXT, repo_timeout INTEGER, "+
+		"repo_allow_pr BOOLEAN, repo_config_path TEXT, repo_visibility TEXT, repo_counter INTEGER, repo_active BOOLEAN, "+
+		"repo_fallback BOOLEAN, UNIQUE(repo_full_name) )", removeColumnFromSQLITETableSchema(schema, "repo_avatar"))
+
+	assert.EqualValues(t, "CREATE TABLE repos ( repo_user_id INTEGER, repo_owner TEXT, "+
+		"repo_name TEXT, repo_full_name TEXT, `repo_avatar` TEXT, repo_timeout INTEGER, "+
+		"repo_allow_pr BOOLEAN, repo_config_path TEXT, repo_visibility TEXT, repo_counter INTEGER, repo_active BOOLEAN, "+
+		"repo_fallback BOOLEAN, UNIQUE(repo_full_name) )", removeColumnFromSQLITETableSchema(schema, "repo_id", "repo_branch", "invalid", ""))
+}
+
+func TestNormalizeSQLiteTableSchema(t *testing.T) {
+	assert.EqualValues(t, "", normalizeSQLiteTableSchema(``))
+	assert.EqualValues(t,
+		"CREATE TABLE repos ( repo_id INTEGER PRIMARY KEY AUTOINCREMENT, "+
+			"repo_user_id INTEGER, repo_owner TEXT, repo_name TEXT, repo_full_name TEXT, "+
+			"`repo_avatar` TEXT, repo_link TEXT, repo_clone TEXT, repo_branch TEXT, "+
+			"repo_timeout INTEGER, repo_allow_pr BOOLEAN, repo_config_path TEXT, "+
+			"repo_visibility TEXT, repo_counter INTEGER, repo_active BOOLEAN, "+
+			"repo_fallback BOOLEAN, UNIQUE(repo_full_name) )",
+		normalizeSQLiteTableSchema(`CREATE TABLE repos (
+ repo_id            INTEGER PRIMARY KEY AUTOINCREMENT
+,repo_user_id       INTEGER
+,repo_owner         TEXT,
+  repo_name         TEXT
+,repo_full_name     TEXT
+,`+"`"+`repo_avatar`+"`"+`        TEXT
+,repo_link          TEXT
+,repo_clone         TEXT
+,repo_branch        TEXT ,repo_timeout			INTEGER
+,repo_allow_pr      BOOLEAN
+,repo_config_path   TEXT
+, repo_visibility TEXT, repo_counter INTEGER, repo_active BOOLEAN, repo_fallback BOOLEAN,UNIQUE(repo_full_name)
+)`))
+}


### PR DESCRIPTION
since the function was originally written with the idea in mind, that sqlite schema is generated, it did not normalize stuff.

now we normalize table schema and use a custom method to obtain column names from schema

TODO:
 * [x] fix stuff
 * [x] unit tests

close  #628