### PR TITLE
hotfix gitlab sub repo listing

### DIFF
--- a/server/remote/gitlab/convert.go
+++ b/server/remote/gitlab/convert.go
@@ -28,6 +28,7 @@ import (
 
 func (g *Gitlab) convertGitlabRepo(_repo *gitlab.Project) (*model.Repo, error) {
 	parts := strings.Split(_repo.PathWithNamespace, "/")
+	// TODO(648) save repo id (support nested repos)
 	var owner = strings.Join(parts[:len(parts)-1], "/")
 	var name = parts[len(parts)-1]
 	repo := &model.Repo{

--- a/server/remote/gitlab/convert.go
+++ b/server/remote/gitlab/convert.go
@@ -28,9 +28,8 @@ import (
 
 func (g *Gitlab) convertGitlabRepo(_repo *gitlab.Project) (*model.Repo, error) {
 	parts := strings.Split(_repo.PathWithNamespace, "/")
-	// TODO: save repo id (support nested repos)
-	var owner = parts[0]
-	var name = parts[1]
+	var owner = strings.Join(parts[:len(parts)-1], "/")
+	var name = parts[len(parts)-1]
 	repo := &model.Repo{
 		Owner:      owner,
 		Name:       name,


### PR DESCRIPTION
This fix allows us to list sub-repos from Gitlab, so users get a list of all gitlab repos and can activate "normal" repos.
Enabling / using sub-repos is not solved by this PR and will reult in an error for now.

close  #651