### PR TITLE
Split `server/shared`

### DIFF
--- a/pipeline/procBuilder.go
+++ b/pipeline/procBuilder.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package pipeline
 
 import (
 	"fmt"
@@ -36,8 +36,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote"
 )
-
-// TODO(974) move to pipeline/*
 
 // ProcBuilder Takes the hook data and the yaml and returns in internal data model
 type ProcBuilder struct {

--- a/pipeline/procBuilder_test.go
+++ b/pipeline/procBuilder_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package pipeline
 
 import (
 	"fmt"
@@ -22,8 +22,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote"
 )
-
-// TODO(974) move to pipeline/*
 
 func TestGlobalEnvsubst(t *testing.T) {
 	t.Parallel()

--- a/server/api/user.go
+++ b/server/api/user.go
@@ -23,11 +23,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/securecookie"
 	"github.com/rs/zerolog/log"
-
 	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/router/middleware/session"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 	"github.com/woodpecker-ci/woodpecker/shared/token"
 )
@@ -54,11 +52,11 @@ func GetFeed(c *gin.Context) {
 
 		config := ToConfig(c)
 
-		sync := shared.Syncer{
+		sync := remote.Syncer{
 			Remote: remote,
 			Store:  _store,
 			Perms:  _store,
-			Match:  shared.NamespaceFilter(config.OwnersWhitelist),
+			Match:  remote.NamespaceFilter(config.OwnersWhitelist),
 		}
 		if err := sync.Sync(c, user, server.Config.FlatPermissions); err != nil {
 			log.Debug().Msgf("sync error: %s: %s", user.Login, err)
@@ -103,11 +101,11 @@ func GetRepos(c *gin.Context) {
 
 		config := ToConfig(c)
 
-		sync := shared.Syncer{
+		sync := remote.Syncer{
 			Remote: remote,
 			Store:  _store,
 			Perms:  _store,
-			Match:  shared.NamespaceFilter(config.OwnersWhitelist),
+			Match:  remote.NamespaceFilter(config.OwnersWhitelist),
 		}
 
 		if err := sync.Sync(c, user, server.Config.FlatPermissions); err != nil {

--- a/server/pipeline/approve.go
+++ b/server/pipeline/approve.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
@@ -41,7 +40,7 @@ func Approve(ctx context.Context, store store.Store, pipeline *model.Pipeline, u
 		return nil, ErrNotFound{Msg: msg}
 	}
 
-	if pipeline, err = shared.UpdateToStatusPending(store, *pipeline, user.Login); err != nil {
+	if pipeline, err = UpdateToStatusPending(store, *pipeline, user.Login); err != nil {
 		return nil, fmt.Errorf("error updating pipeline. %s", err)
 	}
 

--- a/server/pipeline/cancel.go
+++ b/server/pipeline/cancel.go
@@ -23,7 +23,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/queue"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
@@ -74,18 +73,18 @@ func Cancel(ctx context.Context, store store.Store, repo *model.Repo, pipeline *
 	for _, proc := range procs {
 		if proc.State == model.StatusPending {
 			if proc.PPID != 0 {
-				if _, err = shared.UpdateProcToStatusSkipped(store, *proc, 0); err != nil {
+				if _, err = UpdateProcToStatusSkipped(store, *proc, 0); err != nil {
 					log.Error().Msgf("error: done: cannot update proc_id %d state: %s", proc.ID, err)
 				}
 			} else {
-				if _, err = shared.UpdateProcToStatusKilled(store, *proc); err != nil {
+				if _, err = UpdateProcToStatusKilled(store, *proc); err != nil {
 					log.Error().Msgf("error: done: cannot update proc_id %d state: %s", proc.ID, err)
 				}
 			}
 		}
 	}
 
-	killedBuild, err := shared.UpdateToStatusKilled(store, *pipeline)
+	killedBuild, err := UpdateToStatusKilled(store, *pipeline)
 	if err != nil {
 		log.Error().Err(err).Msgf("UpdateToStatusKilled: %v", pipeline)
 		return err

--- a/server/pipeline/config.go
+++ b/server/pipeline/config.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
@@ -32,7 +31,7 @@ func findOrPersistPipelineConfig(store store.Store, pipeline *model.Pipeline, re
 			RepoID: pipeline.RepoID,
 			Data:   remoteYamlConfig.Data,
 			Hash:   sha,
-			Name:   shared.SanitizePath(remoteYamlConfig.Name),
+			Name:   pipeline.SanitizePath(remoteYamlConfig.Name),
 		}
 		err = store.ConfigCreate(conf)
 		if err != nil {

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -24,7 +24,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
@@ -60,7 +59,7 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 	)
 
 	// fetch the pipeline file from the remote
-	configFetcher := shared.NewConfigFetcher(server.Config.Services.Remote, server.Config.Services.ConfigService, repoUser, repo, pipeline)
+	configFetcher := remote.NewConfigFetcher(server.Config.Services.Remote, server.Config.Services.ConfigService, repoUser, repo, pipeline)
 	remoteYamlConfigs, configFetchErr = configFetcher.Fetch(ctx)
 	if configFetchErr == nil {
 		filtered, parseErr = checkIfFiltered(pipeline, remoteYamlConfigs)

--- a/server/pipeline/decline.go
+++ b/server/pipeline/decline.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/woodpecker-ci/woodpecker/server/model"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
@@ -30,7 +29,7 @@ func Decline(ctx context.Context, store store.Store, pipeline *model.Pipeline, u
 		return nil, fmt.Errorf("cannot decline a pipeline with status %s", pipeline.Status)
 	}
 
-	_, err := shared.UpdateToStatusDeclined(store, *pipeline, user.Login)
+	_, err := UpdateToStatusDeclined(store, *pipeline, user.Login)
 	if err != nil {
 		return nil, fmt.Errorf("error updating pipeline. %s", err)
 	}

--- a/server/pipeline/filter.go
+++ b/server/pipeline/filter.go
@@ -18,16 +18,14 @@ package pipeline
 
 import (
 	"github.com/rs/zerolog/log"
-
 	"github.com/woodpecker-ci/woodpecker/pipeline/frontend"
 	"github.com/woodpecker-ci/woodpecker/pipeline/frontend/yaml"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 )
 
 func zeroSteps(pipeline *model.Pipeline, remoteYamlConfigs []*remote.FileMeta) bool {
-	b := shared.ProcBuilder{
+	b := pipeline.ProcBuilder{
 		Repo:  &model.Repo{},
 		Curr:  pipeline,
 		Last:  &model.Pipeline{},

--- a/server/pipeline/pipelineStatus.go
+++ b/server/pipeline/pipelineStatus.go
@@ -13,15 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package pipeline
 
 import (
 	"time"
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
 )
-
-// TODO(974) move to server/pipeline/*
 
 func UpdateToStatusRunning(store model.UpdatePipelineStore, pipeline model.Pipeline, started int64) (*model.Pipeline, error) {
 	pipeline.Status = model.StatusRunning

--- a/server/pipeline/pipelineStatus_test.go
+++ b/server/pipeline/pipelineStatus_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package pipeline
 
 import (
 	"errors"
@@ -22,8 +22,6 @@ import (
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
 )
-
-// TODO(974) move to server/pipeline/*
 
 type mockUpdatePipelineStore struct{}
 

--- a/server/pipeline/procStatus.go
+++ b/server/pipeline/procStatus.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package pipeline
 
 import (
 	"time"
@@ -20,8 +20,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/pipeline/rpc"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 )
-
-// TODO(974) move to server/pipeline/*
 
 func UpdateProcStatus(store model.UpdateProcStore, proc model.Proc, state rpc.State, started int64) (*model.Proc, error) {
 	if state.Exited {

--- a/server/pipeline/procStatus_test.go
+++ b/server/pipeline/procStatus_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package pipeline
 
 import (
 	"testing"
@@ -21,8 +21,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/pipeline/rpc"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 )
-
-// TODO(974) move to server/pipeline/*
 
 type mockUpdateProcStore struct{}
 

--- a/server/pipeline/queue.go
+++ b/server/pipeline/queue.go
@@ -19,14 +19,14 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/woodpecker-ci/woodpecker/pipeline"
 	"github.com/woodpecker-ci/woodpecker/pipeline/rpc"
 	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/queue"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 )
 
-func queueBuild(pipeline *model.Pipeline, repo *model.Repo, pipelineItems []*shared.PipelineItem) error {
+func queueBuild(pipeline *model.Pipeline, repo *model.Repo, pipelineItems []*pipeline.PipelineItem) error {
 	var tasks []*queue.Task
 	for _, item := range pipelineItems {
 		if item.Proc.State == model.StatusSkipped {
@@ -58,7 +58,7 @@ func queueBuild(pipeline *model.Pipeline, repo *model.Repo, pipelineItems []*sha
 	return server.Config.Services.Queue.PushAtOnce(context.Background(), tasks)
 }
 
-func taskIds(dependsOn []string, pipelineItems []*shared.PipelineItem) (taskIds []string) {
+func taskIds(dependsOn []string, pipelineItems []*pipeline.PipelineItem) (taskIds []string) {
 	for _, dep := range dependsOn {
 		for _, pipelineItem := range pipelineItems {
 			if pipelineItem.Proc.Name == dep {

--- a/server/pipeline/restart.go
+++ b/server/pipeline/restart.go
@@ -26,7 +26,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
@@ -81,7 +80,7 @@ func Restart(ctx context.Context, store store.Store, lastBuild *model.Pipeline, 
 	}
 
 	if len(configs) == 0 {
-		newBuild, uerr := shared.UpdateToStatusError(store, *newBuild, errors.New("pipeline definition not found"))
+		newBuild, uerr := UpdateToStatusError(store, *newBuild, errors.New("pipeline definition not found"))
 		if uerr != nil {
 			log.Debug().Err(uerr).Msg("failure to update pipeline status")
 		}

--- a/server/pipeline/start.go
+++ b/server/pipeline/start.go
@@ -18,14 +18,14 @@ import (
 	"context"
 
 	"github.com/rs/zerolog/log"
+	"github.com/woodpecker-ci/woodpecker/pipeline"
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
 // start a pipeline, make sure it was stored persistent in the store before
-func start(ctx context.Context, store store.Store, activePipeline *model.Pipeline, user *model.User, repo *model.Repo, pipelineItems []*shared.PipelineItem) (*model.Pipeline, error) {
+func start(ctx context.Context, store store.Store, activePipeline *model.Pipeline, user *model.User, repo *model.Repo, pipelineItems []*pipeline.PipelineItem) (*model.Pipeline, error) {
 	// call to cancel previous pipelines if needed
 	if err := cancelPreviousPipelines(ctx, store, activePipeline, repo); err != nil {
 		// should be not breaking

--- a/server/remote/configFetcher.go
+++ b/server/remote/configFetcher.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package remote
 
 import (
 	"context"
@@ -25,24 +25,21 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server/plugins/config"
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
-	"github.com/woodpecker-ci/woodpecker/server/remote"
 )
 
 type ConfigFetcher interface {
-	Fetch(ctx context.Context) (files []*remote.FileMeta, err error)
+	Fetch(ctx context.Context) (files []*FileMeta, err error)
 }
 
-// TODO(974) move to new package
-
 type configFetcher struct {
-	remote          remote.Remote
+	remote          Remote
 	user            *model.User
 	repo            *model.Repo
 	pipeline        *model.Pipeline
 	configExtension config.Extension
 }
 
-func NewConfigFetcher(remote remote.Remote, configExtension config.Extension, user *model.User, repo *model.Repo, pipeline *model.Pipeline) ConfigFetcher {
+func NewConfigFetcher(remote Remote, configExtension config.Extension, user *model.User, repo *model.Repo, pipeline *model.Pipeline) ConfigFetcher {
 	return &configFetcher{
 		remote:          remote,
 		user:            user,
@@ -56,7 +53,7 @@ func NewConfigFetcher(remote remote.Remote, configExtension config.Extension, us
 var configFetchTimeout = time.Second * 3
 
 // Fetch pipeline config from source forge
-func (cf *configFetcher) Fetch(ctx context.Context) (files []*remote.FileMeta, err error) {
+func (cf *configFetcher) Fetch(ctx context.Context) (files []*FileMeta, err error) {
 	log.Trace().Msgf("Start Fetching config for '%s'", cf.repo.FullName)
 
 	// try to fetch 3 times
@@ -92,7 +89,7 @@ func (cf *configFetcher) Fetch(ctx context.Context) (files []*remote.FileMeta, e
 
 // fetch config by timeout
 // TODO: deduplicate code
-func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config string) ([]*remote.FileMeta, error) {
+func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config string) ([]*FileMeta, error) {
 	ctx, cancel := context.WithTimeout(c, timeout)
 	defer cancel()
 
@@ -103,7 +100,7 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 			file, err := cf.remote.File(ctx, cf.user, cf.repo, cf.pipeline, config)
 			if err == nil && len(file) != 0 {
 				log.Trace().Msgf("ConfigFetch[%s]: found file '%s'", cf.repo.FullName, config)
-				return []*remote.FileMeta{{
+				return []*FileMeta{{
 					Name: config,
 					Data: file,
 				}}, nil
@@ -137,7 +134,7 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 	file, err := cf.remote.File(ctx, cf.user, cf.repo, cf.pipeline, config)
 	if err == nil && len(file) != 0 {
 		log.Trace().Msgf("ConfigFetch[%s]: found file '%s'", cf.repo.FullName, config)
-		return []*remote.FileMeta{{
+		return []*FileMeta{{
 			Name: config,
 			Data: file,
 		}}, nil
@@ -147,7 +144,7 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 	file, err = cf.remote.File(ctx, cf.user, cf.repo, cf.pipeline, config)
 	if err == nil && len(file) != 0 {
 		log.Trace().Msgf("ConfigFetch[%s]: found file '%s'", cf.repo.FullName, config)
-		return []*remote.FileMeta{{
+		return []*FileMeta{{
 			Name: config,
 			Data: file,
 		}}, nil
@@ -157,12 +154,12 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
-		return []*remote.FileMeta{}, fmt.Errorf("ConfigFetcher: Fallback did not found config: %s", err)
+		return []*FileMeta{}, fmt.Errorf("ConfigFetcher: Fallback did not found config: %s", err)
 	}
 }
 
-func filterPipelineFiles(files []*remote.FileMeta) []*remote.FileMeta {
-	var res []*remote.FileMeta
+func filterPipelineFiles(files []*FileMeta) []*FileMeta {
+	var res []*FileMeta
 
 	for _, file := range files {
 		if strings.HasSuffix(file.Name, ".yml") {

--- a/server/remote/configFetcher_test.go
+++ b/server/remote/configFetcher_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared_test
+package remote
 
 import (
 	"context"
@@ -32,12 +32,8 @@ import (
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/plugins/config"
-	"github.com/woodpecker-ci/woodpecker/server/remote"
 	"github.com/woodpecker-ci/woodpecker/server/remote/mocks"
-	"github.com/woodpecker-ci/woodpecker/server/shared"
 )
-
-// TODO(974) move to new package
 
 func TestFetch(t *testing.T) {
 	t.Parallel()
@@ -239,12 +235,12 @@ func TestFetch(t *testing.T) {
 			repo := &model.Repo{Owner: "laszlocph", Name: "multipipeline", Config: tt.repoConfig}
 
 			r := new(mocks.Remote)
-			dirs := map[string][]*remote.FileMeta{}
+			dirs := map[string][]*FileMeta{}
 			for _, file := range tt.files {
 				r.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, file.name).Return(file.data, nil)
 				path := filepath.Dir(file.name)
 				if path != "." {
-					dirs[path] = append(dirs[path], &remote.FileMeta{
+					dirs[path] = append(dirs[path], &FileMeta{
 						Name: file.name,
 						Data: file.data,
 					})
@@ -259,7 +255,7 @@ func TestFetch(t *testing.T) {
 			r.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("File not found"))
 			r.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("Directory not found"))
 
-			configFetcher := shared.NewConfigFetcher(
+			configFetcher := NewConfigFetcher(
 				r,
 				config.NewHTTP("", ""),
 				&model.User{Token: "xxx"},
@@ -444,12 +440,12 @@ func TestFetchFromConfigService(t *testing.T) {
 			repo := &model.Repo{Owner: "laszlocph", Name: tt.name, Config: tt.repoConfig} // Using test name as repo name to provide different responses in mock server
 
 			r := new(mocks.Remote)
-			dirs := map[string][]*remote.FileMeta{}
+			dirs := map[string][]*FileMeta{}
 			for _, file := range tt.files {
 				r.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, file.name).Return(file.data, nil)
 				path := filepath.Dir(file.name)
 				if path != "." {
-					dirs[path] = append(dirs[path], &remote.FileMeta{
+					dirs[path] = append(dirs[path], &FileMeta{
 						Name: file.name,
 						Data: file.data,
 					})
@@ -464,7 +460,7 @@ func TestFetchFromConfigService(t *testing.T) {
 			r.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("File not found"))
 			r.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("Directory not found"))
 
-			configFetcher := shared.NewConfigFetcher(
+			configFetcher := NewConfigFetcher(
 				r,
 				configAPI,
 				&model.User{Token: "xxx"},

--- a/server/remote/userSyncer.go
+++ b/server/remote/userSyncer.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shared
+package remote
 
 import (
 	"context"
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
-	"github.com/woodpecker-ci/woodpecker/server/remote"
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
@@ -33,7 +32,7 @@ type UserSyncer interface {
 }
 
 type Syncer struct {
-	Remote remote.Remote
+	Remote Remote
 	Store  store.Store
 	Perms  model.PermStore
 	Match  FilterFunc


### PR DESCRIPTION
Moved files as in TODO comments

`configFetcher` and `userSyncer` are in `remote` package because they are communicating with the forge.

Closes #974 