### PR TITLE
Infer docusaurus dev server URL from browser

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -169,6 +169,18 @@ module.exports = {
         };
       },
     }),
+    () => ({
+      name: 'webpack-config',
+      configureWebpack() {
+        return {
+          devServer: {
+            client: {
+              webSocketURL: 'auto://0.0.0.0:0/ws',
+            },
+          },
+        };
+      },
+    }),
   ],
   themes: [
     path.resolve(__dirname, 'plugins', 'woodpecker-plugins', 'dist'),


### PR DESCRIPTION
Fixes hot reload when running behind the gitpod proxy