### PR TITLE
Add support sub-settings and secrets in sub-settings

### DIFF
--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -25,7 +25,7 @@ const (
 	namePipeline = "pipeline"
 )
 
-// Registry represent registry credentials
+// Registry represents registry credentials
 type Registry struct {
 	Hostname string
 	Username string

--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -39,6 +39,16 @@ type Secret struct {
 	Match []string
 }
 
+type secretMap map[string]Secret
+
+func (sm secretMap) toStringMap() map[string]string {
+	m := make(map[string]string, len(sm))
+	for k, v := range sm {
+		m[k] = v.Value
+	}
+	return m
+}
+
 type ResourceLimit struct {
 	MemSwapLimit int64
 	MemLimit     int64
@@ -61,7 +71,7 @@ type Compiler struct {
 	path              string
 	metadata          frontend.Metadata
 	registries        []Registry
-	secrets           map[string]Secret
+	secrets           secretMap
 	cacher            Cacher
 	reslimit          ResourceLimit
 	defaultCloneImage string

--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -25,6 +25,7 @@ const (
 	namePipeline = "pipeline"
 )
 
+// Registry represent registry credentials
 type Registry struct {
 	Hostname string
 	Username string

--- a/pipeline/frontend/yaml/compiler/convert.go
+++ b/pipeline/frontend/yaml/compiler/convert.go
@@ -9,6 +9,7 @@ import (
 
 	backend "github.com/woodpecker-ci/woodpecker/pipeline/backend/types"
 	"github.com/woodpecker-ci/woodpecker/pipeline/frontend/yaml"
+	"github.com/woodpecker-ci/woodpecker/pipeline/frontend/yaml/compiler/settings"
 )
 
 func (c *Compiler) createProcess(name string, container *yaml.Container, section string) *backend.Step {
@@ -71,7 +72,7 @@ func (c *Compiler) createProcess(name string, container *yaml.Container, section
 	}
 
 	if !detached {
-		if err := paramsToEnv(container.Settings, environment, c.secrets); err != nil {
+		if err := settings.ParamsToEnv(container.Settings, environment, c.secrets.toStringMap()); err != nil {
 			log.Error().Err(err).Msg("paramsToEnv")
 		}
 	}

--- a/pipeline/frontend/yaml/compiler/params.go
+++ b/pipeline/frontend/yaml/compiler/params.go
@@ -29,10 +29,8 @@ func paramsToEnv(from map[string]interface{}, to map[string]string, secrets map[
 }
 
 func sanitizeParamKey(k string) string {
-	return "PLUGIN_" +
-		strings.ToUpper(
-			strings.ReplaceAll(k, ".", "_"),
-		)
+	return "PLUGIN_" + strings.ToUpper(
+		strings.ReplaceAll(strings.ReplaceAll(k, ".", "_"), "-", "_"))
 }
 
 func isComplex(t reflect.Kind) bool {

--- a/pipeline/frontend/yaml/compiler/params.go
+++ b/pipeline/frontend/yaml/compiler/params.go
@@ -84,7 +84,6 @@ func sanitizeParamValue(v interface{}, secrets map[string]Secret) (string, error
 		if t.Elem().Kind() == reflect.Interface ||
 			// else check direct handle lists witch contain non complex elements
 			!isComplex(t.Elem().Kind()) {
-
 			containComplex := false
 			in := make([]string, vv.Len())
 

--- a/pipeline/frontend/yaml/compiler/params.go
+++ b/pipeline/frontend/yaml/compiler/params.go
@@ -63,7 +63,7 @@ func sanitizeParamValue(v interface{}, secrets map[string]Secret) (string, error
 		return fmt.Sprintf("%v", vv.Float()), nil
 
 	case reflect.Map:
-		// handle secrets
+		// check if it's a secret and return value if it's the case 
 		value, isSecret, err := injectSecret(v, secrets)
 		if err != nil {
 			return "", err
@@ -80,9 +80,9 @@ func sanitizeParamValue(v interface{}, secrets map[string]Secret) (string, error
 			return "", nil
 		}
 
-		// if it's an interface unwrap and check element
+		// if it's an interface unwrap and element check happen for each iteration later
 		if t.Elem().Kind() == reflect.Interface ||
-			// else check direct handle lists witch contain non complex elements
+			// else check directly if element is not complex
 			!isComplex(t.Elem().Kind()) {
 			containComplex := false
 			in := make([]string, vv.Len())

--- a/pipeline/frontend/yaml/compiler/params_test.go
+++ b/pipeline/frontend/yaml/compiler/params_test.go
@@ -56,6 +56,11 @@ bool: true
 slice: [1, 2, 3]
 my_secret:
   from_secret: secret_token
+logins:
+- registry: https://codeberg.org
+  username: "6543"
+  password:
+    from_secret: cb_password
 `)
 	var from map[string]interface{}
 	err := yaml.Unmarshal(fromYAML, &from)
@@ -68,9 +73,11 @@ my_secret:
 		"PLUGIN_BOOL":      "true",
 		"PLUGIN_SLICE":     "1,2,3",
 		"PLUGIN_MY_SECRET": "FooBar",
+		"PLUGIN_LOGINS":    `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
 	}
 	secrets := map[string]Secret{
 		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},
+		"cb_password":  {Name: "cb_password", Value: "geheim", Match: nil},
 	}
 	got := map[string]string{}
 	assert.NoError(t, paramsToEnv(from, got, secrets))

--- a/pipeline/frontend/yaml/compiler/params_test.go
+++ b/pipeline/frontend/yaml/compiler/params_test.go
@@ -79,8 +79,7 @@ logins:
 		"PLUGIN_BOOL":      "true",
 		"PLUGIN_SLICE":     "1,2,3",
 		"PLUGIN_MY_SECRET": "FooBar",
-		//"PLUGIN_LOGINS":    `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
-		"PLUGIN_LOGINS": `[{"password":{"from_secret":"cb_password"},"registry":"https://codeberg.org","username":"6543"}]`,
+		"PLUGIN_LOGINS":    `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
 	}
 	secrets := map[string]Secret{
 		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},

--- a/pipeline/frontend/yaml/compiler/params_test.go
+++ b/pipeline/frontend/yaml/compiler/params_test.go
@@ -47,6 +47,12 @@ func TestParamsToEnv(t *testing.T) {
 	assert.EqualValues(t, want, got, "Problem converting plugin parameters to environment variables")
 }
 
+func TestSanitizeParamKey(t *testing.T) {
+	assert.EqualValues(t, "PLUGIN_DRY_RUN", sanitizeParamKey("dry-run"))
+	assert.EqualValues(t, "PLUGIN_DRY_RUN", sanitizeParamKey("dry_Run"))
+	assert.EqualValues(t, "PLUGIN_DRY_RUN", sanitizeParamKey("dry.run"))
+}
+
 func TestYAMLToParamsToEnv(t *testing.T) {
 	fromYAML := []byte(`skip: ~
 string: stringz

--- a/pipeline/frontend/yaml/compiler/params_test.go
+++ b/pipeline/frontend/yaml/compiler/params_test.go
@@ -63,10 +63,10 @@ slice: [1, 2, 3]
 my_secret:
   from_secret: secret_token
 logins:
-- registry: https://codeberg.org
-  username: "6543"
-  password:
-    from_secret: cb_password
+  - registry: https://codeberg.org
+    username: "6543"
+    password:
+      from_secret: cb_password
 `)
 	var from map[string]interface{}
 	err := yaml.Unmarshal(fromYAML, &from)

--- a/pipeline/frontend/yaml/compiler/params_test.go
+++ b/pipeline/frontend/yaml/compiler/params_test.go
@@ -79,7 +79,8 @@ logins:
 		"PLUGIN_BOOL":      "true",
 		"PLUGIN_SLICE":     "1,2,3",
 		"PLUGIN_MY_SECRET": "FooBar",
-		"PLUGIN_LOGINS":    `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
+		//"PLUGIN_LOGINS":    `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
+		"PLUGIN_LOGINS": `[{"password":{"from_secret":"cb_password"},"registry":"https://codeberg.org","username":"6543"}]`,
 	}
 	secrets := map[string]Secret{
 		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -70,7 +70,7 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 	case reflect.String:
 		return vv.String(), nil
 
-	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int8:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return fmt.Sprintf("%v", vv.Int()), nil
 
 	case reflect.Float32, reflect.Float64:

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -155,6 +155,7 @@ func injectSecret(v map[string]interface{}, secrets map[string]string) (string, 
 			}
 			return "", false, fmt.Errorf("no secret found for %q", secretName)
 		}
+		return "", false, fmt.Errorf("from_secret has to be a string")
 	}
 	return "", false, nil
 }

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -92,7 +92,7 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 		}
 
 		// it's complex
-		break
+		// break
 
 	case reflect.Slice, reflect.Array:
 		if vv.Len() == 0 {

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -129,7 +129,7 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 		}
 	}
 
-  // handle all elements which are not primitives, string-maps containing secrets or arrays
+	// handle all elements which are not primitives, string-maps containing secrets or arrays
 	return handleComplex(vv.Interface(), secrets)
 }
 

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -85,9 +85,8 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 			return value, nil
 		}
 
-		ymlOut, _ := yaml.Marshal(vv.Interface())
-		out, _ := yaml2json.Convert(ymlOut)
-		return string(out), nil
+		// it's complex
+		break
 
 	case reflect.Slice, reflect.Array:
 		if vv.Len() == 0 {
@@ -119,28 +118,27 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 			if !containComplex {
 				return strings.Join(in, ","), nil
 			}
+			// else it's complex
 		}
-
-		// it's complex use yml.ToJSON
-		fallthrough
-
-	default:
-		// recursive inject secrets
-		v, err := injectSecretRecursive(vv.Interface(), secrets)
-		if err != nil {
-			return "", err
-		}
-
-		out, err := yaml.Marshal(v)
-		if err != nil {
-			return "", err
-		}
-		out, err = yaml2json.Convert(out)
-		if err != nil {
-			return "", err
-		}
-		return string(out), nil
 	}
+
+	// handle complex via yml.ToJSON
+
+	// recursive inject secrets
+	v, err := injectSecretRecursive(vv.Interface(), secrets)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	out, err = yaml2json.Convert(out)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }
 
 func injectSecret(v interface{}, secrets map[string]string) (string, bool, error) {

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -26,7 +26,7 @@ import (
 
 // ParamsToEnv uses reflection to convert a map[string]interface to a list
 // of environment variables.
-func ParamsToEnv(from map[string]interface{}, to map[string]string, secrets map[string]string) (err error) {
+func ParamsToEnv(from map[string]interface{}, to, secrets map[string]string) (err error) {
 	if to == nil {
 		return fmt.Errorf("no map to write to")
 	}
@@ -77,7 +77,7 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 		return fmt.Sprintf("%v", vv.Float()), nil
 
 	case reflect.Map:
-		// check if it's a secret and return value if it's the case 
+		// check if it's a secret and return value if it's the case
 		value, isSecret, err := injectSecret(v, secrets)
 		if err != nil {
 			return "", err

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -42,7 +42,7 @@ func ParamsToEnv(from map[string]interface{}, to, secrets map[string]string) (er
 	return nil
 }
 
-// format hey environment variable key
+// format the environment variable key
 func sanitizeParamKey(k string) string {
 	return "PLUGIN_" + strings.ToUpper(
 		strings.ReplaceAll(strings.ReplaceAll(k, ".", "_"), "-", "_"))
@@ -168,7 +168,7 @@ func injectSecret(v map[string]interface{}, secrets map[string]string) (string, 
 }
 
 // injectSecretRecursive iterates over all types and if they contain elements
-// do so recursive over them too, it use injectSecret internally
+// iterate recursively over them too, it uses injectSecret internally
 func injectSecretRecursive(v interface{}, secrets map[string]string) (interface{}, error) {
 	t := reflect.TypeOf(v)
 

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -42,11 +42,13 @@ func ParamsToEnv(from map[string]interface{}, to, secrets map[string]string) (er
 	return nil
 }
 
+// format hey environment variable key
 func sanitizeParamKey(k string) string {
 	return "PLUGIN_" + strings.ToUpper(
 		strings.ReplaceAll(strings.ReplaceAll(k, ".", "_"), "-", "_"))
 }
 
+// indicate if a data type can be turned into string without encoding as json
 func isComplex(t reflect.Kind) bool {
 	switch t {
 	case reflect.Bool,
@@ -59,6 +61,7 @@ func isComplex(t reflect.Kind) bool {
 	}
 }
 
+// sanitizeParamValue return the value of a setting as string prepared to be injected as environment variable
 func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error) {
 	t := reflect.TypeOf(v)
 	vv := reflect.ValueOf(v)
@@ -130,7 +133,7 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 	return handleComplex(vv.Interface(), secrets)
 }
 
-// handle complex via yml.ToJSON
+// handleComplex use yml.ToJSON to store configuration in environment variables
 func handleComplex(v interface{}, secrets map[string]string) (string, error) {
 	v, err := injectSecretRecursive(v, secrets)
 	if err != nil {
@@ -148,9 +151,9 @@ func handleComplex(v interface{}, secrets map[string]string) (string, error) {
 	return string(out), nil
 }
 
-// injectSecret probe if map is actualy a secret and so a string.
+// injectSecret probe if map is actually a secret and so a string.
 // if it's a string it returns either the value or an error if secret was not found
-// else it just indicate to progress normaly
+// else it just indicate to progress normally
 func injectSecret(v map[string]interface{}, secrets map[string]string) (string, bool, error) {
 	if secretNameI, ok := v["from_secret"]; ok {
 		if secretName, ok := secretNameI.(string); ok {
@@ -164,8 +167,8 @@ func injectSecret(v map[string]interface{}, secrets map[string]string) (string, 
 	return "", false, nil
 }
 
-// injectSecretRecursive itterates over all types and if they countain elements do so recursive over them too
-// it use injectSecret internaly
+// injectSecretRecursive iterates over all types and if they contain elements
+// do so recursive over them too, it use injectSecret internally
 func injectSecretRecursive(v interface{}, secrets map[string]string) (interface{}, error) {
 	t := reflect.TypeOf(v)
 

--- a/pipeline/frontend/yaml/compiler/settings/params.go
+++ b/pipeline/frontend/yaml/compiler/settings/params.go
@@ -113,7 +113,7 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 
 				// ensure each element is not complex
 				if isComplex(reflect.TypeOf(v).Kind()) {
-					containComplex = true
+					containsComplex = true
 					break
 				}
 
@@ -123,7 +123,7 @@ func sanitizeParamValue(v interface{}, secrets map[string]string) (string, error
 				}
 			}
 
-			if !containComplex {
+			if !containsComplex {
 				return strings.Join(in, ","), nil
 			}
 		}

--- a/pipeline/frontend/yaml/compiler/settings/params_test.go
+++ b/pipeline/frontend/yaml/compiler/settings/params_test.go
@@ -1,4 +1,18 @@
-package compiler
+// Copyright 2022 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package settings
 
 import (
 	"testing"
@@ -39,11 +53,11 @@ func TestParamsToEnv(t *testing.T) {
 		"PLUGIN_MY_SECRET":        "FooBar",
 		"PLUGIN_UPPERCASE_SECRET": "FooBar",
 	}
-	secrets := map[string]Secret{
-		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},
+	secrets := map[string]string{
+		"secret_token": "FooBar",
 	}
 	got := map[string]string{}
-	assert.NoError(t, paramsToEnv(from, got, secrets))
+	assert.NoError(t, ParamsToEnv(from, got, secrets))
 	assert.EqualValues(t, want, got, "Problem converting plugin parameters to environment variables")
 }
 
@@ -81,12 +95,12 @@ logins:
 		"PLUGIN_MY_SECRET": "FooBar",
 		"PLUGIN_LOGINS":    `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
 	}
-	secrets := map[string]Secret{
-		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},
-		"cb_password":  {Name: "cb_password", Value: "geheim", Match: nil},
+	secrets := map[string]string{
+		"secret_token": "FooBar",
+		"cb_password":  "geheim",
 	}
 	got := map[string]string{}
-	assert.NoError(t, paramsToEnv(from, got, secrets))
+	assert.NoError(t, ParamsToEnv(from, got, secrets))
 	assert.EqualValues(t, want, got, "Problem converting plugin parameters to environment variables")
 }
 
@@ -97,10 +111,10 @@ func TestYAMLToParamsToEnvError(t *testing.T) {
 	var from map[string]interface{}
 	err := yaml.Unmarshal(fromYAML, &from)
 	assert.NoError(t, err)
-	secrets := map[string]Secret{
-		"secret_token": {Name: "secret_token", Value: "FooBar", Match: nil},
+	secrets := map[string]string{
+		"secret_token": "FooBar",
 	}
-	assert.Error(t, paramsToEnv(from, make(map[string]string), secrets))
+	assert.Error(t, ParamsToEnv(from, make(map[string]string), secrets))
 }
 
 func stringsToInterface(val ...string) []interface{} {

--- a/pipeline/frontend/yaml/compiler/settings/params_test.go
+++ b/pipeline/frontend/yaml/compiler/settings/params_test.go
@@ -76,7 +76,13 @@ bool: true
 slice: [1, 2, 3]
 my_secret:
   from_secret: secret_token
-logins:
+map:
+  key: "value"
+  entry2:
+    - "a"
+    - "b"
+    - 3
+list.map:
   - registry: https://codeberg.org
     username: "6543"
     password:
@@ -93,7 +99,8 @@ logins:
 		"PLUGIN_BOOL":      "true",
 		"PLUGIN_SLICE":     "1,2,3",
 		"PLUGIN_MY_SECRET": "FooBar",
-		"PLUGIN_LOGINS":    `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
+		"PLUGIN_MAP":       `{"entry2":["a","b",3],"key":"value"}`,
+		"PLUGIN_LIST_MAP":  `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
 	}
 	secrets := map[string]string{
 		"secret_token": "FooBar",

--- a/pipeline/frontend/yaml/compiler/settings/params_test.go
+++ b/pipeline/frontend/yaml/compiler/settings/params_test.go
@@ -29,7 +29,7 @@ func TestParamsToEnv(t *testing.T) {
 		"float":            1.2,
 		"bool":             true,
 		"slice":            []int{1, 2, 3},
-		"map":              map[string]string{"hello": "world"},
+		"map":              map[string]interface{}{"hello": "world"},
 		"complex":          []struct{ Name string }{{"Jack"}, {"Jill"}},
 		"complex2":         struct{ Name string }{"Jack"},
 		"from.address":     "noreply@example.com",

--- a/pipeline/frontend/yaml/compiler/settings/params_test.go
+++ b/pipeline/frontend/yaml/compiler/settings/params_test.go
@@ -82,6 +82,8 @@ map:
     - "a"
     - "b"
     - 3
+  secret:
+    from_secret: secret_token
 list.map:
   - registry: https://codeberg.org
     username: "6543"
@@ -99,7 +101,7 @@ list.map:
 		"PLUGIN_BOOL":      "true",
 		"PLUGIN_SLICE":     "1,2,3",
 		"PLUGIN_MY_SECRET": "FooBar",
-		"PLUGIN_MAP":       `{"entry2":["a","b",3],"key":"value"}`,
+		"PLUGIN_MAP":       `{"entry2":["a","b",3],"key":"value","secret":"FooBar"}`,
 		"PLUGIN_LIST_MAP":  `[{"password":"geheim","registry":"https://codeberg.org","username":"6543"}]`,
 	}
 	secrets := map[string]string{


### PR DESCRIPTION
example:
```yml
settings:
  logins:
    - registry: https://codeberg.org
      username: "6543"
      password: geheim
    - registry: https://index.docker.io/v1/
      username: a6543
      password: anders_geheim
```

needed for https://codeberg.org/woodpecker-plugins/plugin-docker-buildx/pulls/23