### PR TITLE
Add note about Gitlab & Gitea internal connections to docs

### DIFF
--- a/docs/docs/30-administration/20-vcs/30-gitea.md
+++ b/docs/docs/30-administration/20-vcs/30-gitea.md
@@ -24,6 +24,14 @@ services:
 
 Register your application with Gitea to create your client id and secret. You can find the OAuth applications settings of Gitea at `https://gitea.<host>/user/settings/`. It is very import the authorization callback URL matches your http(s) scheme and hostname exactly with `https://<host>/authorize` as the path.
 
+If you run the Woodpecker CI server on the same host as the Gitea instance, you might also need to allow local connections in Gitea, since version `v1.16`. Otherwise API requests will fail. Add the following lines to your Gitea configuration (usually at `/etc/gitea/conf/app.ini`).
+```ini
+...
+[webhook]
+ALLOWED_HOST_LIST=external,loopback
+```
+For reference see [Configuration Cheat Sheet](https://docs.gitea.io/en-us/config-cheat-sheet/#webhook-webhook).
+
 ![gitea oauth setup](gitea_oauth.gif)
 
 

--- a/docs/docs/30-administration/20-vcs/30-gitea.md
+++ b/docs/docs/30-administration/20-vcs/30-gitea.md
@@ -24,7 +24,7 @@ services:
 
 Register your application with Gitea to create your client id and secret. You can find the OAuth applications settings of Gitea at `https://gitea.<host>/user/settings/`. It is very import the authorization callback URL matches your http(s) scheme and hostname exactly with `https://<host>/authorize` as the path.
 
-If you run the Woodpecker CI server on the same host as the Gitea instance, you might also need to allow local connections in Gitea, since version `v1.16`. Otherwise API requests will fail. Add the following lines to your Gitea configuration (usually at `/etc/gitea/conf/app.ini`).
+If you run the Woodpecker CI server on the same host as the Gitea instance, you might also need to allow local connections in Gitea, since version `v1.16`. Otherwise webhooks will fail. Add the following lines to your Gitea configuration (usually at `/etc/gitea/conf/app.ini`).
 ```ini
 ...
 [webhook]

--- a/docs/docs/30-administration/20-vcs/40-gitlab.md
+++ b/docs/docs/30-administration/20-vcs/40-gitlab.md
@@ -25,6 +25,8 @@ You must register your application with GitLab in order to generate a Client and
 
 Please use `http://woodpecker.mycompany.com/authorize` as the Authorization callback URL. Grant `api` scope to the application.
 
+If you run the Woodpecker CI server on the same host as the GitLab instance, you might also need to allow local connections in GitLab, otherwise API requests will fail. In GitLab, navigate to the Admin dashboard, then go to `Settings > Network > Outbound requests` and enable `Allow requests to the local network from web hooks and services`.
+
 ## Configuration
 
 This is a full list of configuration options. Please note that many of these options use default configuration values that should work for the majority of installations.


### PR DESCRIPTION
This PR adds a little note to the docs to enable internal connections when the Woodpecker CI server and GitLab are run on the same host. This caused the webhooks to fail.

> [..] similar thing applys to newest gitea too

@6543 also mentioned this might apply to other VCS (e.g. Gitea). Should we check for all of them before merging this PR?

## Previous monologue

Right now I cannot sync any repo from GitLab with WP.
I get an error and the request (on WP) logs:
```
POST https://gitlab.example.com/api/v4/projects/192/hooks: 422 {error: Invalid url given}
```
At least this route seems to exist: https://docs.gitlab.com/ee/api/projects.html#add-project-hook

The message "Invalid url given" probably refers to the message body and not the request (URL) itself.
HTTP 422 is for "Unprocessable".

Okay, this fixed it: https://gitlab.com/gitlab-org/gitlab/-/issues/25867#note_215577922
Probably because I was running the Woodpecker Server and the GitLab Server on the same host.


