### PR TITLE
Add `logs` command to CLI & update forges features docs

### DIFF
--- a/cli/build/build_logs.go
+++ b/cli/build/build_logs.go
@@ -2,8 +2,10 @@ package build
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/woodpecker-ci/woodpecker/cli/common"
+	"github.com/woodpecker-ci/woodpecker/cli/internal"
 
 	"github.com/urfave/cli/v2"
 )
@@ -17,6 +19,35 @@ var buildLogsCmd = &cli.Command{
 }
 
 func buildLogs(c *cli.Context) error {
-	// TODO: add logs command
-	return fmt.Errorf("Command temporarily disabled. See https://github.com/woodpecker-ci/woodpecker/issues/383")
+	repo := c.Args().First()
+	owner, name, err := internal.ParseRepo(repo)
+	if err != nil {
+		return err
+	}
+
+	number, err := strconv.Atoi(c.Args().Get(1))
+	if err != nil {
+		return err
+	}
+
+	job, err := strconv.Atoi(c.Args().Get(2))
+	if err != nil {
+		return err
+	}
+
+	client, err := internal.NewClient(c)
+	if err != nil {
+		return err
+	}
+
+	logs, err := client.BuildLogs(owner, name, number, job)
+	if err != nil {
+		return err
+	}
+
+	for _, log := range logs {
+		fmt.Print(log.Output)
+	}
+
+	return nil
 }

--- a/docs/docs/30-administration/11-forges/10-overview.md
+++ b/docs/docs/30-administration/11-forges/10-overview.md
@@ -10,6 +10,6 @@
 | Event: Deploy | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 | OAuth | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: |
 | [Multi pipeline](/docs/usage/multi-pipeline) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: |
-| [when.path filter](/docs/usage/pipeline-syntax#path) | :white_check_mark: | :white_check_mark:¹ | :white_check_mark: | :x:  | :x: | :x: | :x: |
+| [when.path filter](/docs/usage/pipeline-syntax#path) | :white_check_mark: | :white_check_mark:¹ | :white_check_mark: | :x: | :x: | :x: | :x: |
 
 ¹) [except for pull requests](https://github.com/woodpecker-ci/woodpecker/issues/754)

--- a/docs/docs/30-administration/11-forges/10-overview.md
+++ b/docs/docs/30-administration/11-forges/10-overview.md
@@ -4,12 +4,12 @@
 
 | Feature | [GitHub](github/) | [Gitea](gitea/) | [Gitlab](gitlab/) | [Bitbucket](bitbucket/) | [Bitbucket Server](bitbucket_server/) | [Gogs](gogs/) | [Coding](coding/) |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| Event: Push | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Event: Tag | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Event: Pull-Request | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Event: Deploy | :white_check_mark: | :x: | :x: |
-| OAuth | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Event: Push | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Event: Tag | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: |
+| Event: Pull-Request | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: |
+| Event: Deploy | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
+| OAuth | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: |
 | [Multi pipeline](/docs/usage/multi-pipeline) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: |
-| [when.path filter](/docs/usage/pipeline-syntax#path) | :white_check_mark: | :white_check_mark:¹ | :white_check_mark: | :x: | :x: | :x: | :x: |
+| [when.path filter](/docs/usage/pipeline-syntax#path) | :white_check_mark: | :white_check_mark:¹ | :white_check_mark: | :x:  | :x: | :x: | :x: |
 
 ¹) [except for pull requests](https://github.com/woodpecker-ci/woodpecker/issues/754)

--- a/woodpecker-go/woodpecker/client.go
+++ b/woodpecker-go/woodpecker/client.go
@@ -3,7 +3,6 @@ package woodpecker
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -22,6 +21,7 @@ const (
 	pathRepair         = "%s/api/repos/%s/%s/repair"
 	pathBuilds         = "%s/api/repos/%s/%s/builds"
 	pathBuild          = "%s/api/repos/%s/%s/builds/%v"
+	pathLogs           = "%s/api/repos/%s/%s/logs/%d/%d"
 	pathApprove        = "%s/api/repos/%s/%s/builds/%d/approve"
 	pathDecline        = "%s/api/repos/%s/%s/builds/%d/decline"
 	pathJob            = "%s/api/repos/%s/%s/builds/%d/%d"
@@ -258,8 +258,11 @@ func (c *client) BuildKill(owner, name string, num int) error {
 }
 
 // BuildLogs returns the build logs for the specified job.
-func (c *client) BuildLogs(owner, name string, num, job int) (io.ReadCloser, error) {
-	return nil, errors.New("Method not implemented")
+func (c *client) BuildLogs(owner, name string, num, job int) ([]*Logs, error) {
+	uri := fmt.Sprintf(pathLogs, c.addr, owner, name, num, job)
+	var out []*Logs
+	err := c.get(uri, &out)
+	return out, err
 }
 
 // Deploy triggers a deployment for an existing build using the

--- a/woodpecker-go/woodpecker/interface.go
+++ b/woodpecker-go/woodpecker/interface.go
@@ -88,6 +88,9 @@ type Client interface {
 	// BuildKill force kills the running build.
 	BuildKill(string, string, int) error
 
+	// BuildLogs returns the logs for the given build
+	BuildLogs(string, string, int, int) ([]*Logs, error)
+
 	// Deploy triggers a deployment for an existing build using the specified
 	// target environment.
 	Deploy(string, string, int, string, map[string]string) (*Build, error)

--- a/woodpecker-go/woodpecker/types.go
+++ b/woodpecker-go/woodpecker/types.go
@@ -157,4 +157,10 @@ type (
 	LogLevel struct {
 		Level string `json:"log-level"`
 	}
+
+	// Logs is the JSON data for a logs response
+	Logs struct {
+		Proc   string `json:"proc"`
+		Output string `json:"out"`
+	}
 )


### PR DESCRIPTION
1. complete the forges overview table with missing fields
2. add a `build logs` command to show build logs

Closes https://github.com/woodpecker-ci/woodpecker/issues/383