### PR TITLE
Fix various typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@
   * Format code with 'simplify' flag and check via CI (#509)
   * Use Goblin Assert as intended (#501)
   * Embedding libcompose types for yaml parsing (#495)
-  * Use std methode to get SystemCertPool (#488)
+  * Use std method to get SystemCertPool (#488)
   * Upgrade urfave/cli to v2 (#483)
   * Remove some wrapper and make code more redable (#478)
   * More logging and refactor (#457)

--- a/docs/docs/20-usage/71-project-settings.md
+++ b/docs/docs/20-usage/71-project-settings.md
@@ -24,7 +24,7 @@ If you set your project to trusted, a pipeline step and by this the underlying c
 
 :::note
 
-Only server admins can set this option. If you are not a server admin this option wont be shown in your project settings.
+Only server admins can set this option. If you are not a server admin this option won't be shown in your project settings.
 
 :::
 

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -76,9 +76,9 @@ services:
 
 To handle sensitive data in docker-compose or docker-swarm configurations there are several options:
 
-For docker-compose you can use a .env file next to your compose condfiguration to store the secrets outside of the compose file. While this seperates configuration from secrets it is still not very secure.
+For docker-compose you can use a .env file next to your compose condfiguration to store the secrets outside of the compose file. While this separates configuration from secrets it is still not very secure.
 
-Alternatively use docker-secrets. As it may be difficult to use docker secrets for environment variables woodpecker allows to read sensible data from files by profiding a `*_FILE` option of all sensible configuration variables. Woodpecker will try to read the value directly from this file. Keep in mind that when the original environment varibale gets specified at the same time it will override the value read from the file.
+Alternatively use docker-secrets. As it may be difficult to use docker secrets for environment variables woodpecker allows to read sensible data from files by providing a `*_FILE` option of all sensible configuration variables. Woodpecker will try to read the value directly from this file. Keep in mind that when the original environment variable gets specified at the same time it will override the value read from the file.
 
 ```diff
 # docker-compose.yml

--- a/docs/docs/30-administration/15-agent-config.md
+++ b/docs/docs/30-administration/15-agent-config.md
@@ -1,6 +1,6 @@
 # Agent configuration
 
-Agents are configured by the command line or environement variables. At the minimum you need the following information:
+Agents are configured by the command line or environment variables. At the minimum you need the following information:
 
 ```yaml
 # docker-compose.yml

--- a/docs/docs/92-development/06-guides.md
+++ b/docs/docs/92-development/06-guides.md
@@ -32,5 +32,5 @@ Adding new properties to models will be handled automatically by the underlying 
 You should not use `sess.Begin()`, `sess.Commit()` or `sess.Close()` inside a migration. Session / transaction handling will be done by the underlying migration manager.
 :::
 
-To automatically execute the migration after the start of the server, the new migration needs to be added to the end of `migrationTasks` in `server/store/datastore/migration/migration.go`. After a successful execution of that transaction the server will automatically add the migration to a list, so it wont be executed again on the next start.
+To automatically execute the migration after the start of the server, the new migration needs to be added to the end of `migrationTasks` in `server/store/datastore/migration/migration.go`. After a successful execution of that transaction the server will automatically add the migration to a list, so it won't be executed again on the next start.
 

--- a/server/plugins/environments/parse.go
+++ b/server/plugins/environments/parse.go
@@ -12,7 +12,7 @@ type builtin struct {
 	globals []*model.Environ
 }
 
-// Parse returns a EnvironService based on a string slice where key and value are separated by a ":" delimeter.
+// Parse returns a EnvironService based on a string slice where key and value are separated by a ":" delimiter.
 func Parse(params []string) model.EnvironService {
 	var globals []*model.Environ
 

--- a/server/shared/configFetcher.go
+++ b/server/shared/configFetcher.go
@@ -60,7 +60,7 @@ func (cf *configFetcher) Fetch(ctx context.Context) (files []*remote.FileMeta, e
 			log.Trace().Msgf("ConfigFetch[%s]: getting config from external http service", cf.repo.FullName)
 			newConfigs, useOld, err := cf.configService.FetchExternalConfig(fetchCtx, cf.repo, cf.build, files)
 			if err != nil {
-				log.Error().Msg("Got errror " + err.Error())
+				log.Error().Msg("Got error " + err.Error())
 				return nil, fmt.Errorf("On Fetching config via http : %s", err)
 			}
 

--- a/server/store/datastore/repo.go
+++ b/server/store/datastore/repo.go
@@ -101,7 +101,7 @@ func (s storage) DeleteRepo(repo *model.Repo) error {
 	return sess.Commit()
 }
 
-// RepoList list all repos where permissions fo specific user are stored
+// RepoList list all repos where permissions for specific user are stored
 // TODO: paginate
 func (s storage) RepoList(user *model.User, owned bool) ([]*model.Repo, error) {
 	repos := make([]*model.Repo, 0, perPage)

--- a/shared/utils/strings.go
+++ b/shared/utils/strings.go
@@ -31,7 +31,7 @@ func DedupStrings(list []string) []string {
 	return newList
 }
 
-// EqualStringSlice compare two string slices if they have equal values independ of how they are sorted
+// EqualStringSlice compare two string slices if they have equal values independent of how they are sorted
 func EqualStringSlice(l1, l2 []string) bool {
 	if len(l1) != len(l2) {
 		return false


### PR DESCRIPTION
Note, detected using:
`codespell --skip="./vendor/**/*" -I=.codespell_ignore  .`

I guess this could be used to tackle #738 as well. I'll create a PR for that as well.