### PR TITLE
Fix repository sync aborts after a signle repo failed

### DIFF
--- a/server/model/repo.go
+++ b/server/model/repo.go
@@ -97,3 +97,8 @@ type RepoPatch struct {
 	Visibility *string `json:"visibility,omitempty"`
 	AllowPull  *bool   `json:"allow_pr,omitempty"`
 }
+
+type RepoList struct {
+	Message string  `json:"message"`
+	Repos   []*Repo `json:"repos"`
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -1,14 +1,25 @@
 import ApiClient, { encodeQueryString } from './client';
-import { Build, BuildFeed, BuildLog, BuildProc, Registry, Repo, RepoPermissions, RepoSettings, Secret } from './types';
+import {
+  Build,
+  BuildFeed,
+  BuildLog,
+  BuildProc,
+  Registry,
+  Repo,
+  RepoList,
+  RepoPermissions,
+  RepoSettings,
+  Secret,
+} from './types';
 
 type RepoListOptions = {
   all?: boolean;
   flush?: boolean;
 };
 export default class WoodpeckerClient extends ApiClient {
-  getRepoList(opts?: RepoListOptions): Promise<Repo[]> {
+  getRepoList(opts?: RepoListOptions): Promise<RepoList> {
     const query = encodeQueryString(opts);
-    return this._get(`/api/user/repos?${query}`) as Promise<Repo[]>;
+    return this._get(`/api/user/repos?${query}`) as Promise<RepoList>;
   }
 
   getRepo(owner: string, repo: string): Promise<Repo> {

--- a/web/src/lib/api/types/repo.ts
+++ b/web/src/lib/api/types/repo.ts
@@ -70,3 +70,11 @@ export type RepoPermissions = {
   admin: boolean;
   synced: number;
 };
+
+export type RepoList = {
+  message: string | null;
+  // error message if any errors occurred
+
+  repos: Repo[];
+  // list of the fetched repositories
+};

--- a/web/src/store/repos.ts
+++ b/web/src/store/repos.ts
@@ -34,8 +34,8 @@ export default defineStore({
       this.repos[repoSlug(repo)] = repo;
     },
     async loadRepos() {
-      const repos = await apiClient.getRepoList();
-      repos.forEach((repo) => {
+      const result = await apiClient.getRepoList();
+      result.repos.forEach((repo) => {
         this.repos[repoSlug(repo.owner, repo.name)] = repo;
       });
     },

--- a/web/src/views/RepoAdd.vue
+++ b/web/src/views/RepoAdd.vue
@@ -72,13 +72,25 @@ export default defineComponent({
     const { searchedRepos } = useRepoSearch(repos, search);
 
     onMounted(async () => {
-      repos.value = await apiClient.getRepoList({ all: true });
+      const result = await apiClient.getRepoList({ all: true });
+      repos.value = result.repos;
+
+      if (result.message) {
+        notifications.notify({ title: result.message, type: 'error' });
+      }
     });
 
     const { doSubmit: reloadRepos, isLoading: isReloadingRepos } = useAsyncAction(async () => {
+      const result = await apiClient.getRepoList({ all: true, flush: true });
+
       repos.value = undefined;
-      repos.value = await apiClient.getRepoList({ all: true, flush: true });
-      notifications.notify({ title: 'Repository list reloaded', type: 'success' });
+      repos.value = result.repos;
+
+      if (result.message) {
+        notifications.notify({ title: result.message, type: 'error' });
+      } else {
+        notifications.notify({ title: 'Repository list reloaded', type: 'success' });
+      }
     });
 
     const { doSubmit: activateRepo, isLoading: isActivatingRepo } = useAsyncAction(async (repo: Repo) => {

--- a/woodpecker-go/woodpecker/client.go
+++ b/woodpecker-go/woodpecker/client.go
@@ -124,19 +124,19 @@ func (c *client) Repo(owner string, name string) (*Repo, error) {
 // RepoList returns a list of all repositories to which
 // the user has explicit access in the host system.
 func (c *client) RepoList() ([]*Repo, error) {
-	var out []*Repo
+	var out RepoList
 	uri := fmt.Sprintf(pathRepos, c.addr)
 	err := c.get(uri, &out)
-	return out, err
+	return out.Repos, err
 }
 
 // RepoListOpts returns a list of all repositories to which
 // the user has explicit access in the host system.
 func (c *client) RepoListOpts(sync, all bool) ([]*Repo, error) {
-	var out []*Repo
+	var out RepoList
 	uri := fmt.Sprintf(pathRepos+"?flush=%v&all=%v", c.addr, sync, all)
 	err := c.get(uri, &out)
-	return out, err
+	return out.Repos, err
 }
 
 // RepoPost activates a repository.

--- a/woodpecker-go/woodpecker/types.go
+++ b/woodpecker-go/woodpecker/types.go
@@ -43,6 +43,12 @@ type (
 		BuildCounter *int    `json:"build_counter,omitempty"`
 	}
 
+	// RepoList defines the response type of the repos request
+	RepoList struct {
+		Message string  `json:"message"`
+		Repos   []*Repo `json:"repos"`
+	}
+
 	// Build defines a build object.
 	Build struct {
 		ID        int64   `json:"id"`


### PR DESCRIPTION
This PR fixes the issue, where the whole repository sync process would be canceled if only one repository fails to sync.
It thereby partly fixes, or circumvents, #648 as described (see item 1).

In order to display an additional status/error message after syncing, I had to change the API response types/schemas to include an optional message string (see `RepoList` types both in the frontend and the server). I'm not 100% happy with how I named that type though.