### PR TITLE
Fix insecure /tmp usage in local backend

### DIFF
--- a/pipeline/backend/local/local.go
+++ b/pipeline/backend/local/local.go
@@ -3,18 +3,19 @@ package local
 import (
 	"context"
 	"encoding/base64"
+	"github.com/woodpecker-ci/woodpecker/pipeline/backend/types"
+	"github.com/woodpecker-ci/woodpecker/server"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/woodpecker-ci/woodpecker/pipeline/backend/types"
-	"github.com/woodpecker-ci/woodpecker/server"
 )
 
 type local struct {
-	cmd    *exec.Cmd
-	output io.ReadCloser
+	cmd        *exec.Cmd
+	output     io.ReadCloser
+	workingdir string
 }
 
 // make sure local implements Engine
@@ -34,7 +35,9 @@ func (e *local) IsAvailable() bool {
 }
 
 func (e *local) Load() error {
-	return nil
+	dir, err := ioutil.TempDir("", "woodpecker-local-*")
+	e.workingdir = dir
+	return err
 }
 
 // Setup the pipeline environment.
@@ -60,7 +63,7 @@ func (e *local) Exec(ctx context.Context, proc *types.Step) error {
 
 	if proc.Image == defaultCloneImage {
 		// Default clone step
-		Command = append(Command, "CI_WORKSPACE=/tmp/woodpecker/"+proc.Environment["CI_REPO"])
+		Command = append(Command, "CI_WORKSPACE="+e.workingdir+"/"+proc.Environment["CI_REPO"])
 		Command = append(Command, "plugin-git")
 	} else {
 		// Use "image name" as run command
@@ -78,12 +81,14 @@ func (e *local) Exec(ctx context.Context, proc *types.Step) error {
 
 	// Prepare working directory
 	if proc.Image == defaultCloneImage {
-		e.cmd.Dir = "/tmp/woodpecker/" + proc.Environment["CI_REPO_OWNER"]
+		e.cmd.Dir = e.workingdir + "/" + proc.Environment["CI_REPO_OWNER"]
 	} else {
-		e.cmd.Dir = "/tmp/woodpecker/" + proc.Environment["CI_REPO"]
+		e.cmd.Dir = e.workingdir + "/" + proc.Environment["CI_REPO"]
 	}
-	_ = os.MkdirAll(e.cmd.Dir, 0o700)
-
+	err := os.MkdirAll(e.cmd.Dir, 0o700)
+	if err != nil {
+		return err
+	}
 	// Get output and redirect Stderr to Stdout
 	e.output, _ = e.cmd.StdoutPipe()
 	e.cmd.Stderr = e.cmd.Stdout

--- a/pipeline/backend/local/local.go
+++ b/pipeline/backend/local/local.go
@@ -3,13 +3,14 @@ package local
 import (
 	"context"
 	"encoding/base64"
-	"github.com/woodpecker-ci/woodpecker/pipeline/backend/types"
-	"github.com/woodpecker-ci/woodpecker/server"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/woodpecker-ci/woodpecker/pipeline/backend/types"
+	"github.com/woodpecker-ci/woodpecker/server"
 )
 
 type local struct {


### PR DESCRIPTION
Since /tmp is writable by everybody, a user could precreate
/tmp/woodpecker with 777 permissions, allowing them to modify the
pipeline while it is being run, or preventing the pipeline from running.

And since os.MkdirAll error code wasn't checked, the same attacker
could have precreated the directory where the pipeline is executed to
mess with the run, allowing code execution under the UID of the
agent (who has access to the toke, to communicate with the server, which
mean a attacker could inject a fake agent, steal credentials, etc)