### PR TITLE
refactor pipeline compiling

### DIFF
--- a/server/pipeline/compiler/compiler.go
+++ b/server/pipeline/compiler/compiler.go
@@ -1,0 +1,6 @@
+package compiler
+
+type Compiler interface {
+	area() float64
+	perim() float64
+}

--- a/server/pipeline/compiler/v1/procBuilder.go
+++ b/server/pipeline/compiler/v1/procBuilder.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package compiler
 
 import (
 	"fmt"

--- a/server/pipeline/compiler/v1/procBuilder_test.go
+++ b/server/pipeline/compiler/v1/procBuilder_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package compiler
 
 import (
 	"fmt"


### PR DESCRIPTION
- clean up types for internal representation of pipelines
  - one for the backend to be executable as step array
  - one to do further checks on
- migrate procBuilder into pipeline compiler & move all compiling related code into own package
- make pipeline compiler / procBuilder generic by using an interface to allow alternative implementations (new versions, different config languages, ...)
  - it should "simply" get some string and output an internal data representation 
- add some general utils for a compiled pipeline like zerosteps etc