### PR TITLE
Add option to launch all needed services for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.so
 *.dylib
 vendor/
+__debug_bin
 
 # Test binary, built with `go test -c`
 *.test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,8 +1,16 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
+  "compounds": [
+    {
+      "name": "Woodpecker CI",
+      "configurations": [
+        "Woodpecker UI",
+        "Woodpecker server",
+        "Woodpecker agent"
+      ],
+      "stopAll": true
+    }
+  ],
   "configurations": [
     {
       "name": "Woodpecker server",
@@ -39,7 +47,6 @@
         "start",
       ],
       "cwd": "${workspaceFolder}/web",
-      "port": 3000,
       "resolveSourceMapLocations": [
         "${workspaceFolder}/web/**",
         "!**/node_modules/**"

--- a/docs/docs/92-development/01-getting-started.md
+++ b/docs/docs/92-development/01-getting-started.md
@@ -65,7 +65,7 @@ Create an O-Auth app for your forge as describe in the [forges documentation](/d
 
 You can use different methods for debugging the Woodpecker applications. One of the currently recommended ways to debug and test the Woodpecker application is using [VS-Code](https://code.visualstudio.com/) or [VS-Codium](https://vscodium.com/) (Open-Source binaries of VS-Code) as most maintainers are using it and Woodpecker already includes the needed debug configurations for it.
 
-To launch all needed services for local development you can use "Woodpecker CI" debugging configuration that will launch UI, server and agent in debugging mode. Than open `http://localhost:8000` to access it.
+To launch all needed services for local development you can use "Woodpecker CI" debugging configuration that will launch UI, server and agent in debugging mode. Then open `http://localhost:8000` to access it.
 
 As a starting guide for programming Go with VS-Code you can use this video guide:
 [![Getting started with Go in VS-Code](https://img.youtube.com/vi/1MXIGYrMk80/0.jpg)](https://www.youtube.com/watch?v=1MXIGYrMk80)

--- a/docs/docs/92-development/01-getting-started.md
+++ b/docs/docs/92-development/01-getting-started.md
@@ -65,6 +65,8 @@ Create an O-Auth app for your forge as describe in the [forges documentation](/d
 
 You can use different methods for debugging the Woodpecker applications. One of the currently recommend ways to debug and test the Woodpecker application is using [VS-Code](https://code.visualstudio.com/) or [VS-Codium](https://vscodium.com/) (Open-Source binaries of VS-Code) as most maintainers are using it and Woodpecker already includes the needed debug configurations for it.
 
+To launch all needed services for local development you can use "Woodpecker CI" debugging configuration that will launch UI, server and agent in debugging mode. Than open `http://localhost:8000` to access it.
+
 As a starting guide for programming Go with VS-Code you can use this video guide:
 [![Getting started with Go in VS-Code](https://img.youtube.com/vi/1MXIGYrMk80/0.jpg)](https://www.youtube.com/watch?v=1MXIGYrMk80)
 

--- a/docs/docs/92-development/01-getting-started.md
+++ b/docs/docs/92-development/01-getting-started.md
@@ -63,7 +63,7 @@ Create an O-Auth app for your forge as describe in the [forges documentation](/d
 
 ## Developing with VS-Code
 
-You can use different methods for debugging the Woodpecker applications. One of the currently recommend ways to debug and test the Woodpecker application is using [VS-Code](https://code.visualstudio.com/) or [VS-Codium](https://vscodium.com/) (Open-Source binaries of VS-Code) as most maintainers are using it and Woodpecker already includes the needed debug configurations for it.
+You can use different methods for debugging the Woodpecker applications. One of the currently recommended ways to debug and test the Woodpecker application is using [VS-Code](https://code.visualstudio.com/) or [VS-Codium](https://vscodium.com/) (Open-Source binaries of VS-Code) as most maintainers are using it and Woodpecker already includes the needed debug configurations for it.
 
 To launch all needed services for local development you can use "Woodpecker CI" debugging configuration that will launch UI, server and agent in debugging mode. Than open `http://localhost:8000` to access it.
 


### PR DESCRIPTION
`"port"` option in `Woodpecker UI` launch task is unsupported and not needed.

Also add `__debug_bin` to git ignore that is binary file created when launching debug tasks in VS Code