### PR TITLE
Wait to finish reading logs before calling Wait() on pipeline

### DIFF
--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -216,13 +217,16 @@ func (r *Runtime) exec(step *backend.Step) (*backend.State, error) {
 		return nil, err
 	}
 
+	var wg sync.WaitGroup
 	if r.logger != nil {
 		rc, err := r.engine.Tail(r.ctx, step)
 		if err != nil {
 			return nil, err
 		}
 
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			logger := r.MakeLogger()
 
 			if err := r.logger.Log(step, multipart.New(rc)); err != nil {
@@ -237,6 +241,9 @@ func (r *Runtime) exec(step *backend.Step) (*backend.State, error) {
 		return nil, nil
 	}
 
+	// Some pipeline backends, such as local, will close the pipe from Tail on Wait,
+	// so first make sure all reading has finished.
+	wg.Wait()
 	waitState, err := r.engine.Wait(r.ctx, step)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes errors like the following and chopped off
logs with the local backend:
```
{"level":"error","error":"read |0: file already closed","time":"2022-07-04T17:42:29+02:00","message":"copy limited logStream part"}
```
The reason for this issue is that exec's Wait(), which is used
internally by the this backend, closes the stdout/stderr pipe, so we
must wait until all reading is done before calling it.

See https://pkg.go.dev/os/exec?utm_source=gopls#Cmd.StdoutPipe:
> Wait will close the pipe after seeing the command exit, so most
> callers need not close the pipe themselves. It is thus incorrect
> to call Wait before all reads from the pipe have completed.

Instead of using a WaitGroup, one could call the reading synchronously,
but with the `step.Detached` case probably still needing it as a goroutine,
it might become less readable.

An alternative solution could be to move this synchronization into the local backend
implementation itself, for example by constructing a new `io.Pipe()`, copying everything
into it and waiting for this to be done before calling the exec `Wait()`.
But I think it might be better in general to wait until all log has been read before considering
a pipeline finished.

I have also sometimes encountered errors like these:
```
{"level":"error","error":"read |0: file already closed","time":"2022-07-04T17:42:29+02:00","message":"copy limited logStream part"}
{"level":"error","error":"rpc error: code = Unknown desc = database is locked","time":"2022-07-04T17:42:29+02:00","message":"grpc error: upload(): code: Unknown: rpc error: code = Unknown desc = database is locked"}
{"level":"error","repo":"thestr4ng3r/ci-test","build":"23","id":"178","image":"/bin/bash","stage":"build","error":"rpc error: code = Unknown desc = database is locked","time":"2022-07-04T17:42:29+02:00","message":"log stream upload error"}
```
Maybe it is related. In those cases, I did not get any logs at all in the webui. After the fix, I have not seen those anymore, but they were sporadic before too.