### PR TITLE
Gracefully handle non-zero exit code in local backend

### DIFF
--- a/pipeline/backend/local/local.go
+++ b/pipeline/backend/local/local.go
@@ -94,9 +94,17 @@ func (e *local) Exec(ctx context.Context, proc *types.Step) error {
 // Wait for the pipeline step to complete and returns
 // the completion results.
 func (e *local) Wait(context.Context, *types.Step) (*types.State, error) {
+	err := e.cmd.Wait()
+	ExitCode := 0
+	if eerr, ok := err.(*exec.ExitError); ok {
+		ExitCode = eerr.ExitCode()
+		// Non-zero exit code is a build failure, but not an agent error.
+		err = nil
+	}
 	return &types.State{
-		Exited: true,
-	}, e.cmd.Wait()
+		Exited:   true,
+		ExitCode: ExitCode,
+	}, err
 }
 
 // Tail the pipeline step logs.


### PR DESCRIPTION
A non-zero exit code signifies a pipeline failure, but is not a fatal
error in the agent. Since exec reports this as exec.ExitError, this has
to be handled explicitly.

This also fixes logs not being shown on build errors.
Before: https://ci.rizin.re/rizinorg/rizin/build/23/4
After: https://ci.rizin.re/rizinorg/rizin/build/24/4