### PR TITLE
Return to page after clicking login at navbar

### DIFF
--- a/web/src/components/layout/header/Navbar.vue
+++ b/web/src/components/layout/header/Navbar.vue
@@ -37,6 +37,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { useRoute } from 'vue-router';
 
 import Button from '~/components/atomic/Button.vue';
 import IconButton from '~/components/atomic/IconButton.vue';
@@ -53,12 +54,13 @@ export default defineComponent({
 
   setup() {
     const config = useConfig();
+    const route = useRoute();
     const authentication = useAuthentication();
     const { darkMode } = useDarkMode();
     const docsUrl = window.WOODPECKER_DOCS;
 
     function doLogin() {
-      authentication.authenticate();
+      authentication.authenticate(route.fullPath);
     }
 
     const version = config.version?.startsWith('next') ? 'next' : config.version;


### PR DESCRIPTION
By this change the user will be returned to the currently opened page (for example a public repo), after pressing the login button att the nav-bar.