### PR TITLE
Add pipeline.step.when.branch string-array type to schema.json

### DIFF
--- a/pipeline/schema/schema.json
+++ b/pipeline/schema/schema.json
@@ -200,7 +200,18 @@
         },
         "branch": {
           "description": "TODO Read more: https://woodpecker-ci.org/docs/usage/pipeline-syntax#branch",
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minLength": 1
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "event": {
           "description": "TODO Read more: https://woodpecker-ci.org/docs/usage/pipeline-syntax#event",


### PR DESCRIPTION
Previously the schema only accepted string, this fixes #1379 and matches the linter to the existing capabilities of the constraints.go (and therefore server).