### PR TITLE
API GetRepos() return empty list if no active repos exist

### DIFF
--- a/server/api/user.go
+++ b/server/api/user.go
@@ -128,7 +128,7 @@ func GetRepos(c *gin.Context) {
 		return
 	}
 
-	var active []*model.Repo
+	active := make([]*model.Repo, 0)
 	for _, repo := range repos {
 		if repo.IsActive {
 			active = append(active, repo)


### PR DESCRIPTION
When there are no repositories yet, you can observe the following error in the JavaScript console:
```
TypeError: null has no properties
    loadRepos http://localhost:8000/assets/index.3d82d057.js:1
    C http://localhost:8000/assets/vendor.82796ebf.js:5
    setup http://localhost:8000/assets/Repos.1bb0497d.js:1
    ...
```

This is due to the fact, that the `/api/user/repos` returns the literal string `"null"`.

I still think the API returns the wrong value. I would expect it to return a `[]*model.Repo`  which would yield an empty array `[]` if empty and **not** `null`. Otherwise we might need to catch a similar case in every API call in the client?