### PR TITLE
Support .yaml as file-ending for workflow config too

### DIFF
--- a/cli/common/pipeline.go
+++ b/cli/common/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/urfave/cli/v2"
+
 	"github.com/woodpecker-ci/woodpecker/shared/constant"
 )
 

--- a/cli/common/pipeline.go
+++ b/cli/common/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/urfave/cli/v2"
+	"github.com/woodpecker-ci/woodpecker/shared/constant"
 )
 
 func DetectPipelineConfig() (multiplies bool, config string, _ error) {
@@ -13,21 +14,12 @@ func DetectPipelineConfig() (multiplies bool, config string, _ error) {
 		return true, config, nil
 	}
 
-	config = ".woodpecker.yml"
-	if fi, err := os.Stat(config); err == nil && !fi.IsDir() {
-		return true, config, nil
+	for _, file := range constant.DefaultConfigFiles {
+		if fi, err := os.Stat(file); err == nil && !fi.IsDir() {
+			return true, config, nil
+		}
 	}
 
-	config = ".woodpecker.yaml"
-	if fi, err := os.Stat(config); err == nil && !fi.IsDir() {
-		return true, config, nil
-	}
-
-	config = ".drone.yml"
-	fi, err := os.Stat(config)
-	if err == nil && !fi.IsDir() {
-		return false, config, nil
-	}
 	return false, "", fmt.Errorf("could not detect pipeline config")
 }
 

--- a/cli/common/pipeline.go
+++ b/cli/common/pipeline.go
@@ -18,6 +18,11 @@ func DetectPipelineConfig() (multiplies bool, config string, _ error) {
 		return true, config, nil
 	}
 
+	config = ".woodpecker.yaml"
+	if fi, err := os.Stat(config); err == nil && !fi.IsDir() {
+		return true, config, nil
+	}
+
 	config = ".drone.yml"
 	fi, err := os.Stat(config)
 	if err == nil && !fi.IsDir() {

--- a/cli/common/pipeline.go
+++ b/cli/common/pipeline.go
@@ -3,21 +3,20 @@ package common
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 
 	"github.com/woodpecker-ci/woodpecker/shared/constant"
 )
 
-func DetectPipelineConfig() (multiplies bool, config string, _ error) {
-	config = ".woodpecker"
-	if fi, err := os.Stat(config); err == nil && fi.IsDir() {
-		return true, config, nil
-	}
+func DetectPipelineConfig() (isDir bool, config string, _ error) {
+	for _, config := range constant.DefaultConfigOrder {
+		shouldBeDir := strings.HasSuffix(config, "/")
+		config = strings.TrimSuffix(config, "/")
 
-	for _, file := range constant.DefaultConfigFiles {
-		if fi, err := os.Stat(file); err == nil && !fi.IsDir() {
-			return true, config, nil
+		if fi, err := os.Stat(config); err == nil && shouldBeDir == fi.IsDir() {
+			return fi.IsDir(), config, nil
 		}
 	}
 

--- a/docs/docs/20-usage/25-multi-pipeline.md
+++ b/docs/docs/20-usage/25-multi-pipeline.md
@@ -6,7 +6,7 @@ This Feature is only available for GitHub, Gitea & GitLab repositories. Follow [
 
 By default, Woodpecker looks for the pipeline definition in `.woodpecker.yml` in the project root.
 
-The Multi-Pipeline feature allows the pipeline to be split into several files and placed in the `.woodpecker/` folder. Only `.yml` files will be used and files in any subfolders like `.woodpecker/sub-folder/test.yml` will be ignored. You can set some custom path like `.my-ci/pipelines/` instead of `.woodpecker/` in the [project settings](./71-project-settings.md).
+The Multi-Pipeline feature allows the pipeline to be split into several files and placed in the `.woodpecker/` folder. Only `.yml` and `.yaml` files will be used and files in any subfolders like `.woodpecker/sub-folder/test.yml` will be ignored. You can set some custom path like `.my-ci/pipelines/` instead of `.woodpecker/` in the [project settings](./71-project-settings.md).
 
 ## Rational
 
@@ -90,7 +90,7 @@ The pipelines run in parallel on separate agents and share nothing.
 
 Dependencies between pipelines can be set with the `depends_on` element. A pipeline doesn't execute until all of its dependencies finished successfully.
 
-The name for a `depends_on` entry is the filename without the path, leading dots and without the file extension `.yml`. If the project config for example uses `.woodpecker/` as path for CI files with a file named `.woodpecker/.lint.yml` the corresponding `depends_on` entry would be `lint`.
+The name for a `depends_on` entry is the filename without the path, leading dots and without the file extension `.yml` or `.yaml`. If the project config for example uses `.woodpecker/` as path for CI files with a file named `.woodpecker/.lint.yml` the corresponding `depends_on` entry would be `lint`.
 
 ```diff
 pipeline:

--- a/docs/docs/20-usage/71-project-settings.md
+++ b/docs/docs/20-usage/71-project-settings.md
@@ -6,7 +6,7 @@ As the owner of a project in Woodpecker you can change project related settings 
 
 ## Pipeline path
 
-The path to the pipeline config file or folder. By default it is left empty which will use the following configuration resolution `.woodpecker/*.yml` -> `.woodpecker.yml` -> `.drone.yml`. If you set a custom path Woodpecker tries to load your configuration or fails if no configuration could be found at the specified location. To use a [multi pipeline](./25-multi-pipeline.md) you have to change it to a folder path ending with a `/` like `.woodpecker/`.
+The path to the pipeline config file or folder. By default it is left empty which will use the following configuration resolution `.woodpecker/*.yml` and `.woodpecker/*.yaml` (without any preference in handling them) -> `.woodpecker.yml` -> `.woodpecker.yaml` -> `.drone.yml`. If you set a custom path Woodpecker tries to load your configuration or fails if no configuration could be found at the specified location. To use a [multi pipeline](./25-multi-pipeline.md) you have to change it to a folder path ending with a `/` like `.woodpecker/`.
 
 ## Repository hooks
 

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -13,7 +13,7 @@ Some versions need some changes to the server configuration or the pipeline conf
 - Updated Prometheus gauge `build_*` to `pipeline_*`
 - Updated Prometheus gauge `*_job_*` to `*_step_*`
 - Renamed config env `WOODPECKER_MAX_PROCS` to `WOODPECKER_MAX_WORKFLOWS` (still available as fallback)
-- The pipelines are now also read from `.yaml` files, the new default order is `.woodpecker/*.yml` and `.woodpecker/*.yaml` (without any prioritization) -> `.woodpecker.yml` ->  `.woodpecker.yml` -> `.drone.yml`
+- The pipelines are now also read from `.yaml` files, the new default order is `.woodpecker/*.yml` and `.woodpecker/*.yaml` (without any prioritization) -> `.woodpecker.yml` ->  `.woodpecker.yaml` -> `.drone.yml`
 
 ## 0.15.0
 

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -13,6 +13,7 @@ Some versions need some changes to the server configuration or the pipeline conf
 - Updated Prometheus gauge `build_*` to `pipeline_*`
 - Updated Prometheus gauge `*_job_*` to `*_step_*`
 - Renamed config env `WOODPECKER_MAX_PROCS` to `WOODPECKER_MAX_WORKFLOWS` (still available as fallback)
+- The pipelines are now also read from `.yaml` files, the new default order is `.woodpecker/*.yml` and `.woodpecker/*.yaml` (without ani prioritization) -> `.woodpecker.yml` ->  `.woodpecker.yml` -> `.drone.yml`
 
 ## 0.15.0
 

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -13,7 +13,7 @@ Some versions need some changes to the server configuration or the pipeline conf
 - Updated Prometheus gauge `build_*` to `pipeline_*`
 - Updated Prometheus gauge `*_job_*` to `*_step_*`
 - Renamed config env `WOODPECKER_MAX_PROCS` to `WOODPECKER_MAX_WORKFLOWS` (still available as fallback)
-- The pipelines are now also read from `.yaml` files, the new default order is `.woodpecker/*.yml` and `.woodpecker/*.yaml` (without ani prioritization) -> `.woodpecker.yml` ->  `.woodpecker.yml` -> `.drone.yml`
+- The pipelines are now also read from `.yaml` files, the new default order is `.woodpecker/*.yml` and `.woodpecker/*.yaml` (without any prioritization) -> `.woodpecker.yml` ->  `.woodpecker.yml` -> `.drone.yml`
 
 ## 0.15.0
 

--- a/server/shared/configFetcher.go
+++ b/server/shared/configFetcher.go
@@ -112,7 +112,7 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 
 	log.Trace().Msgf("ConfigFetch[%s]: user did not defined own config, following default procedure", cf.repo.FullName)
 	// for the order see shared/constants/constants.go
-	fileMeta, err := cf.getFirstAvailableConfig(ctx, constant.DefaultConfigFiles[:], false)
+	fileMeta, err := cf.getFirstAvailableConfig(ctx, constant.DefaultConfigOrder[:], false)
 	if err == nil {
 		return fileMeta, err
 	}

--- a/server/shared/configFetcher.go
+++ b/server/shared/configFetcher.go
@@ -91,7 +91,6 @@ func (cf *configFetcher) Fetch(ctx context.Context) (files []*remote.FileMeta, e
 }
 
 // fetch config by timeout
-// TODO: deduplicate code
 func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config string) ([]*remote.FileMeta, error) {
 	ctx, cancel := context.WithTimeout(c, timeout)
 	defer cancel()
@@ -100,13 +99,8 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 		log.Trace().Msgf("ConfigFetch[%s]: use user config '%s'", cf.repo.FullName, config)
 		// either a file
 		if !strings.HasSuffix(config, "/") {
-			file, err := cf.remote.File(ctx, cf.user, cf.repo, cf.pipeline, config)
-			if err == nil && len(file) != 0 {
-				log.Trace().Msgf("ConfigFetch[%s]: found file '%s'", cf.repo.FullName, config)
-				return []*remote.FileMeta{{
-					Name: config,
-					Data: file,
-				}}, nil
+			if fileMeta, found := cf.checkPipelineFile(ctx, config); found {
+				return fileMeta, nil
 			}
 		}
 
@@ -117,11 +111,11 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 			return filterPipelineFiles(files), nil
 		}
 
-		return nil, fmt.Errorf("config '%s' not found: %s", config, err)
+		return nil, fmt.Errorf("user defined config '%s' not found: %s", config, err)
 	}
 
 	log.Trace().Msgf("ConfigFetch[%s]: user did not defined own config follow default procedure", cf.repo.FullName)
-	// no user defined config so try .woodpecker/*.yml -> .woodpecker.yml -> .drone.yml
+	// no user defined config so try .woodpecker/*.(yml|yaml)  -> .woodpecker.yml -> .woodpecker.yaml -> .drone.yml
 
 	// test .woodpecker/ folder
 	// if folder is not supported we will get a "Not implemented" error and continue
@@ -134,30 +128,25 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 	}
 
 	config = ".woodpecker.yml"
-	file, err := cf.remote.File(ctx, cf.user, cf.repo, cf.pipeline, config)
-	if err == nil && len(file) != 0 {
-		log.Trace().Msgf("ConfigFetch[%s]: found file '%s'", cf.repo.FullName, config)
-		return []*remote.FileMeta{{
-			Name: config,
-			Data: file,
-		}}, nil
+	if fileMeta, found := cf.checkPipelineFile(ctx, config); found {
+		return fileMeta, nil
+	}
+
+	config = ".woodpecker.yaml"
+	if fileMeta, found := cf.checkPipelineFile(ctx, config); found {
+		return fileMeta, nil
 	}
 
 	config = ".drone.yml"
-	file, err = cf.remote.File(ctx, cf.user, cf.repo, cf.pipeline, config)
-	if err == nil && len(file) != 0 {
-		log.Trace().Msgf("ConfigFetch[%s]: found file '%s'", cf.repo.FullName, config)
-		return []*remote.FileMeta{{
-			Name: config,
-			Data: file,
-		}}, nil
+	if fileMeta, found := cf.checkPipelineFile(ctx, config); found {
+		return fileMeta, nil
 	}
 
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
-		return []*remote.FileMeta{}, fmt.Errorf("ConfigFetcher: Fallback did not found config: %s", err)
+		return []*remote.FileMeta{}, fmt.Errorf("ConfigFetcher: Fallback did not find config: %s", err)
 	}
 }
 
@@ -165,10 +154,25 @@ func filterPipelineFiles(files []*remote.FileMeta) []*remote.FileMeta {
 	var res []*remote.FileMeta
 
 	for _, file := range files {
-		if strings.HasSuffix(file.Name, ".yml") {
+		if strings.HasSuffix(file.Name, ".yml") || strings.HasSuffix(file.Name, ".yaml") {
 			res = append(res, file)
 		}
 	}
 
 	return res
+}
+
+func (cf *configFetcher) checkPipelineFile(c context.Context, config string) (fileMeta []*remote.FileMeta, found bool) {
+	file, err := cf.remote.File(c, cf.user, cf.repo, cf.pipeline, config)
+
+	if err == nil && len(file) != 0 {
+		log.Trace().Msgf("ConfigFetch[%s]: found file '%s'", cf.repo.FullName, config)
+
+		return []*remote.FileMeta{{
+			Name: config,
+			Data: file,
+		}}, true
+	}
+
+	return nil, false
 }

--- a/server/shared/configFetcher.go
+++ b/server/shared/configFetcher.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/remote"
+	"github.com/woodpecker-ci/woodpecker/shared/constant"
 )
 
 type ConfigFetcher interface {
@@ -127,19 +128,10 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 		return files, nil
 	}
 
-	config = ".woodpecker.yml"
-	if fileMeta, found := cf.checkPipelineFile(ctx, config); found {
-		return fileMeta, nil
-	}
-
-	config = ".woodpecker.yaml"
-	if fileMeta, found := cf.checkPipelineFile(ctx, config); found {
-		return fileMeta, nil
-	}
-
-	config = ".drone.yml"
-	if fileMeta, found := cf.checkPipelineFile(ctx, config); found {
-		return fileMeta, nil
+	for _, file := range constant.DefaultConfigFiles {
+		if fileMeta, found := cf.checkPipelineFile(ctx, file); found {
+			return fileMeta, nil
+		}
 	}
 
 	select {

--- a/server/shared/configFetcher_test.go
+++ b/server/shared/configFetcher_test.go
@@ -75,6 +75,61 @@ func TestFetch(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:       "Default config with .yaml - .woodpecker/",
+			repoConfig: "",
+			files: []file{{
+				name: ".woodpecker/text.txt",
+				data: dummyData,
+			}, {
+				name: ".woodpecker/release.yaml",
+				data: dummyData,
+			}, {
+				name: ".woodpecker/image.png",
+				data: dummyData,
+			}},
+			expectedFileNames: []string{
+				".woodpecker/release.yaml",
+			},
+			expectedError: false,
+		},
+		{
+			name:       "Default config with .yaml, .yml mix - .woodpecker/",
+			repoConfig: "",
+			files: []file{{
+				name: ".woodpecker/text.txt",
+				data: dummyData,
+			}, {
+				name: ".woodpecker/release.yaml",
+				data: dummyData,
+			}, {
+				name: ".woodpecker/other.yml",
+				data: dummyData,
+			}, {
+				name: ".woodpecker/image.png",
+				data: dummyData,
+			}},
+			expectedFileNames: []string{
+				".woodpecker/release.yaml",
+				".woodpecker/other.yml",
+			},
+			expectedError: false,
+		},
+		{
+			name:       "Default config check .woodpecker.yml before .woodpecker.yaml",
+			repoConfig: "",
+			files: []file{{
+				name: ".woodpecker.yaml",
+				data: dummyData,
+			}, {
+				name: ".woodpecker.yml",
+				data: dummyData,
+			}},
+			expectedFileNames: []string{
+				".woodpecker.yml",
+			},
+			expectedError: false,
+		},
+		{
 			name:       "Override via API with custom config",
 			repoConfig: "",
 			files: []file{{

--- a/server/shared/stepBuilder.go
+++ b/server/shared/stepBuilder.go
@@ -400,6 +400,7 @@ func metadataPipelineFromModelPipeline(pipeline *model.Pipeline, includeParent b
 func SanitizePath(path string) string {
 	path = filepath.Base(path)
 	path = strings.TrimSuffix(path, ".yml")
+	path = strings.TrimSuffix(path, ".yaml")
 	path = strings.TrimPrefix(path, ".")
 	return path
 }

--- a/server/shared/stepBuilder_test.go
+++ b/server/shared/stepBuilder_test.go
@@ -568,6 +568,18 @@ func TestSanitizePath(t *testing.T) {
 			path:          "folder/sub-folder/test.yml",
 			sanitizedPath: "test",
 		},
+		{
+			path:          ".woodpecker/test.yaml",
+			sanitizedPath: "test",
+		},
+		{
+			path:          ".woodpecker.yaml",
+			sanitizedPath: "woodpecker",
+		},
+		{
+			path:          "folder/sub-folder/test.yaml",
+			sanitizedPath: "test",
+		},
 	}
 
 	for _, test := range testTable {

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -22,8 +22,9 @@ var PrivilegedPlugins = []string{
 	"woodpeckerci/plugin-docker-buildx",
 }
 
-// folders may be added by supplying a trailing /
-var DefaultConfigFiles = [...]string{
+// DefaultConfigOrder represent the priority in witch woodpecker serarch for a pipeline config by default
+// folders are indicated by supplying a trailing /
+var DefaultConfigOrder = [...]string{
 	".woodpecker/",
 	".woodpecker.yml",
 	".woodpecker.yaml",

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -22,6 +22,12 @@ var PrivilegedPlugins = []string{
 	"woodpeckerci/plugin-docker-buildx",
 }
 
+var DefaultConfigFiles = [...]string{
+	".woodpecker.yml",
+	".woodpecker.yaml",
+	".drone.yml",
+}
+
 const (
 	DefaultCloneImage = "docker.io/woodpeckerci/plugin-git:v1.6.0"
 )

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -22,7 +22,9 @@ var PrivilegedPlugins = []string{
 	"woodpeckerci/plugin-docker-buildx",
 }
 
+// folders may be added by supplying a trailing /
 var DefaultConfigFiles = [...]string{
+	".woodpecker/",
 	".woodpecker.yml",
 	".woodpecker.yaml",
 	".drone.yml",


### PR DESCRIPTION
This implements #1073, adds .yaml to the accepted endings for woodpecker configs.

This currently adds some more lines to the duplication (tried to compensate by fixing the other duplication in the configFetcher) as the CLI and Server are still separate.

# ToDos

- [x] Add documentation
- [x] Add possibly more testing ~(currently just testing the path sanitization)~ Done do we need more?
- [x] ~Add option to disable the .yaml variant (is this really needed for next)~ -> we are only breaking in edge-cases so in accordance with the chat between @6543 and me this should be fine without
- [x] Decide whether default reading .yaml is breaking (else we might just skip the conditional) -> see above
- [x] ~Add a backport with a default off addition of .yaml~ -> only backporting bugfixes, etc. I'll do it if needed, but that will be a less invasive change