### PR TITLE
Fix tab URLs to be language agnostic

### DIFF
--- a/web/src/views/repo/RepoSettings.vue
+++ b/web/src/views/repo/RepoSettings.vue
@@ -6,19 +6,19 @@
     </div>
 
     <Tabs>
-      <Tab :title="$t('repo.settings.general.general')">
+      <Tab id="general" :title="$t('repo.settings.general.general')">
         <GeneralTab />
       </Tab>
-      <Tab :title="$t('repo.settings.secrets.secrets')">
+      <Tab id="secrets" :title="$t('repo.settings.secrets.secrets')">
         <SecretsTab />
       </Tab>
-      <Tab :title="$t('repo.settings.registries.registries')">
+      <Tab id="registries" :title="$t('repo.settings.registries.registries')">
         <RegistriesTab />
       </Tab>
-      <Tab :title="$t('repo.settings.badge.badge')">
+      <Tab id="badge" :title="$t('repo.settings.badge.badge')">
         <BadgeTab />
       </Tab>
-      <Tab :title="$t('repo.settings.actions.actions')">
+      <Tab id="actions" :title="$t('repo.settings.actions.actions')">
         <ActionsTab />
       </Tab>
     </Tabs>

--- a/web/src/views/repo/RepoWrapper.vue
+++ b/web/src/views/repo/RepoWrapper.vue
@@ -23,8 +23,8 @@
     </div>
 
     <Tabs v-model="activeTab" disable-hash-mode class="mb-4">
-      <Tab :title="$t('repo.activity')" />
-      <Tab :title="$t('repo.branches')" />
+      <Tab id="activity" :title="$t('repo.activity')" />
+      <Tab id="branches" :title="$t('repo.branches')" />
     </Tabs>
 
     <router-view />


### PR DESCRIPTION
Otherwise currently URL's (after `#`) would change depending on language, also activity/branch tabs would work only in English version.