### PR TITLE
Add `repo` to `when` block

### DIFF
--- a/docs/docs/20-usage/22-conditional-execution.md
+++ b/docs/docs/20-usage/22-conditional-execution.md
@@ -4,6 +4,20 @@ Woodpecker supports defining conditional pipeline steps in the `when` block. If 
 
 This can also be utilised on a playbook level if you have multi-arch agents and require specific pipelines to be run on specific architectures. See [platform](#platform) below.
 
+## `repo`
+
+Example conditional execution by branch:
+
+```diff
+pipeline:
+  slack:
+    image: plugins/slack
+    settings:
+      channel: dev
++   when:
++     repo: test/test
+```
+
 ## `branch`
 
 Example conditional execution by branch:

--- a/docs/docs/20-usage/22-conditional-execution.md
+++ b/docs/docs/20-usage/22-conditional-execution.md
@@ -6,7 +6,7 @@ This can also be utilised on a playbook level if you have multi-arch agents and 
 
 ## `repo`
 
-Example conditional execution by branch:
+Example conditional execution by repository:
 
 ```diff
 pipeline:

--- a/docs/docs/20-usage/22-conditional-execution.md
+++ b/docs/docs/20-usage/22-conditional-execution.md
@@ -9,13 +9,13 @@ This can also be utilised on a playbook level if you have multi-arch agents and 
 Example conditional execution by repository:
 
 ```diff
-pipeline:
-  slack:
-    image: plugins/slack
-    settings:
-      channel: dev
-+   when:
-+     repo: test/test
+ pipeline:
+   slack:
+     image: plugins/slack
+     settings:
+       channel: dev
++    when:
++      repo: test/test
 ```
 
 ## `branch`

--- a/pipeline/schema/.woodpecker/test-when.yml
+++ b/pipeline/schema/.woodpecker/test-when.yml
@@ -88,3 +88,10 @@ pipeline:
         include: [ '.woodpecker/*.yml', '*.ini' ]
         exclude: [ '*.md', 'docs/**' ]
         ignore_message: "[ALL]"
+
+  when-repo:
+    image: alpine
+    commands:
+      - echo "test"
+    when:
+      repo: test/test

--- a/pipeline/schema/schema.json
+++ b/pipeline/schema/schema.json
@@ -185,6 +185,19 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "repo": {
+          "description": "Execute a step only on a specific repository. Read more: https://woodpecker-ci.org/docs/usage/conditional-execution#repo",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minLength": 1
+            },
+            { "type": "string" }
+          ]
+        },
         "branch": {
           "description": "TODO Read more: https://woodpecker-ci.org/docs/usage/pipeline-syntax#branch",
           "type": "string"


### PR DESCRIPTION
I "accidentally" used `repo` for my `when` clause and was surprised that it isn't covered at any doc - but it's working :D

I digged a little bit into the code and found that the code is already ready to use:
https://github.com/woodpecker-ci/woodpecker/blob/fe31fb1e06f510cb90ef7600756d566c10b85ce3/pipeline/frontend/yaml/constraint.go#L58