### PR TITLE
support conditional branch as an array to align with documentation

### DIFF
--- a/pipeline/schema/.woodpecker/test-when.yml
+++ b/pipeline/schema/.woodpecker/test-when.yml
@@ -6,6 +6,13 @@ pipeline:
     when:
       branch: master
 
+  when-branch-array:
+    image: alpine
+    commands:
+      - echo "test"
+    when:
+      branch: [master, deploy]
+
   when-event:
     image: alpine
     commands:

--- a/pipeline/schema/schema.json
+++ b/pipeline/schema/schema.json
@@ -200,7 +200,16 @@
         },
         "branch": {
           "description": "TODO Read more: https://woodpecker-ci.org/docs/usage/pipeline-syntax#branch",
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minLength": 1
+            },
+            { "type": "string" }
+          ]
         },
         "event": {
           "description": "TODO Read more: https://woodpecker-ci.org/docs/usage/pipeline-syntax#event",


### PR DESCRIPTION
according to the documentation on [conditional step execution](https://woodpecker-ci.org/docs/usage/conditional-execution) ([md source line](https://github.com/woodpecker-ci/woodpecker/blob/074e2cd38ac100e81f7eb1f072d9c6eafb8abd90/docs/docs/20-usage/22-conditional-execution.md?plain=1#L39)),  `branch` should support both string and array of string types

this PR adjusts the schema to align with the documentation

the outcome of this PR is for my editor (which downloads schemas pointed from [schemastore](https://www.schemastore.org/json/)) to not highlight an error when using the array format instead of the string format in my `.woodpecker.yml`