### PR TITLE
Do not hardcode default in several place

### DIFF
--- a/pipeline/backend/local/local.go
+++ b/pipeline/backend/local/local.go
@@ -53,10 +53,7 @@ func (e *local) Exec(ctx context.Context, proc *types.Step) error {
 	}
 
 	// Get default clone image
-	defaultCloneImage := "docker.io/woodpeckerci/plugin-git:latest"
-	if len(server.Config.Pipeline.DefaultCloneImage) > 0 {
-		defaultCloneImage = server.Config.Pipeline.DefaultCloneImage
-	}
+	defaultCloneImage := server.Config.Pipeline.DefaultCloneImage
 
 	if proc.Image == defaultCloneImage {
 		// Default clone step


### PR DESCRIPTION
Since DefaultCloneImage is always defined by the code, there is no
need to have a 2nd place where the default is defined.

Mentionned on #861