### PR TITLE
Add flag to always authenticate when cloning public repositories

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,14 @@
   "go.lintTool":"golangci-lint",
   "go.lintFlags": [
     "--fast"
+  ],
+  "spellright.language": [
+    "en"
+  ],
+  "spellright.documentTypes": [
+    "markdown",
+    "latex",
+    "plaintext",
+    "go"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,14 +9,5 @@
   "go.lintTool":"golangci-lint",
   "go.lintFlags": [
     "--fast"
-  ],
-  "spellright.language": [
-    "en"
-  ],
-  "spellright.documentTypes": [
-    "markdown",
-    "latex",
-    "plaintext",
-    "go"
   ]
 }

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -91,6 +91,12 @@ var flags = []cli.Flag{
 		Name:    "open",
 		Usage:   "enable open user registration",
 	},
+	// added it here but not sure
+	&cli.BoolFlag{
+		EnvVars: []string{"WOODPECKER_AUTHENTICATE_PUBLIC_REPOS"},
+		Name:    "authenticate-public-repos",
+		Usage:   "Enable authentication for public repos",
+	},
 	&cli.StringFlag{
 		EnvVars: []string{"WOODPECKER_DOCS"},
 		Name:    "docs",

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -91,7 +91,6 @@ var flags = []cli.Flag{
 		Name:    "open",
 		Usage:   "enable open user registration",
 	},
-	// added it here but not sure
 	&cli.BoolFlag{
 		EnvVars: []string{"WOODPECKER_AUTHENTICATE_PUBLIC_REPOS"},
 		Name:    "authenticate-public-repos",

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -271,6 +271,9 @@ func setupEvilGlobals(c *cli.Context, v store.Store, r remote.Remote) {
 		server.Config.Services.Senders = sender.NewRemote(endpoint)
 	}
 
+	// authentication
+	server.Config.Pipeline.AuthenticatePublicRepos = c.Bool("authenticate-public-repos")
+
 	// limits
 	server.Config.Pipeline.Limits.MemSwapLimit = c.Int64("limit-mem-swap")
 	server.Config.Pipeline.Limits.MemLimit = c.Int64("limit-mem")

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -159,6 +159,11 @@ Enable to allow user registration.
 
 Link to documentation in the UI.
 
+### `WOODPECKER_AUTHENTICATE_PUBLIC_REPOS`
+> Default: `false`
+
+Always use authentication to clone repositories even if they are public. Needed if the SCM requires to always authenticate as used by many companies.
+
 ### `WOODPECKER_SESSION_EXPIRES`
 > Default: `72h`
 

--- a/server/config.go
+++ b/server/config.go
@@ -66,10 +66,11 @@ var Config = struct {
 		AuthToken string
 	}
 	Pipeline struct {
-		Limits     model.ResourceLimit
-		Volumes    []string
-		Networks   []string
-		Privileged []string
+		AuthenticatePublicRepos bool
+		Limits                  model.ResourceLimit
+		Volumes                 []string
+		Networks                []string
+		Privileged              []string
 	}
 	FlatPermissions bool // TODO(485) temporary workaround to not hit api rate limits
 }{}

--- a/server/shared/procBuilder.go
+++ b/server/shared/procBuilder.go
@@ -244,7 +244,7 @@ func (b *ProcBuilder) toInternalRepresentation(parsed *yaml.Config, environ map[
 				b.Netrc.Password,
 				b.Netrc.Machine,
 			),
-			b.Repo.IsSCMPrivate,
+			b.Repo.IsSCMPrivate || server.Config.Pipeline.AuthenticatePublicRepos,
 		),
 		compiler.WithRegistry(registries...),
 		compiler.WithSecret(secrets...),


### PR DESCRIPTION
As a developer using an custom git server (e.g. Github Enterprise) I would like to be able to authenticate 
the user on repositories which are marked as public.

See issue: https://github.com/woodpecker-ci/woodpecker/issues/473

Ref: https://github.com/woodpecker-ci/woodpecker/pull/693#issuecomment-1025771162