### PR TITLE
Add missing flag and docs

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -169,9 +169,10 @@ var flags = []cli.Flag{
 		Usage:   "url used for calling configuration service endpoint",
 	},
 	&cli.StringFlag{
-		EnvVars: []string{"WOODPECKER_CONFIG_SERVICE_SECRET"},
-		Name:    "config-service-secret",
-		Usage:   "secret to sign requests send to configuration service",
+		EnvVars:  []string{"WOODPECKER_CONFIG_SERVICE_SECRET"},
+		Name:     "config-service-secret",
+		Usage:    "secret to sign requests send to configuration service",
+		FilePath: os.Getenv("WOODPECKER_CONFIG_SERVICE_SECRET_FILE"),
 	},
 	&cli.StringFlag{
 		EnvVars: []string{"WOODPECKER_DATABASE_DRIVER"},

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -334,6 +334,22 @@ Comma-separated list to limit the specific CPUs or cores a pipeline container ca
 
 Example: `WOODPECKER_LIMIT_CPU_SET=1,2`
 
+
+### `WOODPECKER_CONFIG_SERVICE_ENDPOINT`
+> Default: `0`
+
+Specify a configuration service endpoint, see [Configuration Extension](docs/administration/external-configuration-api)
+
+### `WOODPECKER_CONFIG_SERVICE_SECRET`
+> Default: `0`
+
+Specify a signing secret for the configuration service endpoint, see [Configuration Extension](docs/administration/external-configuration-api)
+
+### `WOODPECKER_CONFIG_SERVICE_SECRET_FILE`
+> Default: `0`
+
+Read the value for `WOODPECKER_CONFIG_SERVICE_SECRET` from the specified filepath
+
 ---
 
 ### `WOODPECKER_GITHUB_...`

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -336,17 +336,17 @@ Example: `WOODPECKER_LIMIT_CPU_SET=1,2`
 
 
 ### `WOODPECKER_CONFIG_SERVICE_ENDPOINT`
-> Default: `0`
+> Default: ``
 
 Specify a configuration service endpoint, see [Configuration Extension](docs/administration/external-configuration-api)
 
 ### `WOODPECKER_CONFIG_SERVICE_SECRET`
-> Default: `0`
+> Default: ``
 
 Specify a signing secret for the configuration service endpoint, see [Configuration Extension](docs/administration/external-configuration-api)
 
 ### `WOODPECKER_CONFIG_SERVICE_SECRET_FILE`
-> Default: `0`
+> Default: ``
 
 Read the value for `WOODPECKER_CONFIG_SERVICE_SECRET` from the specified filepath
 


### PR DESCRIPTION
Seems like I missed something in my last 2 PRs :-)

This adds the missing flag and missing docs for the configuration api env vars to server config
