### PR TITLE
Docs: Fix link on FAQ page

### DIFF
--- a/docs/src/pages/faq.md
+++ b/docs/src/pages/faq.md
@@ -4,7 +4,7 @@
 
 Apart from Woodpecker staying free and OpenSource forever, the growing community already introduced some nifty features like:
 - [Multi pipelines](/docs/usage/multi-pipeline)
-- [Conditional step execution on file changes](/docs/usage/pipeline-syntax#path)
+- [Conditional step execution on file changes](/docs/usage/conditional-execution#path)
 - [More features are already in the pipeline :wink:](https://github.com/woodpecker-ci/woodpecker/pulls) ...
 
 ## Why is Woodpecker a fork of Drone version 0.8?


### PR DESCRIPTION
In #506 the documentation for _Conditional Step Execution_ got moved to a separate page. This PR updates the link on the FAQ page to point to the new location.