### PR TITLE
Hide icon in plugin detail page if not set

### DIFF
--- a/docs/plugins/woodpecker-plugins/src/theme/WoodpeckerPlugin.tsx
+++ b/docs/plugins/woodpecker-plugins/src/theme/WoodpeckerPlugin.tsx
@@ -60,9 +60,7 @@ export function WoodpeckerPlugin({ plugin }: { plugin: WoodpeckerPluginType }) {
 
                 <p style={{ marginTop: '2rem', marginBottom: '1rem' }}>{plugin.description}</p>
               </div>
-              <div className="col col--2">
-                <img src={plugin.icon} width="150" height="150" />
-              </div>
+              { plugin.icon ? <div className="col col--2"> <img src={plugin.icon} width="150" height="150"/> </div> : '' }
             </div>
             <hr style={{ margin: '1rem 0' }} />
             <div dangerouslySetInnerHTML={{ __html: plugin.docs }} />


### PR DESCRIPTION
fix: 
![image](https://user-images.githubusercontent.com/24977596/195733225-dc3e17aa-f188-4f06-820f-835693539b20.png)
