### PR TITLE
FIX: database docker-compose documentation

### DIFF
--- a/docs/docs/30-administration/30-database.md
+++ b/docs/docs/30-administration/30-database.md
@@ -29,8 +29,8 @@ services:
   woodpecker-server:
     [...]
     environment:
-+     WOODPECKER_DATABASE_DRIVER: mysql
-+     WOODPECKER_DATABASE_DATASOURCE: root:password@tcp(1.2.3.4:3306)/woodpecker?parseTime=true
++     - WOODPECKER_DATABASE_DRIVER=mysql
++     - WOODPECKER_DATABASE_DATASOURCE=root:password@tcp(1.2.3.4:3306)/woodpecker?parseTime=true
 ```
 
 ## Configure Postgres
@@ -46,8 +46,8 @@ services:
   woodpecker-server:
     [...]
     environment:
-+     WOODPECKER_DATABASE_DRIVER: postgres
-+     WOODPECKER_DATABASE_DATASOURCE: postgres://root:password@1.2.3.4:5432/postgres?sslmode=disable
++     - WOODPECKER_DATABASE_DRIVER=postgres
++     - WOODPECKER_DATABASE_DATASOURCE=postgres://root:password@1.2.3.4:5432/postgres?sslmode=disable
 ```
 
 ## Database Creation


### PR DESCRIPTION
environment in docker-compose files is an array: lines start with a dash (-) and key value assignments are done using an equal sign (=)