### PR TITLE
Set a default value for `build-event` flag of `cli exec` command

### DIFF
--- a/cli/exec/flags.go
+++ b/cli/exec/flags.go
@@ -157,6 +157,7 @@ var flags = []cli.Flag{
 	&cli.StringFlag{
 		EnvVars: []string{"CI_BUILD_EVENT"},
 		Name:    "build-event",
+		Value:   "manual",
 	},
 	&cli.StringFlag{
 		EnvVars: []string{"CI_BUILD_LINK"},

--- a/docs/docs/40-cli.md
+++ b/docs/docs/40-cli.md
@@ -286,7 +286,7 @@ execute a local build
 
 **--build-created**="":  (default: 0)
 
-**--build-event**="": 
+**--build-event**="":  (default: manual)
 
 **--build-finished**="":  (default: 0)
 


### PR DESCRIPTION
Otherwise `cli exec` does not do anything due to the default constraints applied to a pipeline (i.e., some kind of build event is expected).