### PR TITLE
View better error if repo was deleted/renamed

### DIFF
--- a/server/remote/gitea/gitea.go
+++ b/server/remote/gitea/gitea.go
@@ -381,7 +381,12 @@ func (c *Gitea) Activate(ctx context.Context, u *model.User, r *model.Repo, link
 	if err != nil {
 		return err
 	}
-	_, _, err = client.CreateRepoHook(r.Owner, r.Name, hook)
+	_, response, err := client.CreateRepoHook(r.Owner, r.Name, hook)
+	if (err != nil && response.StatusCode == 200) || response.StatusCode == 404 {
+		// if repo was renamed, Gitea redirects as a GET request which
+		// results in an error of the SDK which can not parse the response
+		return fmt.Errorf("Could not find repository")
+	}
 	return err
 }
 


### PR DESCRIPTION
If the repo was renamed, there's an issue with Gitea: it redirects the /api/v1/repos/\<owner>/\<repo>/hooks POST request to a GET request at the same URL (returns a 302 Found which always redirects to GET - it should return a 307 or woodpecker needs to request again with the correct repo).
This URL returns the list of all hooks, thus the Gitea SDK can't parse the response into a single gitea.Hook type. The PR includes a workaround for this case.

A better error is also visisble if the repo was deleted.

Closes #726