### PR TITLE
Remove xterm and use ansi converter for logs

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,7 @@
     "@intlify/vite-plugin-vue-i18n": "^3.4.0",
     "@kyvg/vue3-notification": "2.3.4",
     "@meforma/vue-toaster": "1.2.2",
-    "ansi-to-html": "0.7.2",
+    "ansi_up": "^5.1.0",
     "dayjs": "1.10.7",
     "floating-vue": "2.0.0-beta.5",
     "fuse.js": "6.4.6",
@@ -31,10 +31,7 @@
     "pinia": "2.0.0",
     "vue": "v3.2.20",
     "vue-i18n": "9",
-    "vue-router": "4.0.10",
-    "xterm": "4.17.0",
-    "xterm-addon-fit": "0.5.0",
-    "xterm-addon-web-links": "0.5.1"
+    "vue-router": "4.0.10"
   },
   "devDependencies": {
     "@iconify/json": "1.1.421",

--- a/web/src/components/repo/build/BuildLog.vue
+++ b/web/src/components/repo/build/BuildLog.vue
@@ -230,6 +230,7 @@ export default defineComponent({
       log.value = [];
       logBuffer.value = [];
       ansiUp.value = new AnsiUp();
+      ansiUp.value.use_classes = true;
 
       if (!repo) {
         throw new Error('Unexpected: "repo" should be provided at this place');

--- a/web/src/components/repo/build/BuildLog.vue
+++ b/web/src/components/repo/build/BuildLog.vue
@@ -218,7 +218,7 @@ export default defineComponent({
       ansiUp.value = new AnsiUp();
       ansiUp.value.use_classes = true;
       if (timer) {
-        clearTimeout(timer);
+        window.clearTimeout(timer);
       }
 
       if (!repo) {
@@ -256,7 +256,7 @@ export default defineComponent({
       }
 
       if (isProcRunning(proc.value)) {
-        timer = setInterval(() => {
+        timer = window.setInterval(() => {
           if (flush() && autoScroll.value) {
             scrollDown();
           }

--- a/web/src/components/repo/build/BuildLog.vue
+++ b/web/src/components/repo/build/BuildLog.vue
@@ -272,7 +272,7 @@ export default defineComponent({
         const logs = await apiClient.getLogs(repo.value.owner, repo.value.name, build.value.number, proc.value.pid);
         write(
           logs
-            .slice(Math.max(logs.length, 0) - maxLineCount, logs.length) // TODO: think about way to support lazy-loading more than last 300 logs (#776))
+            .slice(Math.max(logs.length, 0) - maxLineCount, logs.length) // TODO: think about way to support lazy-loading more than last 300 logs (#776)
             .map((l) => ({
               line: l.pos,
               text: l.out,

--- a/web/src/style/console.css
+++ b/web/src/style/console.css
@@ -1,0 +1,67 @@
+.ansi-black-fg { color: #374151; }
+.ansi-red-fg { color: #cc0000; }
+.ansi-green-fg { color: #4e9a06; }
+.ansi-yellow-fg { color: #c4a000; }
+.ansi-blue-fg { color: #729fcf; }
+.ansi-magenta-fg { color: #75507b; }
+.ansi-cyan-fg { color: #06989a; }
+.ansi-white-fg { color: #d3d7cf; }
+.ansi-bright-black-fg { color: #555753; }
+.ansi-bright-red-fg { color: #ef2929; }
+.ansi-bright-green-fg { color: #8ae234; }
+.ansi-bright-yellow-fg { color: #fce94f; }
+.ansi-bright-blue-fg { color: #32afff; }
+.ansi-bright-magenta-fg { color: #ad7fa8; }
+.ansi-bright-cyan-fg { color: #34e2e2; }
+.ansi-bright-white-fg { color: #ffffff; }
+
+.ansi-black-bg { background-color: #374151; }
+.ansi-red-bg { background-color: #cc0000; }
+.ansi-green-bg { background-color: #4e9a06; }
+.ansi-yellow-bg { background-color: #c4a000; }
+.ansi-blue-bg { background-color: #729fcf; }
+.ansi-magenta-bg { background-color: #75507b; }
+.ansi-cyan-bg { background-color: #06989a; }
+.ansi-white-bg { background-color: #d3d7cf; }
+.ansi-bright-black-bg { background-color: #555753; }
+.ansi-bright-red-bg { background-color: #ef2929; }
+.ansi-bright-green-bg { background-color: #8ae234; }
+.ansi-bright-yellow-bg { background-color: #fce94f; }
+.ansi-bright-blue-bg { background-color: #32afff; }
+.ansi-bright-magenta-bg { background-color: #ad7fa8; }
+.ansi-bright-cyan-bg { background-color: #34e2e2; }
+.ansi-bright-white-bg { background-color: #ffffff; }
+
+.dark .ansi-black-fg { color: #666666; }
+.dark .ansi-red-fg { color: #ff7070; }
+.dark .ansi-green-fg { color: #b0f986; }
+.dark .ansi-yellow-fg { color: #c6c502; }
+.dark .ansi-blue-fg { color: #8db7e0; }
+.dark .ansi-magenta-fg { color: #f271fb; }
+.dark .ansi-cyan-fg { color: #6bf7ff; }
+.dark .ansi-white-fg { color: #9ca3af; }
+.dark .ansi-bright-black-fg { color: #838887; }
+.dark .ansi-bright-red-fg { color: #ff3333; }
+.dark .ansi-bright-green-fg { color: #00ff00; }
+.dark .ansi-bright-yellow-fg { color: #fffc67; }
+.dark .ansi-bright-blue-fg { color: #6871ff; }
+.dark .ansi-bright-magenta-fg { color: #ff76ff; }
+.dark .ansi-bright-cyan-fg { color: #60fcff; }
+.dark .ansi-bright-white-fg { color: #e6e3e3; }
+
+.dark .ansi-black-bg { background-color: #666666; }
+.dark .ansi-red-bg { background-color: #ff7070; }
+.dark .ansi-green-bg { background-color: #b0f986; }
+.dark .ansi-yellow-bg { background-color: #c6c502; }
+.dark .ansi-blue-bg { background-color: #8db7e0; }
+.dark .ansi-magenta-bg { background-color: #f271fb; }
+.dark .ansi-cyan-bg { background-color: #6bf7ff; }
+.dark .ansi-white-bg { background-color: #9ca3af; }
+.dark .ansi-bright-black-bg { background-color: #838887; }
+.dark .ansi-bright-red-bg { background-color: #ff3333; }
+.dark .ansi-bright-green-bg { background-color: #00ff00; }
+.dark .ansi-bright-yellow-bg { background-color: #fffc67; }
+.dark .ansi-bright-blue-bg { background-color: #6871ff; }
+.dark .ansi-bright-magenta-bg { background-color: #ff76ff; }
+.dark .ansi-bright-cyan-bg { background-color: #60fcff; }
+.dark .ansi-bright-white-bg { background-color: #e6e3e3; }

--- a/web/src/style/console.css
+++ b/web/src/style/console.css
@@ -1,67 +1,195 @@
-.ansi-black-fg { color: #374151; }
-.ansi-red-fg { color: #cc0000; }
-.ansi-green-fg { color: #4e9a06; }
-.ansi-yellow-fg { color: #c4a000; }
-.ansi-blue-fg { color: #729fcf; }
-.ansi-magenta-fg { color: #75507b; }
-.ansi-cyan-fg { color: #06989a; }
-.ansi-white-fg { color: #d3d7cf; }
-.ansi-bright-black-fg { color: #555753; }
-.ansi-bright-red-fg { color: #ef2929; }
-.ansi-bright-green-fg { color: #8ae234; }
-.ansi-bright-yellow-fg { color: #fce94f; }
-.ansi-bright-blue-fg { color: #32afff; }
-.ansi-bright-magenta-fg { color: #ad7fa8; }
-.ansi-bright-cyan-fg { color: #34e2e2; }
-.ansi-bright-white-fg { color: #ffffff; }
+.ansi-black-fg {
+  color: #374151;
+}
+.ansi-red-fg {
+  color: #cc0000;
+}
+.ansi-green-fg {
+  color: #4e9a06;
+}
+.ansi-yellow-fg {
+  color: #c4a000;
+}
+.ansi-blue-fg {
+  color: #729fcf;
+}
+.ansi-magenta-fg {
+  color: #75507b;
+}
+.ansi-cyan-fg {
+  color: #06989a;
+}
+.ansi-white-fg {
+  color: #d3d7cf;
+}
+.ansi-bright-black-fg {
+  color: #555753;
+}
+.ansi-bright-red-fg {
+  color: #ef2929;
+}
+.ansi-bright-green-fg {
+  color: #8ae234;
+}
+.ansi-bright-yellow-fg {
+  color: #fce94f;
+}
+.ansi-bright-blue-fg {
+  color: #32afff;
+}
+.ansi-bright-magenta-fg {
+  color: #ad7fa8;
+}
+.ansi-bright-cyan-fg {
+  color: #34e2e2;
+}
+.ansi-bright-white-fg {
+  color: #ffffff;
+}
 
-.ansi-black-bg { background-color: #374151; }
-.ansi-red-bg { background-color: #cc0000; }
-.ansi-green-bg { background-color: #4e9a06; }
-.ansi-yellow-bg { background-color: #c4a000; }
-.ansi-blue-bg { background-color: #729fcf; }
-.ansi-magenta-bg { background-color: #75507b; }
-.ansi-cyan-bg { background-color: #06989a; }
-.ansi-white-bg { background-color: #d3d7cf; }
-.ansi-bright-black-bg { background-color: #555753; }
-.ansi-bright-red-bg { background-color: #ef2929; }
-.ansi-bright-green-bg { background-color: #8ae234; }
-.ansi-bright-yellow-bg { background-color: #fce94f; }
-.ansi-bright-blue-bg { background-color: #32afff; }
-.ansi-bright-magenta-bg { background-color: #ad7fa8; }
-.ansi-bright-cyan-bg { background-color: #34e2e2; }
-.ansi-bright-white-bg { background-color: #ffffff; }
+.ansi-black-bg {
+  background-color: #374151;
+}
+.ansi-red-bg {
+  background-color: #cc0000;
+}
+.ansi-green-bg {
+  background-color: #4e9a06;
+}
+.ansi-yellow-bg {
+  background-color: #c4a000;
+}
+.ansi-blue-bg {
+  background-color: #729fcf;
+}
+.ansi-magenta-bg {
+  background-color: #75507b;
+}
+.ansi-cyan-bg {
+  background-color: #06989a;
+}
+.ansi-white-bg {
+  background-color: #d3d7cf;
+}
+.ansi-bright-black-bg {
+  background-color: #555753;
+}
+.ansi-bright-red-bg {
+  background-color: #ef2929;
+}
+.ansi-bright-green-bg {
+  background-color: #8ae234;
+}
+.ansi-bright-yellow-bg {
+  background-color: #fce94f;
+}
+.ansi-bright-blue-bg {
+  background-color: #32afff;
+}
+.ansi-bright-magenta-bg {
+  background-color: #ad7fa8;
+}
+.ansi-bright-cyan-bg {
+  background-color: #34e2e2;
+}
+.ansi-bright-white-bg {
+  background-color: #ffffff;
+}
 
-.dark .ansi-black-fg { color: #666666; }
-.dark .ansi-red-fg { color: #ff7070; }
-.dark .ansi-green-fg { color: #b0f986; }
-.dark .ansi-yellow-fg { color: #c6c502; }
-.dark .ansi-blue-fg { color: #8db7e0; }
-.dark .ansi-magenta-fg { color: #f271fb; }
-.dark .ansi-cyan-fg { color: #6bf7ff; }
-.dark .ansi-white-fg { color: #9ca3af; }
-.dark .ansi-bright-black-fg { color: #838887; }
-.dark .ansi-bright-red-fg { color: #ff3333; }
-.dark .ansi-bright-green-fg { color: #00ff00; }
-.dark .ansi-bright-yellow-fg { color: #fffc67; }
-.dark .ansi-bright-blue-fg { color: #6871ff; }
-.dark .ansi-bright-magenta-fg { color: #ff76ff; }
-.dark .ansi-bright-cyan-fg { color: #60fcff; }
-.dark .ansi-bright-white-fg { color: #e6e3e3; }
+.dark .ansi-black-fg {
+  color: #666666;
+}
+.dark .ansi-red-fg {
+  color: #ff7070;
+}
+.dark .ansi-green-fg {
+  color: #b0f986;
+}
+.dark .ansi-yellow-fg {
+  color: #c6c502;
+}
+.dark .ansi-blue-fg {
+  color: #8db7e0;
+}
+.dark .ansi-magenta-fg {
+  color: #f271fb;
+}
+.dark .ansi-cyan-fg {
+  color: #6bf7ff;
+}
+.dark .ansi-white-fg {
+  color: #9ca3af;
+}
+.dark .ansi-bright-black-fg {
+  color: #838887;
+}
+.dark .ansi-bright-red-fg {
+  color: #ff3333;
+}
+.dark .ansi-bright-green-fg {
+  color: #00ff00;
+}
+.dark .ansi-bright-yellow-fg {
+  color: #fffc67;
+}
+.dark .ansi-bright-blue-fg {
+  color: #6871ff;
+}
+.dark .ansi-bright-magenta-fg {
+  color: #ff76ff;
+}
+.dark .ansi-bright-cyan-fg {
+  color: #60fcff;
+}
+.dark .ansi-bright-white-fg {
+  color: #e6e3e3;
+}
 
-.dark .ansi-black-bg { background-color: #666666; }
-.dark .ansi-red-bg { background-color: #ff7070; }
-.dark .ansi-green-bg { background-color: #b0f986; }
-.dark .ansi-yellow-bg { background-color: #c6c502; }
-.dark .ansi-blue-bg { background-color: #8db7e0; }
-.dark .ansi-magenta-bg { background-color: #f271fb; }
-.dark .ansi-cyan-bg { background-color: #6bf7ff; }
-.dark .ansi-white-bg { background-color: #9ca3af; }
-.dark .ansi-bright-black-bg { background-color: #838887; }
-.dark .ansi-bright-red-bg { background-color: #ff3333; }
-.dark .ansi-bright-green-bg { background-color: #00ff00; }
-.dark .ansi-bright-yellow-bg { background-color: #fffc67; }
-.dark .ansi-bright-blue-bg { background-color: #6871ff; }
-.dark .ansi-bright-magenta-bg { background-color: #ff76ff; }
-.dark .ansi-bright-cyan-bg { background-color: #60fcff; }
-.dark .ansi-bright-white-bg { background-color: #e6e3e3; }
+.dark .ansi-black-bg {
+  background-color: #666666;
+}
+.dark .ansi-red-bg {
+  background-color: #ff7070;
+}
+.dark .ansi-green-bg {
+  background-color: #b0f986;
+}
+.dark .ansi-yellow-bg {
+  background-color: #c6c502;
+}
+.dark .ansi-blue-bg {
+  background-color: #8db7e0;
+}
+.dark .ansi-magenta-bg {
+  background-color: #f271fb;
+}
+.dark .ansi-cyan-bg {
+  background-color: #6bf7ff;
+}
+.dark .ansi-white-bg {
+  background-color: #9ca3af;
+}
+.dark .ansi-bright-black-bg {
+  background-color: #838887;
+}
+.dark .ansi-bright-red-bg {
+  background-color: #ff3333;
+}
+.dark .ansi-bright-green-bg {
+  background-color: #00ff00;
+}
+.dark .ansi-bright-yellow-bg {
+  background-color: #fffc67;
+}
+.dark .ansi-bright-blue-bg {
+  background-color: #6871ff;
+}
+.dark .ansi-bright-magenta-bg {
+  background-color: #ff76ff;
+}
+.dark .ansi-bright-cyan-bg {
+  background-color: #60fcff;
+}
+.dark .ansi-bright-white-bg {
+  background-color: #e6e3e3;
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -677,12 +677,10 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-to-html@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.7.2.tgz#a92c149e4184b571eb29a0135ca001a8e2d710cb"
-  integrity sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==
-  dependencies:
-    entities "^2.2.0"
+ansi_up@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ansi_up/-/ansi_up-5.1.0.tgz#9cf10e6d359bb434bdcfab5ae4c3abfe1617b6db"
+  integrity sha512-3wwu+nJCKBVBwOCurm0uv91lMoVkhFB+3qZQz3U11AmAdDJ4tkw1sNPWJQcVxMVYwe0pGEALOjSBOxdxNc+pNQ==
 
 anymatch@~3.1.2:
   version "3.1.2"
@@ -1097,7 +1095,7 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
-entities@^2.0.0, entities@^2.2.0:
+entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
@@ -3241,21 +3239,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
-
-xterm-addon-fit@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"
-  integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
-
-xterm-addon-web-links@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.5.1.tgz#73bfa3ed567af98fba947f638bd12093ee2a0bc6"
-  integrity sha512-dBjbOIrCNmxAcUQkkSrKj9BM6yLpmqUpZ9SOCUuZe/sznPl4d8OBZQClK7VcdZ0vf0+5i5Fce2rUUrew/XTZTg==
-
-xterm@4.17.0:
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.17.0.tgz#e48ba6eeb83e118ec163f5512c3cfe9dbbf3f838"
-  integrity sha512-WGXlIHvLvZKtwMdFaL6kUwp+c9abd2Pcakp/GmuefBuOtGCu9fP9tBDPKyL/A17N+5tt44EYk3YsBbvkPBubMw==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
* Steaming works without flickering
* Text can be correctly copied
* Show only selected step output when streaming
* Improved exit code colors for better readability
* Adds time display on right side

When compiled assets/Build.js size was 355K, now it is 26K

Fixes #1012 
Fixes #998

Screenshots:

![attels](https://user-images.githubusercontent.com/165205/182637643-5e4fa1d6-d119-4c72-addc-77200d5fc7ac.png)

![attels](https://user-images.githubusercontent.com/165205/182637821-4779e67e-e107-4101-a64c-d14b4b503c94.png)
