### PR TITLE
Make it clear that MariaDB is also a supported DB

### DIFF
--- a/docs/docs/30-administration/30-database.md
+++ b/docs/docs/30-administration/30-database.md
@@ -1,6 +1,6 @@
 # Databases
 
-The default database engine of Woodpecker is an embedded SQLite database which requires zero installation or configuration. But you can replace it with a MySQL or Postgres database.
+The default database engine of Woodpecker is an embedded SQLite database which requires zero installation or configuration. But you can replace it with a MySQL/MariaDB or Postgres database.
 
 ## Configure sqlite
 
@@ -17,7 +17,7 @@ services:
 +     - woodpecker-server-data:/var/lib/woodpecker/
 ```
 
-## Configure MySQL
+## Configure MySQL/MariaDB
 
 The below example demonstrates mysql database configuration. See the official driver [documentation](https://github.com/go-sql-driver/mysql#dsn-data-source-name) for configuration options and examples.
 


### PR DESCRIPTION
As discussed on matrix, since MySQL and MariaDB are now different and diverging projects (and since MariaDB is now the [default](https://mariadb.com/kb/en/distributions-which-include-mariadb/) relational DB on lots of Linux distribution), it's important to make it clear that it is supported by woodpecker.