### PR TITLE
[Bitbucket] Use workspaces instead of deprecated/removed teams path

### DIFF
--- a/server/remote/bitbucket/bitbucket.go
+++ b/server/remote/bitbucket/bitbucket.go
@@ -130,15 +130,15 @@ func (c *config) Refresh(ctx context.Context, user *model.User) (bool, error) {
 
 // Teams returns a list of all team membership for the Bitbucket account.
 func (c *config) Teams(ctx context.Context, u *model.User) ([]*model.Team, error) {
-	opts := &internal.ListTeamOpts{
+	opts := &internal.ListWorkspacesOpts{
 		PageLen: 100,
 		Role:    "member",
 	}
-	resp, err := c.newClient(ctx, u).ListTeams(opts)
+	resp, err := c.newClient(ctx, u).ListWorkspaces(opts)
 	if err != nil {
 		return nil, err
 	}
-	return convertTeamList(resp.Values), nil
+	return convertWorkspaceList(resp.Values), nil
 }
 
 // Repo returns the named Bitbucket repository.
@@ -160,20 +160,16 @@ func (c *config) Repos(ctx context.Context, u *model.User) ([]*model.Repo, error
 
 	var all []*model.Repo
 
-	accounts := []string{u.Login}
-	resp, err := client.ListTeams(&internal.ListTeamOpts{
+	resp, err := client.ListWorkspaces(&internal.ListWorkspacesOpts{
 		PageLen: 100,
 		Role:    "member",
 	})
 	if err != nil {
 		return all, err
 	}
-	for _, team := range resp.Values {
-		accounts = append(accounts, team.Login)
-	}
 
-	for _, account := range accounts {
-		repos, err := client.ListReposAll(account)
+	for _, workspace := range resp.Values {
+		repos, err := client.ListReposAll(workspace.Slug)
 		if err != nil {
 			return all, err
 		}

--- a/server/remote/bitbucket/bitbucket_test.go
+++ b/server/remote/bitbucket/bitbucket_test.go
@@ -184,8 +184,8 @@ func Test_bitbucket(t *testing.T) {
 			g.It("Should return the details", func() {
 				teams, err := c.Teams(ctx, fakeUser)
 				g.Assert(err).IsNil()
-				g.Assert(teams[0].Login).Equal("superfriends")
-				g.Assert(teams[0].Avatar).Equal("http://i.imgur.com/ZygP55A.jpg")
+				g.Assert(teams[0].Login).Equal("ueberdev42")
+				g.Assert(teams[0].Avatar).Equal("https://bitbucket.org/workspaces/ueberdev42/avatar/?ts=1658761964")
 			})
 			g.It("Should handle not found error", func() {
 				_, err := c.Teams(ctx, fakeUserNoTeams)

--- a/server/remote/bitbucket/bitbucket_test.go
+++ b/server/remote/bitbucket/bitbucket_test.go
@@ -264,9 +264,10 @@ func Test_bitbucket(t *testing.T) {
 			req.Header = http.Header{}
 			req.Header.Set(hookEvent, hookPush)
 
-			r, _, err := c.Hook(ctx, req)
+			r, b, err := c.Hook(ctx, req)
 			g.Assert(err).IsNil()
-			g.Assert(r.FullName).Equal("user_name/repo_name")
+			g.Assert(r.FullName).Equal("martinherren1984/publictestrepo")
+			g.Assert(b.Commit).Equal("c14c1bb05dfb1fdcdf06b31485fff61b0ea44277")
 		})
 	})
 }

--- a/server/remote/bitbucket/convert.go
+++ b/server/remote/bitbucket/convert.go
@@ -111,19 +111,19 @@ func convertUser(from *internal.Account, token *oauth2.Token) *model.User {
 
 // convertTeamList is a helper function used to convert a Bitbucket team list
 // structure to the Woodpecker Team structure.
-func convertTeamList(from []*internal.Account) []*model.Team {
+func convertWorkspaceList(from []*internal.Workspace) []*model.Team {
 	var teams []*model.Team
-	for _, team := range from {
-		teams = append(teams, convertTeam(team))
+	for _, workspace := range from {
+		teams = append(teams, convertWorkspace(workspace))
 	}
 	return teams
 }
 
 // convertTeam is a helper function used to convert a Bitbucket team account
 // structure to the Woodpecker Team structure.
-func convertTeam(from *internal.Account) *model.Team {
+func convertWorkspace(from *internal.Workspace) *model.Team {
 	return &model.Team{
-		Login:  from.Login,
+		Login:  from.Slug,
 		Avatar: from.Links.Avatar.Href,
 	}
 }

--- a/server/remote/bitbucket/convert_test.go
+++ b/server/remote/bitbucket/convert_test.go
@@ -65,19 +65,19 @@ func Test_helper(t *testing.T) {
 		})
 
 		g.It("should convert team", func() {
-			from := &internal.Account{Login: "octocat"}
+			from := &internal.Workspace{Slug: "octocat"}
 			from.Links.Avatar.Href = "http://..."
-			to := convertTeam(from)
+			to := convertWorkspace(from)
 			g.Assert(to.Avatar).Equal(from.Links.Avatar.Href)
-			g.Assert(to.Login).Equal(from.Login)
+			g.Assert(to.Login).Equal(from.Slug)
 		})
 
 		g.It("should convert team list", func() {
-			from := &internal.Account{Login: "octocat"}
+			from := &internal.Workspace{Slug: "octocat"}
 			from.Links.Avatar.Href = "http://..."
-			to := convertTeamList([]*internal.Account{from})
+			to := convertWorkspaceList([]*internal.Workspace{from})
 			g.Assert(to[0].Avatar).Equal(from.Links.Avatar.Href)
-			g.Assert(to[0].Login).Equal(from.Login)
+			g.Assert(to[0].Login).Equal(from.Slug)
 		})
 
 		g.It("should convert user", func() {

--- a/server/remote/bitbucket/fixtures/handler.go
+++ b/server/remote/bitbucket/fixtures/handler.go
@@ -27,8 +27,8 @@ func Handler() http.Handler {
 	gin.SetMode(gin.TestMode)
 
 	e := gin.New()
-	e.GET("/2.0/workspaces/", getWorkspace)
 	e.POST("/site/oauth2/access_token", getOauth)
+	e.GET("/2.0/workspaces/", getWorkspaces)
 	e.GET("/2.0/repositories/:owner/:name", getRepo)
 	e.GET("/2.0/repositories/:owner/:name/hooks", getRepoHooks)
 	e.GET("/2.0/repositories/:owner/:name/src/:commit/:file", getRepoFile)
@@ -36,16 +36,10 @@ func Handler() http.Handler {
 	e.POST("/2.0/repositories/:owner/:name/hooks", createRepoHook)
 	e.POST("/2.0/repositories/:owner/:name/commit/:commit/statuses/build", createRepoStatus)
 	e.GET("/2.0/repositories/:owner", getUserRepos)
-	e.GET("/2.0/teams/", getUserTeams)
 	e.GET("/2.0/user/", getUser)
 	e.GET("/2.0/user/permissions/repositories", getPermissions)
 
 	return e
-}
-
-func getWorkspace(c *gin.Context) {
-	// role, _ := c.Params.Get("role")
-	// TODO: add dummy response for get workplace
 }
 
 func getOauth(c *gin.Context) {
@@ -71,6 +65,18 @@ func getOauth(c *gin.Context) {
 	default:
 		c.Header("Content-Type", "application/json")
 		c.String(200, tokenPayload)
+	}
+}
+
+func getWorkspaces(c *gin.Context) {
+	// TODO: should the role be used ?
+	// role, _ := c.Params.Get("role")
+
+	switch c.Request.Header.Get("Authorization") {
+	case "Bearer teams_not_found", "Bearer c81e728d":
+		c.String(404, "")
+	default:
+		c.String(200, workspacesPayload)
 	}
 }
 
@@ -133,15 +139,6 @@ func getUser(c *gin.Context) {
 		c.String(404, "")
 	default:
 		c.String(200, userPayload)
-	}
-}
-
-func getUserTeams(c *gin.Context) {
-	switch c.Request.Header.Get("Authorization") {
-	case "Bearer teams_not_found", "Bearer c81e728d":
-		c.String(404, "")
-	default:
-		c.String(200, userTeamPayload)
 	}
 }
 
@@ -254,18 +251,28 @@ const userRepoPayload = `
 }
 `
 
-const userTeamPayload = `
+const workspacesPayload = `
 {
+	"page": 1,
   "pagelen": 100,
+	"size": 1,
   "values": [
     {
-      "username": "superfriends",
+			"type": "workspace",
+			"uuid": "{c7a04a76-fa20-43e4-dc42-a7506db4c95b}",
+			"name": "Ueber Dev",
+			"slug": "ueberdev42",
       "links": {
-        "avatar": {
-          "href": "http:\/\/i.imgur.com\/ZygP55A.jpg"
-        }
-      },
-      "type": "team"
+				"avatar": {
+				  "href": "https://bitbucket.org/workspaces/ueberdev42/avatar/?ts=1658761964"
+			  },
+			  "html": {
+				  "href": "https://bitbucket.org/ueberdev42/"
+			  },
+			  "self": {
+				  "href": "https://api.bitbucket.org/2.0/workspaces/ueberdev42"
+			  }
+      }
     }
   ]
 }

--- a/server/remote/bitbucket/fixtures/handler.go
+++ b/server/remote/bitbucket/fixtures/handler.go
@@ -27,6 +27,7 @@ func Handler() http.Handler {
 	gin.SetMode(gin.TestMode)
 
 	e := gin.New()
+	e.GET("/2.0/workspaces/", getWorkspace)
 	e.POST("/site/oauth2/access_token", getOauth)
 	e.GET("/2.0/repositories/:owner/:name", getRepo)
 	e.GET("/2.0/repositories/:owner/:name/hooks", getRepoHooks)
@@ -40,6 +41,11 @@ func Handler() http.Handler {
 	e.GET("/2.0/user/permissions/repositories", getPermissions)
 
 	return e
+}
+
+func getWorkspace(c *gin.Context) {
+	// role, _ := c.Params.Get("role")
+	// TODO: add dummy response for get workplace
 }
 
 func getOauth(c *gin.Context) {

--- a/server/remote/bitbucket/fixtures/hooks.go
+++ b/server/remote/bitbucket/fixtures/hooks.go
@@ -1,4 +1,5 @@
 // Copyright 2018 Drone.IO Inc.
+// Copyright 2022 Woodpecker Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/remote/bitbucket/fixtures/hooks.go
+++ b/server/remote/bitbucket/fixtures/hooks.go
@@ -17,48 +17,333 @@ package fixtures
 const HookPush = `
 {
   "actor": {
-    "username": "emmap1",
+    "display_name": "Martin Herren",
     "links": {
-      "avatar": {
-        "href": "https:\/\/bitbucket-api-assetroot.s3.amazonaws.com\/c\/photos\/2015\/Feb\/26\/3613917261-0-emmap1-avatar_avatar.png"
-      }
-    }
-  },
-  "repository": {
-    "links": {
-      "html": {
-        "href": "https:\/\/api.bitbucket.org\/team_name\/repo_name"
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/%7Bc5a0d676-fd27-4bd4-ac69-a7540d7b495b%7D"
       },
       "avatar": {
-        "href": "https:\/\/api-staging-assetroot.s3.amazonaws.com\/c\/photos\/2014\/Aug\/01\/bitbucket-logo-2629490769-3_avatar.png"
+        "href": "https://secure.gravatar.com/avatar/37de364488b2ec474b5458ca86442bbb?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FMH-2.png"
+      },
+      "html": {
+        "href": "https://bitbucket.org/%7Bc5a0d676-fd27-4bd4-ac69-a7540d7b495b%7D/"
       }
     },
-    "full_name": "user_name\/repo_name",
+    "type": "user",
+    "uuid": "{c5a0d676-fd27-4bd4-ac69-a7540d7b495b}",
+    "account_id": "5cf8e3a9678ca90f8e7cc8a8",
+    "nickname": "Martin Herren"
+  },
+  "repository": {
+    "type": "repository",
+    "full_name": "martinherren1984/publictestrepo",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo"
+      },
+      "html": {
+        "href": "https://bitbucket.org/martinherren1984/publictestrepo"
+      },
+      "avatar": {
+        "href": "https://bytebucket.org/ravatar/%7B898477b2-a080-4089-b385-597a783db392%7D?ts=default"
+      }
+    },
+    "name": "PublicTestRepo",
     "scm": "git",
-    "is_private": true
+    "website": null,
+    "owner": {
+      "display_name": "Martin Herren",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/%7Bc5a0d676-fd27-4bd4-ac69-a7540d7b495b%7D"
+        },
+        "avatar": {
+          "href": "https://secure.gravatar.com/avatar/37de364488b2ec474b5458ca86442bbb?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FMH-2.png"
+        },
+        "html": {
+          "href": "https://bitbucket.org/%7Bc5a0d676-fd27-4bd4-ac69-a7540d7b495b%7D/"
+        }
+      },
+      "type": "user",
+      "uuid": "{c5a0d676-fd27-4bd4-ac69-a7540d7b495b}",
+      "account_id": "5cf8e3a9678ca90f8e7cc8a8",
+      "nickname": "Martin Herren"
+    },
+    "workspace": {
+      "type": "workspace",
+      "uuid": "{c5a0d676-fd27-4bd4-ac69-a7540d7b495b}",
+      "name": "Martin Herren",
+      "slug": "martinherren1984",
+      "links": {
+        "avatar": {
+          "href": "https://bitbucket.org/workspaces/martinherren1984/avatar/?ts=1658761964"
+        },
+        "html": {
+          "href": "https://bitbucket.org/martinherren1984/"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/workspaces/martinherren1984"
+        }
+      }
+    },
+    "is_private": false,
+    "project": {
+      "type": "project",
+      "key": "PUB",
+      "uuid": "{2cede481-f59e-49ec-88d0-a85629b7925d}",
+      "name": "PublicTestProject",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/workspaces/martinherren1984/projects/PUB"
+        },
+        "html": {
+          "href": "https://bitbucket.org/martinherren1984/workspace/projects/PUB"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/user/martinherren1984/projects/PUB/avatar/32?ts=1658768453"
+        }
+      }
+    },
+    "uuid": "{898477b2-a080-4089-b385-597a783db392}"
   },
   "push": {
     "changes": [
       {
-        "new": {
-          "type": "branch",
-          "name": "name-of-branch",
+        "old": {
+          "name": "master",
           "target": {
             "type": "commit",
-            "hash": "709d658dc5b6d6afcd46049c2f332ee3f515a67d",
+            "hash": "a51241ae1f00cbe728930db48e890b18fd527f99",
+            "date": "2022-08-17T15:24:29+00:00",
             "author": {
-              "raw": "emmap1 <email@domain.tld>",
-              "username": "emmap1",
-              "links": {
-                "avatar": {
-                  "href": "https:\/\/bitbucket-api-assetroot.s3.amazonaws.com\/c\/photos\/2015\/Feb\/26\/3613917261-0-emmap1-avatar_avatar.png"
-                }
+              "type": "author",
+              "raw": "Martin Herren <martin.herren@xxx.com>",
+              "user": {
+                "display_name": "Martin Herren",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7B69cc59f2-706b-4a9c-b99c-eac2ace320da%7D"
+                  },
+                  "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/7b2e50690b4ab7bb9e1db18ea3b8ae95?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FMH-5.png"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/%7B69cc59f2-706b-4a9c-b99c-eac2ace320da%7D/"
+                  }
+                },
+                "type": "user",
+                "uuid": "{69cc59f2-706b-4a9c-b99c-eac2ace320da}",
+                "account_id": "5d286e857133f10c17e026cb",
+                "nickname": "Martin Herren"
               }
             },
-            "message": "new commit message\n",
-            "date": "2015-06-09T03:34:49+00:00"
+            "message": "Add test .woodpecker.yml\n",
+            "summary": {
+              "type": "rendered",
+              "raw": "Add test .woodpecker.yml\n",
+              "markup": "markdown",
+              "html": "<p>Add test .woodpecker.yml</p>"
+            },
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commit/a51241ae1f00cbe728930db48e890b18fd527f99"
+              },
+              "html": {
+                "href": "https://bitbucket.org/martinherren1984/publictestrepo/commits/a51241ae1f00cbe728930db48e890b18fd527f99"
+              }
+            },
+            "parents": [],
+            "rendered": {},
+            "properties": {}
+          },
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/refs/branches/master"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commits/master"
+            },
+            "html": {
+              "href": "https://bitbucket.org/martinherren1984/publictestrepo/branch/master"
+            }
+          },
+          "type": "branch",
+          "merge_strategies": [
+            "merge_commit",
+            "squash",
+            "fast_forward"
+          ],
+          "default_merge_strategy": "merge_commit"
+        },
+        "new": {
+          "name": "master",
+          "target": {
+            "type": "commit",
+            "hash": "c14c1bb05dfb1fdcdf06b31485fff61b0ea44277",
+            "date": "2022-09-07T20:19:25+00:00",
+            "author": {
+              "type": "author",
+              "raw": "Martin Herren <martin.herren@yyy.com>",
+              "user": {
+                "display_name": "Martin Herren",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7Bc5a0d676-fd27-4bd4-ac69-a7540d7b495b%7D"
+                  },
+                  "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/37de364488b2ec474b5458ca86442bbb?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FMH-2.png"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/%7Bc5a0d676-fd27-4bd4-ac69-a7540d7b495b%7D/"
+                  }
+                },
+                "type": "user",
+                "uuid": "{c5a0d676-fd27-4bd4-ac69-a7540d7b495b}",
+                "account_id": "5cf8e3a9678ca90f8e7cc8a8",
+                "nickname": "Martin Herren"
+              }
+            },
+            "message": "a\n",
+            "summary": {
+              "type": "rendered",
+              "raw": "a\n",
+              "markup": "markdown",
+              "html": "<p>a</p>"
+            },
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commit/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277"
+              },
+              "html": {
+                "href": "https://bitbucket.org/martinherren1984/publictestrepo/commits/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277"
+              }
+            },
+            "parents": [
+              {
+                "type": "commit",
+                "hash": "a51241ae1f00cbe728930db48e890b18fd527f99",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commit/a51241ae1f00cbe728930db48e890b18fd527f99"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/martinherren1984/publictestrepo/commits/a51241ae1f00cbe728930db48e890b18fd527f99"
+                  }
+                }
+              }
+            ],
+            "rendered": {},
+            "properties": {}
+          },
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/refs/branches/master"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commits/master"
+            },
+            "html": {
+              "href": "https://bitbucket.org/martinherren1984/publictestrepo/branch/master"
+            }
+          },
+          "type": "branch",
+          "merge_strategies": [
+            "merge_commit",
+            "squash",
+            "fast_forward"
+          ],
+          "default_merge_strategy": "merge_commit"
+        },
+        "truncated": false,
+        "created": false,
+        "forced": false,
+        "closed": false,
+        "links": {
+          "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commits?include=c14c1bb05dfb1fdcdf06b31485fff61b0ea44277&exclude=a51241ae1f00cbe728930db48e890b18fd527f99"
+          },
+          "diff": {
+            "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/diff/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277..a51241ae1f00cbe728930db48e890b18fd527f99"
+          },
+          "html": {
+            "href": "https://bitbucket.org/martinherren1984/publictestrepo/branches/compare/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277..a51241ae1f00cbe728930db48e890b18fd527f99"
           }
-        }
+        },
+        "commits": [
+          {
+            "type": "commit",
+            "hash": "c14c1bb05dfb1fdcdf06b31485fff61b0ea44277",
+            "date": "2022-09-07T20:19:25+00:00",
+            "author": {
+              "type": "author",
+              "raw": "Martin Herren <martin.herren@yyy.com>",
+              "user": {
+                "display_name": "Martin Herren",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7Bc5a0d676-fd27-4bd4-ac69-a7540d7b495b%7D"
+                  },
+                  "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/37de364488b2ec474b5458ca86442bbb?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FMH-2.png"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/%7Bc5a0d676-fd27-4bd4-ac69-a7540d7b495b%7D/"
+                  }
+                },
+                "type": "user",
+                "uuid": "{c5a0d676-fd27-4bd4-ac69-a7540d7b495b}",
+                "account_id": "5cf8e3a9678ca90f8e7cc8a8",
+                "nickname": "Martin Herren"
+              }
+            },
+            "message": "a\n",
+            "summary": {
+              "type": "rendered",
+              "raw": "a\n",
+              "markup": "markdown",
+              "html": "<p>a</p>"
+            },
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commit/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277"
+              },
+              "html": {
+                "href": "https://bitbucket.org/martinherren1984/publictestrepo/commits/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277"
+              },
+              "diff": {
+                "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/diff/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277"
+              },
+              "approve": {
+                "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commit/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277/approve"
+              },
+              "comments": {
+                "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commit/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277/comments"
+              },
+              "statuses": {
+                "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commit/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277/statuses"
+              },
+              "patch": {
+                "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/patch/c14c1bb05dfb1fdcdf06b31485fff61b0ea44277"
+              }
+            },
+            "parents": [
+              {
+                "type": "commit",
+                "hash": "a51241ae1f00cbe728930db48e890b18fd527f99",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/martinherren1984/publictestrepo/commit/a51241ae1f00cbe728930db48e890b18fd527f99"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/martinherren1984/publictestrepo/commits/a51241ae1f00cbe728930db48e890b18fd527f99"
+                  }
+                }
+              }
+            ],
+            "rendered": {},
+            "properties": {}
+          }
+        ]
       }
     ]
   }

--- a/server/remote/bitbucket/internal/client.go
+++ b/server/remote/bitbucket/internal/client.go
@@ -37,7 +37,7 @@ const (
 	pathUser        = "%s/2.0/user/"
 	pathEmails      = "%s/2.0/user/emails"
 	pathPermissions = "%s/2.0/user/permissions/repositories?q=repository.full_name=%q"
-	pathTeams       = "%s/2.0/teams/?%s"
+	pathWorkspace   = "%s/2.0/workspaces/?%s"
 	pathRepo        = "%s/2.0/repositories/%s/%s"
 	pathRepos       = "%s/2.0/repositories/%s?%s"
 	pathHook        = "%s/2.0/repositories/%s/%s/hooks/%s"
@@ -85,9 +85,9 @@ func (c *Client) ListEmail() (*EmailResp, error) {
 	return out, err
 }
 
-func (c *Client) ListTeams(opts *ListTeamOpts) (*AccountResp, error) {
-	out := new(AccountResp)
-	uri := fmt.Sprintf(pathTeams, c.base, opts.Encode())
+func (c *Client) ListWorkspaces(opts *ListWorkspacesOpts) (*WorkspacesResp, error) {
+	out := new(WorkspacesResp)
+	uri := fmt.Sprintf(pathWorkspace, c.base, opts.Encode())
 	_, err := c.do(uri, get, nil, out)
 	return out, err
 }
@@ -99,19 +99,19 @@ func (c *Client) FindRepo(owner, name string) (*Repo, error) {
 	return out, err
 }
 
-func (c *Client) ListRepos(account string, opts *ListOpts) (*RepoResp, error) {
+func (c *Client) ListRepos(workspace string, opts *ListOpts) (*RepoResp, error) {
 	out := new(RepoResp)
-	uri := fmt.Sprintf(pathRepos, c.base, account, opts.Encode())
+	uri := fmt.Sprintf(pathRepos, c.base, workspace, opts.Encode())
 	_, err := c.do(uri, get, nil, out)
 	return out, err
 }
 
-func (c *Client) ListReposAll(account string) ([]*Repo, error) {
+func (c *Client) ListReposAll(workspace string) ([]*Repo, error) {
 	page := 1
 	var repos []*Repo
 
 	for {
-		resp, err := c.ListRepos(account, &ListOpts{Page: page, PageLen: 100})
+		resp, err := c.ListRepos(workspace, &ListOpts{Page: page, PageLen: 100})
 		if err != nil {
 			return repos, err
 		}

--- a/server/remote/bitbucket/internal/types.go
+++ b/server/remote/bitbucket/internal/types.go
@@ -27,12 +27,20 @@ type Account struct {
 	Links Links  `json:"links"`
 }
 
-type AccountResp struct {
-	Page   int        `json:"page"`
-	Pages  int        `json:"pagelen"`
-	Size   int        `json:"size"`
-	Next   string     `json:"next"`
-	Values []*Account `json:"values"`
+type Workspace struct {
+	UUID  string `json:"uuid"`
+	Slug  string `json:"slug"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Links Links  `json:"links"`
+}
+
+type WorkspacesResp struct {
+	Page   int         `json:"page"`
+	Pages  int         `json:"pagelen"`
+	Size   int         `json:"size"`
+	Next   string      `json:"next"`
+	Values []*Workspace `json:"values"`
 }
 
 type BuildStatus struct {
@@ -201,13 +209,13 @@ func (o *ListOpts) Encode() string {
 	return params.Encode()
 }
 
-type ListTeamOpts struct {
+type ListWorkspacesOpts struct {
 	Page    int
 	PageLen int
 	Role    string
 }
 
-func (o *ListTeamOpts) Encode() string {
+func (o *ListWorkspacesOpts) Encode() string {
 	params := url.Values{}
 	if o.Page != 0 {
 		params.Set("page", strconv.Itoa(o.Page))

--- a/server/remote/bitbucket/internal/types.go
+++ b/server/remote/bitbucket/internal/types.go
@@ -36,10 +36,10 @@ type Workspace struct {
 }
 
 type WorkspacesResp struct {
-	Page   int         `json:"page"`
-	Pages  int         `json:"pagelen"`
-	Size   int         `json:"size"`
-	Next   string      `json:"next"`
+	Page   int          `json:"page"`
+	Pages  int          `json:"pagelen"`
+	Size   int          `json:"size"`
+	Next   string       `json:"next"`
 	Values []*Workspace `json:"values"`
 }
 
@@ -82,6 +82,7 @@ type HookResp struct {
 }
 
 type Links struct {
+	Self   Link   `json:"self"`
 	Avatar Link   `json:"avatar"`
 	HTML   Link   `json:"html"`
 	Clone  []Link `json:"clone"`

--- a/server/remote/bitbucket/parse_test.go
+++ b/server/remote/bitbucket/parse_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/franela/goblin"
 
+	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote/bitbucket/fixtures"
 )
 
@@ -106,8 +107,11 @@ func Test_parser(t *testing.T) {
 
 				r, b, err := parseHook(req)
 				g.Assert(err).IsNil()
-				g.Assert(r.FullName).Equal("user_name/repo_name")
-				g.Assert(b.Commit).Equal("709d658dc5b6d6afcd46049c2f332ee3f515a67d")
+				g.Assert(r.FullName).Equal("martinherren1984/publictestrepo")
+				g.Assert(r.SCMKind).Equal(model.RepoGit)
+				g.Assert(r.Clone).Equal("https://bitbucket.org/martinherren1984/publictestrepo")
+				g.Assert(b.Commit).Equal("c14c1bb05dfb1fdcdf06b31485fff61b0ea44277")
+				g.Assert(b.Message).Equal("a\n")
 			})
 		})
 	})


### PR DESCRIPTION
Crude fix to allow to correctly list workspaces for bitbucket cloud (https://bitbucket.org) and so run a pipeline.
Last year they removed a bunch of deprecated APIs and replaced them with new ones.

User management is still broken (maybe even more with this PR), it doesn't retrieve correct user info like email for example.

Unit tests are not yet aligned with my changes. Will try to fix that.

Got a server running locally connected to bitbucket.org, can privately provide the url if someone needs testing.

Discovered a 'feature' of bitbucket: oauth2 tokens are created at 'workspace' level but are not scoped to a specific workspace, so anyone with a bitbucket.org account can login into woodpecker. This makes it important not to allow user registration, if not possible use filters to allow only the desired workspaces in order to prevent anyone to abuse your server and runners to build their own pipelines.

I also renamed a few functions containing 'Team' to 'Workspace'. I don't know the convention here, if inside a forge you prefer to keep the 'woodpecker terminology' or the 'server specific terminology'. There is no notion of 'Team' in bitbucket cloud. Only workspaces and projects. From what i understood a repo is part of a workspace and can be part of a project. A project only serves to apply some global git settings (like merge strategies) to a group of repos. User management is done at workspace and repo level. Also the git url only contains the workspace and repo.

I'm not a Go developer yet so still learning...

Signed-off-by: Martin Herren <martin.herren@gmail.com>