### PR TITLE
Fix terminal DOM existing multiple times

### DIFF
--- a/web/src/components/repo/build/BuildLog.vue
+++ b/web/src/components/repo/build/BuildLog.vue
@@ -167,13 +167,13 @@ export default defineComponent({
       fitAddon.value.fit();
     }
 
-    let unmounted = false;
+    const unmounted = ref(false);
     onMounted(async () => {
       term.value.loadAddon(fitAddon.value);
       term.value.loadAddon(new WebLinksAddon());
 
       await nextTick(() => {
-        if (unmounted) {
+        if (unmounted.value) {
           // need to check if unmounted already because we are async here
           return;
         }
@@ -219,7 +219,7 @@ export default defineComponent({
     );
 
     onBeforeUnmount(() => {
-      unmounted = true;
+      unmounted.value = true;
       if (stream.value) {
         stream.value.close();
       }

--- a/web/src/components/repo/build/BuildLog.vue
+++ b/web/src/components/repo/build/BuildLog.vue
@@ -167,11 +167,16 @@ export default defineComponent({
       fitAddon.value.fit();
     }
 
+    let unmounted = false;
     onMounted(async () => {
       term.value.loadAddon(fitAddon.value);
       term.value.loadAddon(new WebLinksAddon());
 
       await nextTick(() => {
+        if (unmounted) {
+          // need to check if unmounted already because we are async here
+          return;
+        }
         const element = document.getElementById('terminal');
         if (element === null) {
           throw new Error('Unexpected: "terminal" should be provided at this place');
@@ -214,8 +219,14 @@ export default defineComponent({
     );
 
     onBeforeUnmount(() => {
+      unmounted = true;
       if (stream.value) {
         stream.value.close();
+      }
+      const element = document.getElementById('terminal');
+      if (element !== null) {
+        // Clean up any custom DOM added in onMounted above
+        element.innerHTML = '';
       }
       window.removeEventListener('resize', resize);
     });


### PR DESCRIPTION
When switching between the tasks/config/changed files tabs in the build
view, the DOM for the log xterm would be inserted multiple times,
causing the current terminal to be shifted down weirdly:


https://user-images.githubusercontent.com/1460997/175767842-ad72bbec-c68f-42a7-b622-68d55a5f0615.mov


This fixes this behavior by cleaning any custom DOM before the log is
unmounted.

Suggestions welcome if there are better ways clean up such custom elements. It has been a while since I last dived deeper into vue.