### PR TITLE
 On Repo update, keep old "Clone" if update would empty it (#1170)

### DIFF
--- a/server/model/repo.go
+++ b/server/model/repo.go
@@ -76,7 +76,9 @@ func (r *Repo) Update(from *Repo) {
 	r.Avatar = from.Avatar
 	r.Link = from.Link
 	r.SCMKind = from.SCMKind
-	r.Clone = from.Clone
+	if len(from.Clone) > 0 {
+		r.Clone = from.Clone
+	}
 	r.Branch = from.Branch
 	if from.IsSCMPrivate != r.IsSCMPrivate {
 		if from.IsSCMPrivate {


### PR DESCRIPTION
fixed #1169 

after debugging, I found that:
if `Clone` in database is empty, before
https://github.com/woodpecker-ci/woodpecker/blob/master/server/api/hook.go#L128, the `repo.Clone` be always unset, so clone is failed.

This PR makes the empty `Clone` can't overwrite the value in database.