### PR TITLE
Improve UI colors to have more contrast 

### DIFF
--- a/web/src/components/layout/Panel.vue
+++ b/web/src/components/layout/Panel.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="rounded-md w-full shadow overflow-hidden text-gray-500 bg-gray-300 dark:bg-dark-gray-700">
-    <div v-if="title" class="font-bold bg-gray-400 dark:bg-dark-gray-800 p-2">{{ title }}</div>
-    <div class="w-full p-4 bg-gray-300 dark:bg-dark-gray-700">
+  <div class="rounded-md w-full shadow overflow-hidden bg-gray-300 dark:bg-dark-gray-700">
+    <div v-if="title" class="font-bold text-gray-200 bg-gray-400 dark:bg-dark-gray-800 px-4 py-2">{{ title }}</div>
+    <div class="w-full p-4 bg-white dark:bg-dark-gray-700">
       <slot />
     </div>
   </div>

--- a/web/src/components/repo/build/BuildProcList.vue
+++ b/web/src/components/repo/build/BuildProcList.vue
@@ -1,19 +1,6 @@
 <template>
   <div class="flex flex-col w-full md:w-3/12 text-gray-200 dark:text-gray-400 bg-gray-600 dark:bg-dark-gray-800">
-    <div
-      class="
-        flex
-        py-4
-        px-2
-        mx-2
-        space-x-1
-        justify-between
-        flex-shrink-0
-        text-gray-500
-        border-b-1
-        dark:border-dark-gray-600
-      "
-    >
+    <div class="flex py-4 px-2 mx-2 space-x-1 justify-between flex-shrink-0 border-b-1 dark:border-dark-gray-600">
       <div class="flex space-x-1 items-center flex-shrink-0">
         <div class="flex items-center"><img class="w-6" :src="build.author_avatar" /></div>
         <span>{{ build.author }}</span>


### PR DESCRIPTION
Hello! I'd love to get rid of my personal eye sore (maybe something wrong with my eyes). First, in the build view, I can barely read the username and the branch on the sidebar; I'd like to make it more legible from my point of view, if you don't mind.

![BuildProcList_before](https://user-images.githubusercontent.com/355889/171060137-3f20b027-3b6f-4185-9c40-bf2cfa1072b8.png)
![BuildProcList_after](https://user-images.githubusercontent.com/355889/171060179-9a9a9f45-e58d-492c-8616-57b9eae9e363.png)

Second, in the repository settings, isn't the settings panel too gray for the text? I switched it to white, and it does seem to look a bit clearer, wouldn't you agree?

![Panel_before](https://user-images.githubusercontent.com/355889/171060286-03aed457-5f70-45db-8bf9-ed214247a539.png)
![Panel_after](https://user-images.githubusercontent.com/355889/171060299-81c428dd-6c0e-4024-b64c-bc5a4b87fad7.png)

To be honest, even here I would prefer the muted gray text to be slightly darker, but that I can definitely live with.