### PR TITLE
Update docker hub link

### DIFF
--- a/docs/docs/10-intro.md
+++ b/docs/docs/10-intro.md
@@ -27,7 +27,7 @@ pipeline:
 
 - Define any Docker image as context
   - either use your own and install the needed tools in custom Docker images, or
-  - search [Docker Hub](https://hub.docker.com/) for images that are already tailored for your needs) 
+  - search [Docker Hub](https://hub.docker.com/search?type=image) for images that are already tailored for your needs) 
 - List the commands that should be executed in your container, in order to build or test your application
 
 ```diff


### PR DESCRIPTION
The old docker hub link directs you either to a login page or to your profile. I think it makes more sense to redirect the user directly to available images in the explore tab