### PR TITLE
Fix screenshot upload for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,6 @@ body:
         and copy paste the text instead.
 
         Tip: You can attach images by clicking this area to highlight it and then dragging files in.
-      render: shell
     validations:
       required: false
   - type: checkboxes


### PR DESCRIPTION
The `render: shell`

actually just does a
```
```shell
```
which breaks drag and drop functionality.