### PR TITLE
docs: add alternative naming options

### DIFF
--- a/docs/docs/20-usage/20-pipeline-syntax.md
+++ b/docs/docs/20-usage/20-pipeline-syntax.md
@@ -20,6 +20,24 @@ pipeline:
 ```
 
 In the above example we define two pipeline steps, `frontend` and `backend`. The names of these steps are completely arbitrary.
+Another way to name a step is by using the name keyword:
+
+```yaml
+pipeline:
+  - name: backend
+    image: golang
+    commands:
+      - go build
+      - go test
+  - name: frontend
+    image: node
+    commands:
+      - npm install
+      - npm run test
+      - npm run build
+```
+
+Keep in mind the name is optional, if not added the steps will be numerated.
 
 ### Skip Commits
 

--- a/docs/docs/20-usage/20-pipeline-syntax.md
+++ b/docs/docs/20-usage/20-pipeline-syntax.md
@@ -20,6 +20,7 @@ pipeline:
 ```
 
 In the above example we define two pipeline steps, `frontend` and `backend`. The names of these steps are completely arbitrary.
+
 Another way to name a step is by using the name keyword:
 
 ```yaml


### PR DESCRIPTION
Added naming option to pipeline syntax with a list and name keyword

resolves #1119 