### PR TITLE
Set default logging value of cli to info

### DIFF
--- a/cli/common/flags.go
+++ b/cli/common/flags.go
@@ -51,6 +51,7 @@ var GlobalFlags = []cli.Flag{
 		EnvVars: []string{"WOODPECKER_LOG_LEVEL"},
 		Name:    "log-level",
 		Usage:   "set logging level",
+		Value:   "info",
 	},
 }
 

--- a/cli/common/zerologger.go
+++ b/cli/common/zerologger.go
@@ -7,14 +7,12 @@ import (
 )
 
 func SetupConsoleLogger(c *cli.Context) error {
-	if c.IsSet("log-level") {
-		level := c.String("log-level")
-		lvl, err := zerolog.ParseLevel(level)
-		if err != nil {
-			log.Fatal().Msgf("unknown logging level: %s", level)
-		}
-		zerolog.SetGlobalLevel(lvl)
+	level := c.String("log-level")
+	lvl, err := zerolog.ParseLevel(level)
+	if err != nil {
+		log.Fatal().Msgf("unknown logging level: %s", level)
 	}
+	zerolog.SetGlobalLevel(lvl)
 	if zerolog.GlobalLevel() <= zerolog.DebugLevel {
 		log.Logger = log.With().Caller().Logger()
 		log.Log().Msgf("LogLevel = %s", zerolog.GlobalLevel().String())


### PR DESCRIPTION
Since the library use "trace" by default, it always display a message
that seems not useful for a regular CLI usage