### PR TITLE
Add additional tag to `next` image with commit sha

### DIFF
--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -74,7 +74,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.multiarch
       platforms: *platforms_server
-      tag: next
+      tag: [next, next-${CI_COMMIT_SHA:0:10}]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -87,7 +87,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.alpine.multiarch
       platforms: *platforms_alpine
-      tag: next-alpine
+      tag: [next-alpine, next-${CI_COMMIT_SHA:0:10}-alpine]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -168,7 +168,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.multiarch
       platforms: *platforms_release
-      tag: next
+      tag: [next, next-${CI_COMMIT_SHA:0:10}]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -181,7 +181,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.alpine.multiarch
       platforms: *platforms_alpine
-      tag: next-alpine
+      tag: [next-alpine, next-${CI_COMMIT_SHA:0:10}-alpine]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -262,7 +262,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.multiarch
       platforms: *platforms_release
-      tag: next
+      tag: [next, next-${CI_COMMIT_SHA:0:10}]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -275,7 +275,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.alpine.multiarch
       platforms: *platforms_alpine
-      tag: next-alpine
+      tag: [next-alpine, next-${CI_COMMIT_SHA:0:10}-alpine]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -3,14 +3,14 @@ depends_on:
   - web
 
 variables:
-  - &golang_image "golang:1.18"
-  - &node_image "node:18-alpine"
-  - &xgo_image "techknowlogick/xgo:go-1.18.x"
-  - &xgo_version "go-1.18.x"
-  - &platforms_release "linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64,linux/ppc64le,linux/riscv64,linux/s390x,windows/amd64,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64"
-  - &platforms_server "linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,linux/riscv64"
-  - &platforms_preview "linux/arm/v6,linux/arm64/v8,linux/amd64,linux/riscv64,windows/amd64"
-  - &platforms_alpine "linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le"
+  - &golang_image 'golang:1.18'
+  - &node_image 'node:18-alpine'
+  - &xgo_image 'techknowlogick/xgo:go-1.18.x'
+  - &xgo_version 'go-1.18.x'
+  - &platforms_release 'linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64,linux/ppc64le,linux/riscv64,linux/s390x,windows/amd64,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64'
+  - &platforms_server 'linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,linux/riscv64'
+  - &platforms_preview 'linux/arm/v6,linux/arm64/v8,linux/amd64,linux/riscv64,windows/amd64'
+  - &platforms_alpine 'linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le'
 
 pipeline:
   vendor:
@@ -44,7 +44,7 @@ pipeline:
 
   publish-server-preview:
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     group: docker
     settings:
       repo: woodpeckerci/woodpecker-server
@@ -56,7 +56,7 @@ pipeline:
 
   publish-server-alpine-preview:
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     group: docker
     settings:
       repo: woodpeckerci/woodpecker-server
@@ -82,7 +82,7 @@ pipeline:
   publish-next-server-alpine:
     image: woodpeckerci/plugin-docker-buildx
     group: docker
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.alpine.multiarch
@@ -108,7 +108,7 @@ pipeline:
   publish-release-branch-server-alpine:
     image: woodpeckerci/plugin-docker-buildx
     group: docker
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.alpine.multiarch
@@ -134,7 +134,7 @@ pipeline:
   release-server-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.alpine.multiarch
@@ -151,7 +151,7 @@ pipeline:
   publish-agent-preview:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.multiarch
@@ -176,7 +176,7 @@ pipeline:
   publish-next-agent-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.alpine.multiarch
@@ -202,7 +202,7 @@ pipeline:
   publish-release-branch-agent-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.alpine.multiarch
@@ -228,7 +228,7 @@ pipeline:
   release-agent-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.alpine.multiarch
@@ -245,7 +245,7 @@ pipeline:
   publish-cli-preview:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.multiarch
@@ -270,7 +270,7 @@ pipeline:
   publish-next-cli-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.alpine.multiarch
@@ -296,7 +296,7 @@ pipeline:
   publish-release-branch-cli-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.alpine.multiarch
@@ -322,7 +322,7 @@ pipeline:
   release-cli-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [docker_username, docker_password]
+    secrets: [ docker_username, docker_password ]
     settings:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.alpine.multiarch

--- a/.woodpecker/docker.yml
+++ b/.woodpecker/docker.yml
@@ -3,14 +3,14 @@ depends_on:
   - web
 
 variables:
