### PR TITLE
[Charts] Add option to pass in updateStrategy

### DIFF
--- a/charts/woodpecker-server/templates/deployment.yaml
+++ b/charts/woodpecker-server/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "woodpecker-server.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "woodpecker-server.selectorLabels" . | nindent 6 }}

--- a/charts/woodpecker-server/values.yaml
+++ b/charts/woodpecker-server/values.yaml
@@ -1,5 +1,11 @@
 replicaCount: 1
 
+updateStrategy:
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0
+  type: RollingUpdate
+
 image:
   registry: docker.io
   repository: woodpeckerci/woodpecker-server


### PR DESCRIPTION
Add an option to let users specify the updatestrategy.

useful e.g. if the pvc is RWO and therefore, if woodpecker should be updated and kubernetes tries to create a 2nd woodpecker-server pod while the first one is still running (due to the default updatestrategy), kubernetes gets into a multi attach error (`Multi-Attach error for volume "pvc-e5ba1b19-0799-4eb1-9846-706a6662dbe4" Volume is already used by pod(s) woodpecker-server-58dd5594bb-h2lj6`).