### PR TITLE
skip nested GitLab repositories during sync

### DIFF
--- a/server/remote/gitlab/gitlab.go
+++ b/server/remote/gitlab/gitlab.go
@@ -251,6 +251,7 @@ func (g *Gitlab) Repos(ctx context.Context, user *model.User) ([]*model.Repo, er
 				return nil, err
 			}
 
+			// TODO(648) remove when woodpecker understands nested repos
 			if strings.Count(repo.FullName, "/") > 1 {
 				log.Debug().Msgf("Skipping nested repository %s for user %s, because they are not supported, yet (see #648).", repo.FullName, user.Login)
 				continue

--- a/server/remote/gitlab/gitlab.go
+++ b/server/remote/gitlab/gitlab.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/xanzy/go-gitlab"
 
 	"github.com/woodpecker-ci/woodpecker/server"
@@ -249,6 +250,12 @@ func (g *Gitlab) Repos(ctx context.Context, user *model.User) ([]*model.Repo, er
 			if err != nil {
 				return nil, err
 			}
+
+			if strings.Count(repo.FullName, "/") > 1 {
+				log.Debug().Msgf("Skipping nested repository %s for user %s, because they are not supported, yet (see #648).", repo.FullName, user.Login)
+				continue
+			}
+
 			repos = append(repos, repo)
 		}
 


### PR DESCRIPTION
Implements https://github.com/woodpecker-ci/woodpecker/pull/651#issuecomment-1003794674, partly fixes #648 