### PR TITLE
use example.com instead of foo.com

### DIFF
--- a/docs/docs/20-usage/51-plugins/20-sample-plugin.md
+++ b/docs/docs/20-usage/51-plugins/20-sample-plugin.md
@@ -11,7 +11,7 @@ pipeline:
   webhook:
     image: foo/webhook
     settings:
-      url: http://foo.com
+      url: http://example.com
       method: post
       body: |
         hello world
@@ -54,7 +54,7 @@ Execute your plugin locally from the command line to verify it is working:
 ```nohighlight
 docker run --rm \
   -e PLUGIN_METHOD=post \
-  -e PLUGIN_URL=http://foo.com \
+  -e PLUGIN_URL=http://example.com \
   -e PLUGIN_BODY="hello world" \
   foo/webhook
 ```

--- a/docs/docs/30-administration/60-ssl.md
+++ b/docs/docs/30-administration/60-ssl.md
@@ -26,7 +26,7 @@ services:
 +     - WOODPECKER_LETS_ENCRYPT=true
 ```
 
-Note that Woodpecker uses the hostname from the `WOODPECKER_HOST` environment variable when requesting certificates. For example, if `WOODPECKER_HOST=https://foo.com` the certificate is requested for `foo.com`.
+Note that Woodpecker uses the hostname from the `WOODPECKER_HOST` environment variable when requesting certificates. For example, if `WOODPECKER_HOST=https://example.com` the certificate is requested for `example.com`.
 
 >Once enabled you can visit your website at both the http and the https address
 
@@ -58,12 +58,12 @@ services:
 +     - 443:443
       - 9000:9000
     volumes:
-+     - /etc/certs/woodpecker.foo.com/server.crt:/etc/certs/woodpecker.foo.com/server.crt
-+     - /etc/certs/woodpecker.foo.com/server.key:/etc/certs/woodpecker.foo.com/server.key
++     - /etc/certs/woodpecker.example.com/server.crt:/etc/certs/woodpecker.example.com/server.crt
++     - /etc/certs/woodpecker.example.com/server.key:/etc/certs/woodpecker.example.com/server.key
     environment:
       - [...]
-+     - WOODPECKER_SERVER_CERT=/etc/certs/woodpecker.foo.com/server.crt
-+     - WOODPECKER_SERVER_KEY=/etc/certs/woodpecker.foo.com/server.key
++     - WOODPECKER_SERVER_CERT=/etc/certs/woodpecker.example.com/server.crt
++     - WOODPECKER_SERVER_KEY=/etc/certs/woodpecker.example.com/server.key
 ```
 
 Update your configuration to expose the following ports:
@@ -95,8 +95,8 @@ services:
       - 443:443
       - 9000:9000
     volumes:
-+     - /etc/certs/woodpecker.foo.com/server.crt:/etc/certs/woodpecker.foo.com/server.crt
-+     - /etc/certs/woodpecker.foo.com/server.key:/etc/certs/woodpecker.foo.com/server.key
++     - /etc/certs/woodpecker.example.com/server.crt:/etc/certs/woodpecker.example.com/server.crt
++     - /etc/certs/woodpecker.example.com/server.key:/etc/certs/woodpecker.example.com/server.key
 ```
 
 Update your configuration to provide the paths of your certificate and key:
@@ -113,11 +113,11 @@ services:
       - 443:443
       - 9000:9000
     volumes:
-      - /etc/certs/woodpecker.foo.com/server.crt:/etc/certs/woodpecker.foo.com/server.crt
-      - /etc/certs/woodpecker.foo.com/server.key:/etc/certs/woodpecker.foo.com/server.key
+      - /etc/certs/woodpecker.example.com/server.crt:/etc/certs/woodpecker.example.com/server.crt
+      - /etc/certs/woodpecker.example.com/server.key:/etc/certs/woodpecker.example.com/server.key
     environment:
-+     - WOODPECKER_SERVER_CERT=/etc/certs/woodpecker.foo.com/server.crt
-+     - WOODPECKER_SERVER_KEY=/etc/certs/woodpecker.foo.com/server.key
++     - WOODPECKER_SERVER_CERT=/etc/certs/woodpecker.example.com/server.crt
++     - WOODPECKER_SERVER_KEY=/etc/certs/woodpecker.example.com/server.key
 ```
 
 ### Certificate Chain

--- a/pipeline/frontend/yaml/compiler/option_test.go
+++ b/pipeline/frontend/yaml/compiler/option_test.go
@@ -161,7 +161,7 @@ func TestWithProxy(t *testing.T) {
 	}
 
 	// alter the default values
-	noProxy = "foo.com"
+	noProxy = "example.com"
 	httpProxy = "bar.com"
 	httpsProxy = "baz.com"
 

--- a/vendor/github.com/golangci/misspell/url.go
+++ b/vendor/github.com/golangci/misspell/url.go
@@ -11,7 +11,7 @@ import (
 var reURL = regexp.MustCompile(`(?i)(https?|ftp)://(-\.)?([^\s/?\.#]+\.?)+(/[^\s]*)?`)
 
 // StripURL attemps to replace URLs with blank spaces, e.g.
-//  "xxx http://foo.com/ yyy -> "xxx          yyyy"
+//  "xxx http://example.com/ yyy -> "xxx          yyyy"
 func StripURL(s string) string {
 	return reURL.ReplaceAllStringFunc(s, replaceWithBlanks)
 }


### PR DESCRIPTION
http://example.com/ is a reserved domain name, which is perfect for examples, while foo.com is a random domain name