### PR TITLE
Add ingressClassName to ingress template

### DIFF
--- a/charts/woodpecker-server/templates/ingress.yaml
+++ b/charts/woodpecker-server/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/woodpecker-server/values.yaml
+++ b/charts/woodpecker-server/values.yaml
@@ -64,6 +64,10 @@ ingress:
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+
+  # -- Defines which ingress controller will implement the resource
+  ingressClassName: ""
+
   hosts:
     - host: chart-example.local
       paths:


### PR DESCRIPTION
As the configuration of nginx-ingress is changed from annotations to ingressClassName I've added the ingressClassName parameter to the ingress template and the values file.