### PR TITLE
Move value of default clone image into shared constant package

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -101,7 +101,7 @@ var flags = []cli.Flag{
 		EnvVars: []string{"WOODPECKER_DEFAULT_CLONE_IMAGE"},
 		Name:    "default-clone-image",
 		Usage:   "The default docker image to be used when cloning the repo",
-		Value:   "woodpeckerci/plugin-git:latest",
+		Value:   constant.DefaultCloneImage,
 	},
 	&cli.StringFlag{
 		EnvVars: []string{"WOODPECKER_DOCS"},

--- a/pipeline/backend/local/local.go
+++ b/pipeline/backend/local/local.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/woodpecker-ci/woodpecker/pipeline/backend/types"
-	"github.com/woodpecker-ci/woodpecker/server"
+	"github.com/woodpecker-ci/woodpecker/shared/constant"
 )
 
 type local struct {
@@ -52,13 +52,7 @@ func (e *local) Exec(ctx context.Context, proc *types.Step) error {
 		}
 	}
 
-	// Get default clone image
-	defaultCloneImage := "docker.io/woodpeckerci/plugin-git:latest"
-	if len(server.Config.Pipeline.DefaultCloneImage) > 0 {
-		defaultCloneImage = server.Config.Pipeline.DefaultCloneImage
-	}
-
-	if proc.Image == defaultCloneImage {
+	if proc.Image == constant.DefaultCloneImage {
 		// Default clone step
 		Command = append(Command, "CI_WORKSPACE=/tmp/woodpecker/"+proc.Environment["CI_REPO"])
 		Command = append(Command, "plugin-git")
@@ -77,7 +71,7 @@ func (e *local) Exec(ctx context.Context, proc *types.Step) error {
 	e.cmd = exec.CommandContext(ctx, "/bin/env", Command...)
 
 	// Prepare working directory
-	if proc.Image == defaultCloneImage {
+	if proc.Image == constant.DefaultCloneImage {
 		e.cmd.Dir = "/tmp/woodpecker/" + proc.Environment["CI_REPO_OWNER"]
 	} else {
 		e.cmd.Dir = "/tmp/woodpecker/" + proc.Environment["CI_REPO"]
@@ -106,6 +100,6 @@ func (e *local) Tail(context.Context, *types.Step) (io.ReadCloser, error) {
 
 // Destroy the pipeline environment.
 func (e *local) Destroy(context.Context, *types.Config) error {
-	os.RemoveAll(e.cmd.Dir)
+	_ = os.RemoveAll(e.cmd.Dir)
 	return nil
 }

--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -7,6 +7,7 @@ import (
 	backend "github.com/woodpecker-ci/woodpecker/pipeline/backend/types"
 	"github.com/woodpecker-ci/woodpecker/pipeline/frontend"
 	"github.com/woodpecker-ci/woodpecker/pipeline/frontend/yaml"
+	"github.com/woodpecker-ci/woodpecker/shared/constant"
 )
 
 // TODO(bradrydzewski) compiler should handle user-defined volumes from YAML
@@ -15,8 +16,7 @@ import (
 const (
 	windowsPrefix = "windows/"
 
-	defaultCloneImage = "woodpeckerci/plugin-git:latest"
-	defaultCloneName  = "clone"
+	defaultCloneName = "clone"
 
 	networkDriverNAT    = "nat"
 	networkDriverBridge = "bridge"
@@ -121,7 +121,7 @@ func (c *Compiler) Compile(conf *yaml.Config) *backend.Config {
 
 	// add default clone step
 	if !c.local && len(conf.Clone.Containers) == 0 && !conf.SkipClone {
-		cloneImage := defaultCloneImage
+		cloneImage := constant.DefaultCloneImage
 		if len(c.defaultCloneImage) > 0 {
 			cloneImage = c.defaultCloneImage
 		}

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constant
+
+var PrivilegedPlugins = []string{
+	"plugins/docker",
+	"plugins/gcr",
+	"plugins/ecr",
+	"woodpeckerci/plugin-docker",
+	"woodpeckerci/plugin-docker-buildx",
+}
+
+const (
+	DefaultCloneImage = "docker.io/woodpeckerci/plugin-git:latest"
+)

--- a/shared/constant/privileged_plugins.go
+++ b/shared/constant/privileged_plugins.go
@@ -1,9 +1,0 @@
-package constant
-
-var PrivilegedPlugins = []string{
-	"plugins/docker",
-	"plugins/gcr",
-	"plugins/ecr",
-	"woodpeckerci/plugin-docker",
-	"woodpeckerci/plugin-docker-buildx",
-}


### PR DESCRIPTION
we should make sure by linter that the pipeline backends are not importing server stuff, they should only be used in **cli** and **agent** - and so if agent does have indirect dependency to the server packages something went wrong ...

sorry did oversaw that in the local backend pull :/