### PR TITLE
Add dependency security check using trivy

### DIFF
--- a/.woodpecker/docs.yml
+++ b/.woodpecker/docs.yml
@@ -15,6 +15,14 @@ pipeline:
       event: [push, pull_request]
       path: *when_path
 
+  securitycheck:
+    image: aquasec/trivy:latest
+    commands:
+      - trivy fs --exit-code 0 --skip-dirs docs/node_modules --severity UNKNOWN,LOW docs/
+      - trivy fs --exit-code 1 --skip-dirs docs/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
+    when:
+      path: *when_path
+
   deploy-preview:
     image: woodpeckerci/plugin-surge-preview:next
     settings:

--- a/.woodpecker/docs.yml
+++ b/.woodpecker/docs.yml
@@ -18,8 +18,8 @@ pipeline:
   securitycheck:
     image: aquasec/trivy:latest
     commands:
-      - trivy fs --exit-code 0 --skip-dirs docs/node_modules --skip-dirs docs/plugins/woodpecker-plugins/node_modules --severity UNKNOWN,LOW docs/
-      - trivy fs --exit-code 1 --skip-dirs docs/node_modules --skip-dirs docs/plugins/woodpecker-plugins/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
+      - trivy fs --exit-code 0 --skip-dirs node_modules/ --skip-dirs plugins/woodpecker-plugins/node_modules --severity UNKNOWN,LOW docs/
+      - trivy fs --exit-code 1 --skip-dirs node_modules/ --skip-dirs plugins/woodpecker-plugins/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
     when:
       path: *when_path
 

--- a/.woodpecker/docs.yml
+++ b/.woodpecker/docs.yml
@@ -18,6 +18,7 @@ pipeline:
   securitycheck:
     image: aquasec/trivy:latest
     commands:
+      # TODO: solve issue at docs/plugins/woodpecker-plugins and remove skip
       - trivy fs --exit-code 0 --skip-dirs docs/node_modules --skip-dirs docs/plugins/woodpecker-plugins/node_modules --severity UNKNOWN,LOW docs/
       - trivy fs --exit-code 1 --skip-dirs docs/node_modules --skip-dirs docs/plugins/woodpecker-plugins/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
     when:

--- a/.woodpecker/docs.yml
+++ b/.woodpecker/docs.yml
@@ -18,8 +18,8 @@ pipeline:
   securitycheck:
     image: aquasec/trivy:latest
     commands:
-      - trivy fs --exit-code 0 --skip-dirs docs/node_modules --severity UNKNOWN,LOW docs/
-      - trivy fs --exit-code 1 --skip-dirs docs/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
+      - trivy fs --exit-code 0 --skip-dirs docs/node_modules --skip-dirs docs/plugins/woodpecker-plugins/node_modules --severity UNKNOWN,LOW docs/
+      - trivy fs --exit-code 1 --skip-dirs docs/node_modules --skip-dirs docs/plugins/woodpecker-plugins/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
     when:
       path: *when_path
 

--- a/.woodpecker/docs.yml
+++ b/.woodpecker/docs.yml
@@ -18,7 +18,6 @@ pipeline:
   securitycheck:
     image: aquasec/trivy:latest
     commands:
-      # TODO: solve issue at docs/plugins/woodpecker-plugins and remove skip
       - trivy fs --exit-code 0 --skip-dirs docs/node_modules --skip-dirs docs/plugins/woodpecker-plugins/node_modules --severity UNKNOWN,LOW docs/
       - trivy fs --exit-code 1 --skip-dirs docs/node_modules --skip-dirs docs/plugins/woodpecker-plugins/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
     when:

--- a/.woodpecker/docs.yml
+++ b/.woodpecker/docs.yml
@@ -19,7 +19,8 @@ pipeline:
     image: aquasec/trivy:latest
     commands:
       - trivy fs --exit-code 0 --skip-dirs node_modules/ --skip-dirs plugins/woodpecker-plugins/node_modules --severity UNKNOWN,LOW docs/
