### PR TITLE
Increase margin for "No pipeline steps available!"

### DIFF
--- a/web/src/components/repo/build/BuildProcList.vue
+++ b/web/src/components/repo/build/BuildProcList.vue
@@ -45,7 +45,7 @@
       </div>
     </div>
 
-    <div v-if="build.procs === undefined || build.procs.length === 0" class="m-auto">
+    <div v-if="build.procs === undefined || build.procs.length === 0" class="m-auto mt-4">
       <span>No pipeline steps available!</span>
     </div>
 


### PR DESCRIPTION
Just a simple UI improvement, set margin to `1rem` on the "No pipeline steps available!" message.

Without this patch:
![](https://user-images.githubusercontent.com/80460567/153879683-3ac63cf2-ef86-4d3b-9336-14e2b0b917f0.png)
With this patch:
![](https://user-images.githubusercontent.com/80460567/153879675-26bb27da-32f2-4e0e-b238-495fcda2ec9e.png)
