### PR TITLE
fix key/val format for dind env vars

### DIFF
--- a/charts/woodpecker-agent/values.yaml
+++ b/charts/woodpecker-agent/values.yaml
@@ -10,8 +10,7 @@ image:
 dind:
   image: "docker:20.10.12-dind"
   env:
-  - name: DOCKER_DRIVER
-    value: overlay2
+    DOCKER_DRIVER: "overlay2"
   resources: {}
 
 env:


### PR DESCRIPTION
Fixes the key/value format used in the agent values for Helm
Should fix the issue (https://github.com/woodpecker-ci/woodpecker/issues/866)

Closes #866