### PR TITLE
Allow specifying dind container in values

### DIFF
--- a/charts/woodpecker-agent/templates/deployment.yaml
+++ b/charts/woodpecker-agent/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
                 name: {{ . }}
             {{- end }}
         - name: dind
-          image: {{ Values.dind.image }}
+          image: {{ .Values.dind.image }}
           env:
             {{- range $key, $value := .Values.dind.env }}
             - name: {{ $key }}

--- a/charts/woodpecker-agent/templates/deployment.yaml
+++ b/charts/woodpecker-agent/templates/deployment.yaml
@@ -57,12 +57,14 @@ spec:
                 name: {{ . }}
             {{- end }}
         - name: dind
-          image: "docker:20.10.12-dind"
+          image: {{- Values.dind.image -}}
           env:
-          - name: DOCKER_DRIVER
-            value: overlay2
+            {{- range $key, $value := .Values.dind.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.dind.resources | nindent 12 }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/charts/woodpecker-agent/templates/deployment.yaml
+++ b/charts/woodpecker-agent/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
                 name: {{ . }}
             {{- end }}
         - name: dind
-          image: {{- Values.dind.image -}}
+          image: {{ Values.dind.image }}
           env:
             {{- range $key, $value := .Values.dind.env }}
             - name: {{ $key }}

--- a/charts/woodpecker-agent/values.yaml
+++ b/charts/woodpecker-agent/values.yaml
@@ -7,6 +7,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+dind:
+  image: "docker:20.10.12-dind"
+  env:
+  - name: DOCKER_DRIVER
+    value: overlay2
+  resources: {}
+
 env:
   WOODPECKER_SERVER: "woodpecker-server.<namespace>.svc.cluster.local:9000"
 


### PR DESCRIPTION
This allows:

- resource spec for the dind container different from the main agent
- environment variables for the dind container can also be specified in values, e.g. to change the default driver if one so wishes
- crucially: specifying a different dind image

I'm finding myself needing to use an unofficial image instead of the standard `docker` one as the official ones have been broken on `armv7` (e.g. Raspberry Pi 2, or any Pi3/Pi4 running a 32bit operating system) since some time in the 0.19 series.