-  - &golang_image 'golang:1.18'
-  - &node_image 'node:18-alpine'
-  - &xgo_image 'techknowlogick/xgo:go-1.18.x'
-  - &xgo_version 'go-1.18.x'
-  - &platforms_release 'linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64,linux/ppc64le,linux/riscv64,linux/s390x,windows/amd64,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64'
-  - &platforms_server 'linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,linux/riscv64'
-  - &platforms_preview 'linux/arm/v6,linux/arm64/v8,linux/amd64,linux/riscv64,windows/amd64'
-  - &platforms_alpine 'linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le'
+  - &golang_image "golang:1.18"
+  - &node_image "node:18-alpine"
+  - &xgo_image "techknowlogick/xgo:go-1.18.x"
+  - &xgo_version "go-1.18.x"
+  - &platforms_release "linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64,linux/ppc64le,linux/riscv64,linux/s390x,windows/amd64,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64"
+  - &platforms_server "linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,linux/riscv64"
+  - &platforms_preview "linux/arm/v6,linux/arm64/v8,linux/amd64,linux/riscv64,windows/amd64"
+  - &platforms_alpine "linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le"
 
 pipeline:
   vendor:
@@ -44,7 +44,7 @@ pipeline:
 
   publish-server-preview:
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     group: docker
     settings:
       repo: woodpeckerci/woodpecker-server
@@ -56,7 +56,7 @@ pipeline:
 
   publish-server-alpine-preview:
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     group: docker
     settings:
       repo: woodpeckerci/woodpecker-server
@@ -74,7 +74,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.multiarch
       platforms: *platforms_server
-      tag: [next, next-${CI_COMMIT_SHA:0:10}]
+      tag: [next, "next-${CI_COMMIT_SHA:0:10}"]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -82,12 +82,12 @@ pipeline:
   publish-next-server-alpine:
     image: woodpeckerci/plugin-docker-buildx
     group: docker
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.alpine.multiarch
       platforms: *platforms_alpine
-      tag: [next-alpine, next-${CI_COMMIT_SHA:0:10}-alpine]
+      tag: [next-alpine, "next-${CI_COMMIT_SHA:0:10}-alpine"]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -108,7 +108,7 @@ pipeline:
   publish-release-branch-server-alpine:
     image: woodpeckerci/plugin-docker-buildx
     group: docker
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.alpine.multiarch
@@ -134,7 +134,7 @@ pipeline:
   release-server-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-server
       dockerfile: docker/Dockerfile.server.alpine.multiarch
@@ -151,7 +151,7 @@ pipeline:
   publish-agent-preview:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.multiarch
@@ -168,7 +168,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.multiarch
       platforms: *platforms_release
-      tag: [next, next-${CI_COMMIT_SHA:0:10}]
+      tag: [next, "next-${CI_COMMIT_SHA:0:10}"]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -176,12 +176,12 @@ pipeline:
   publish-next-agent-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.alpine.multiarch
       platforms: *platforms_alpine
-      tag: [next-alpine, next-${CI_COMMIT_SHA:0:10}-alpine]
+      tag: [next-alpine, "next-${CI_COMMIT_SHA:0:10}-alpine"]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -202,7 +202,7 @@ pipeline:
   publish-release-branch-agent-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.alpine.multiarch
@@ -228,7 +228,7 @@ pipeline:
   release-agent-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-agent
       dockerfile: docker/Dockerfile.agent.alpine.multiarch
@@ -245,7 +245,7 @@ pipeline:
   publish-cli-preview:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.multiarch
@@ -262,7 +262,7 @@ pipeline:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.multiarch
       platforms: *platforms_release
-      tag: [next, next-${CI_COMMIT_SHA:0:10}]
+      tag: [next, "next-${CI_COMMIT_SHA:0:10}"]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -270,12 +270,12 @@ pipeline:
   publish-next-cli-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.alpine.multiarch
       platforms: *platforms_alpine
-      tag: [next-alpine, next-${CI_COMMIT_SHA:0:10}-alpine]
+      tag: [next-alpine, "next-${CI_COMMIT_SHA:0:10}-alpine"]
     when:
       branch: ${CI_REPO_DEFAULT_BRANCH}
       event: push
@@ -296,7 +296,7 @@ pipeline:
   publish-release-branch-cli-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.alpine.multiarch
@@ -322,7 +322,7 @@ pipeline:
   release-cli-alpine:
     group: docker
     image: woodpeckerci/plugin-docker-buildx
-    secrets: [ docker_username, docker_password ]
+    secrets: [docker_username, docker_password]
     settings:
       repo: woodpeckerci/woodpecker-cli
       dockerfile: docker/Dockerfile.cli.alpine.multiarch


### PR DESCRIPTION
Next image will have an additional tag of fomat `next-${truncated_commit_sha}`, where truncated_commit_sha is the first 10 characters of the commit sha (also, same for for the `next-alpine` image).