### PR TITLE
Take in an io.Reader instead of file path for schema linter

### DIFF
--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -44,7 +44,13 @@ func lintDir(c *cli.Context, dir string) error {
 }
 
 func lintFile(_ *cli.Context, file string) error {
-	configErrors, err := schema.Lint(file)
+	fi, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer fi.Close()
+
+	configErrors, err := schema.Lint(fi)
 	if err != nil {
 		fmt.Println("❌ Config is invalid")
 		for _, configError := range configErrors {

--- a/pipeline/schema/schema.go
+++ b/pipeline/schema/schema.go
@@ -3,6 +3,7 @@ package schema
 import (
 	_ "embed"
 	"fmt"
+	"io"
 
 	"github.com/xeipuuv/gojsonschema"
 
@@ -12,9 +13,10 @@ import (
 //go:embed schema.json
 var schemaDefinition []byte
 
-func Lint(file string) ([]gojsonschema.ResultError, error) {
+// Lint lints an io.Reader against the Woodpecker schema.json
+func Lint(r io.Reader) ([]gojsonschema.ResultError, error) {
 	schemaLoader := gojsonschema.NewBytesLoader(schemaDefinition)
-	j, err := yml.LoadYmlFileAsJSON(file)
+	j, err := yml.LoadYmlReaderAsJSON(r)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load yml file %w", err)
 	}

--- a/pipeline/schema/schema_test.go
+++ b/pipeline/schema/schema_test.go
@@ -2,6 +2,7 @@ package schema_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,7 +79,10 @@ func TestSchema(t *testing.T) {
 
 	for _, tt := range testTable {
 		t.Run(tt.name, func(t *testing.T) {
-			configErrors, err := schema.Lint(tt.testFile)
+			fi, err := os.Open(tt.testFile)
+			assert.NoError(t, err, "could not open test file")
+			defer fi.Close()
+			configErrors, err := schema.Lint(fi)
 			if tt.fail {
 				if len(configErrors) == 0 {
 					assert.Error(t, err, "Expected config errors but got none")

--- a/shared/yml/yml.go
+++ b/shared/yml/yml.go
@@ -3,7 +3,7 @@ package yml
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"strconv"
 
 	"gopkg.in/yaml.v3"
@@ -59,6 +59,7 @@ func toJSON(node *yaml.Node) (interface{}, error) {
 	return nil, fmt.Errorf("do not support yaml node kind '%v'", node.Kind)
 }
 
+// ToJSON converts YAML bytes to JSON
 func ToJSON(data []byte) ([]byte, error) {
 	m := &yaml.Node{}
 	if err := yaml.Unmarshal(data, m); err != nil {
@@ -72,8 +73,9 @@ func ToJSON(data []byte) ([]byte, error) {
 	return json.Marshal(d)
 }
 
-func LoadYmlFileAsJSON(path string) (j []byte, err error) {
-	data, err := os.ReadFile(path)
+// LoadYmlReaderAsJSON reads from an io.Reader containing YAML and converts it to JSON
+func LoadYmlReaderAsJSON(r io.Reader) (j []byte, err error) {
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As title, this adds flexibility to the schema linter.  
By taking an `io.Reader`, we don't need to rely on the file being on disk.