### PR TITLE
Clarify the `when.tag` example

### DIFF
--- a/docs/docs/20-usage/20-pipeline-syntax.md
+++ b/docs/docs/20-usage/20-pipeline-syntax.md
@@ -376,6 +376,7 @@ when:
 
 #### `tag`
 
+This filter only applies to tag events.
 Use glob expression to execute a step if the tag name starts with `v`:
 
 ```diff

--- a/docs/docs/20-usage/20-pipeline-syntax.md
+++ b/docs/docs/20-usage/20-pipeline-syntax.md
@@ -376,12 +376,12 @@ when:
 
 #### `tag`
 
-Execute a step if the tag name starts with `release`:
+Use glob expression to execute a step if the tag name starts with `v`:
 
 ```diff
 when:
   event: tag
-  tag: release*
+  tag: v*
 ```
 
 #### `status`

--- a/docs/docs/20-usage/20-pipeline-syntax.md
+++ b/docs/docs/20-usage/20-pipeline-syntax.md
@@ -380,6 +380,7 @@ Execute a step if the tag name starts with `release`:
 
 ```diff
 when:
+  event: tag
   tag: release*
 ```
 


### PR DESCRIPTION
The `tag` filter is only used if it's also a `tag` event. This makes the example clearer for new users.