### PR TITLE
Fix incorrect port used in docs and docker-compose example

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
     image: woodpeckerci/woodpecker-server:local
     ports:
-      - 8000:8000
+      - 9000:9000
     volumes:
       - /var/lib/woodpecker:/var/lib/woodpecker/
     environment:

--- a/docs/docs/30-administration/00-setup.md
+++ b/docs/docs/30-administration/00-setup.md
@@ -31,7 +31,7 @@ services:
   woodpecker-server:
     image: woodpeckerci/woodpecker-server:latest
     ports:
-      - 8000:8000
+      - 9000:9000
     volumes:
       - woodpecker-server-data:/var/lib/woodpecker/
     environment:


### PR DESCRIPTION
The docker-compose examples in the docs and the example file incorrectly use port 8000 instead of 9000.