### PR TITLE
Use `DOCKER_HOST` env to search for docker before searching for a hardcode docker socket

### DIFF
--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -36,6 +36,9 @@ func (e *docker) Name() string {
 }
 
 func (e *docker) IsAvailable() bool {
+	if os.Getenv("DOCKER_HOST") != "" {
+		return true
+	}
 	_, err := os.Stat("/var/run/docker.sock")
 	return err == nil
 }


### PR DESCRIPTION
Fix #757