### PR TITLE
gitea: fetch all branches

### DIFF
--- a/server/remote/gitea/gitea.go
+++ b/server/remote/gitea/gitea.go
@@ -462,15 +462,28 @@ func (c *Gitea) Branches(ctx context.Context, u *model.User, r *model.Repo) ([]s
 		return nil, err
 	}
 
-	giteaBranches, _, err := client.ListRepoBranches(r.Owner, r.Name, gitea.ListRepoBranchesOptions{})
-	if err != nil {
-		return nil, err
+	branches := make([]string, 0)
+
+	page := 1
+
+	for page > 0 {
+		giteaBranches, _, err := client.ListRepoBranches(r.Owner, r.Name, gitea.ListRepoBranchesOptions{
+			gitea.ListOptions{
+				Page: page,
+			}})
+		if err != nil {
+			return nil, err
+		}
+		if len(giteaBranches) > 0 {
+			for _, branch := range giteaBranches {
+				branches = append(branches, branch.Name)
+			}
+			page++
+		} else {
+			page = -1
+		}
 	}
 
-	branches := make([]string, 0)
-	for _, branch := range giteaBranches {
-		branches = append(branches, branch.Name)
-	}
 	return branches, nil
 }
 

--- a/server/remote/gitea/gitea.go
+++ b/server/remote/gitea/gitea.go
@@ -466,11 +466,12 @@ func (c *Gitea) Branches(ctx context.Context, u *model.User, r *model.Repo) ([]s
 
 	page := 1
 
-	for page > 0 {
+	for {
 		giteaBranches, _, err := client.ListRepoBranches(r.Owner, r.Name, gitea.ListRepoBranchesOptions{
-			gitea.ListOptions{
+			ListOptions: gitea.ListOptions{
 				Page: page,
-			}})
+			},
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -480,7 +481,7 @@ func (c *Gitea) Branches(ctx context.Context, u *model.User, r *model.Repo) ([]s
 			}
 			page++
 		} else {
-			page = -1
+			break
 		}
 	}
 

--- a/server/remote/remote.go
+++ b/server/remote/remote.go
@@ -75,7 +75,7 @@ type Remote interface {
 	Deactivate(ctx context.Context, u *model.User, r *model.Repo, link string) error
 
 	// Branches returns the names of all branches for the named repository.
-        // TODO: Add proper pagination handling and remove workaround in gitea remote
+	// TODO: Add proper pagination handling and remove workaround in gitea remote
 	Branches(ctx context.Context, u *model.User, r *model.Repo) ([]string, error)
 
 	// BranchHead returns the sha of the head (lastest commit) of the specified branch

--- a/server/remote/remote.go
+++ b/server/remote/remote.go
@@ -75,6 +75,7 @@ type Remote interface {
 	Deactivate(ctx context.Context, u *model.User, r *model.Repo, link string) error
 
 	// Branches returns the names of all branches for the named repository.
+        // TODO: Add proper pagination handling and remove workaround in gitea remote
 	Branches(ctx context.Context, u *model.User, r *model.Repo) ([]string, error)
 
 	// BranchHead returns the sha of the head (lastest commit) of the specified branch


### PR DESCRIPTION
Both repo branch view and manual branch selector were limited to the stock pageSize of gitea client.

I've added a loop to fetch all branches from gitea