-      - trivy fs --exit-code 1 --skip-dirs node_modules/ --skip-dirs plugins/woodpecker-plugins/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
+      # TODO currently it is not fixable so just do not block currently
+      - trivy fs --exit-code 0 --skip-dirs node_modules/ --skip-dirs plugins/woodpecker-plugins/node_modules --severity MEDIUM,HIGH,CRITICAL docs/
     when:
       path: *when_path
 

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -54,8 +54,8 @@ pipeline:
     group: test
     image: aquasec/trivy:latest
     commands:
-      - trivy fs --exit-code 0 --skip-dirs web/ --severity UNKNOWN,LOW .
-      - trivy fs --exit-code 1 --skip-dirs web/ --severity MEDIUM,HIGH,CRITICAL .
+      - trivy fs --exit-code 0 --skip-dirs web/ --skip-dirs docs/ --severity UNKNOWN,LOW .
+      - trivy fs --exit-code 1 --skip-dirs web/ --skip-dirs docs/ --severity MEDIUM,HIGH,CRITICAL .
     when:
       path: *when_path
 

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -50,6 +50,15 @@ pipeline:
     image: mstruebing/editorconfig-checker
     group: test
 
+  securitycheck:
+    group: test
+    image: aquasec/trivy:latest
+    commands:
+      - trivy fs --exit-code 0 --skip-dirs web/ --severity UNKNOWN,LOW .
+      - trivy fs --exit-code 1 --skip-dirs web/ --severity MEDIUM,HIGH,CRITICAL .
+    when:
+      path: *when_path
+
   test:
     image: *golang_image
     group: test

--- a/.woodpecker/web.yml
+++ b/.woodpecker/web.yml
@@ -40,6 +40,15 @@ pipeline:
     when:
       path: *when_path
 
+  securitycheck:
+    group: test
+    image: aquasec/trivy:latest
+    commands:
+      - trivy fs --exit-code 0 --skip-dirs web/node_modules --severity UNKNOWN,LOW web/
+      - trivy fs --exit-code 1 --skip-dirs web/node_modules --severity MEDIUM,HIGH,CRITICAL web/
+    when:
+      path: *when_path
+
   test:
     group: test
     image: *node_image

--- a/.woodpecker/web.yml
+++ b/.woodpecker/web.yml
@@ -44,8 +44,8 @@ pipeline:
     group: test
     image: aquasec/trivy:latest
     commands:
-      - trivy fs --exit-code 0 --skip-dirs web/node_modules --severity UNKNOWN,LOW web/
-      - trivy fs --exit-code 1 --skip-dirs web/node_modules --severity MEDIUM,HIGH,CRITICAL web/
+      - trivy fs --exit-code 0 --skip-dirs node_modules/ --severity UNKNOWN,LOW web/
+      - trivy fs --exit-code 1 --skip-dirs node_modules/ --severity MEDIUM,HIGH,CRITICAL web/
     when:
       path: *when_path
 

--- a/.woodpecker/web.yml
+++ b/.woodpecker/web.yml
@@ -1,6 +1,8 @@
 variables:
   - &node_image 'node:16-alpine'
   - &when_path
+      # related config files
+      - ".woodpecker/web.yml"
       # web source code
       - "web/**"
 


### PR DESCRIPTION
Fixes #899

This could be also done for docker image security check but that would probably require building docker image to tar file so I did not add that in this PR.

I usually do this with such steps:

```yaml
  docker-dryrun:
    image: thegeeklab/drone-docker-buildx:20
    settings:
      registry: xxx
      username:
        from_secret: docker_username
      password:
        from_secret: docker_password
      repo: xxx/${CI_REPO_OWNER}/${CI_REPO_NAME}
      tags: test
      dry_run: true
      output: type=oci,dest=${CI_REPO_OWNER}-${CI_REPO_NAME}.tar
    when:
      event:
      - pull_request

  docker-image-security-check:
    image: aquasec/trivy:latest
    commands:
      - trivy image --exit-code 0 --severity UNKNOWN,LOW --input ${CI_REPO_OWNER}-${CI_REPO_NAME}.tar
      - trivy image --exit-code 1 --severity MEDIUM,HIGH,CRITICAL --input ${CI_REPO_OWNER}-${CI_REPO_NAME}.tar
    when:
      event:
        - pull_request
```