### PR TITLE
Show builds failed because of invalid yaml in woodpeckers webui

### DIFF
--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -191,7 +191,7 @@ func PostHook(c *gin.Context) {
 		msg := "failure to parse yaml from hook"
 		log.Debug().Err(err).Str("repo", repo.FullName).Msg(msg)
 		c.String(http.StatusBadRequest, msg)
-		return
+		// No return here, we create the entry in the database to show a failed run in the woodpecker webui
 	}
 	if filtered {
 		msg := "ignoring hook: branch does not match restrictions defined in yaml"


### PR DESCRIPTION
I am not yet 100% sure but this feels like a nicer behavior, related to #811 

I think I need to play with it a little more still... What do you think ?