### PR TITLE
Fix GitLab duplicate pipelines (#618)

### DIFF
--- a/server/remote/gitlab/gitlab.go
+++ b/server/remote/gitlab/gitlab.go
@@ -362,7 +362,6 @@ func (g *Gitlab) Status(ctx context.Context, user *model.User, repo *model.Repo,
 		Description: gitlab.String(common.GetBuildStatusDescription(proc.State)),
 		TargetURL:   gitlab.String(common.GetBuildStatusLink(repo, build, proc)),
 		Context:     gitlab.String(common.GetBuildStatusContext(repo, build, proc)),
-		PipelineID:  gitlab.Int(int(build.Number)),
 	}, gitlab.WithContext(ctx))
 
 	return err


### PR DESCRIPTION
PipelineID is a GitLab internal ID not related to Woodpecker's build numbers. Posting a status with an wrong ID, creates a new pipeline object in GitLab.

It's not a mandatory field and it should be retrieved first through the commit status list API if we were to use it.

Since It doesn't seem to be useful in Woodpecker's case, I've simply removed it. Repo ref (commit sha) and context are enough to update pipeline statuses.

closes #618