### PR TITLE
Fix `local` and `ssh` backends

### DIFF
--- a/pipeline/backend/local/local.go
+++ b/pipeline/backend/local/local.go
@@ -16,6 +16,7 @@ package local
 
 import (
 	"context"
+	"encoding/base64"
 	"io"
 	"os"
 	"os/exec"
@@ -69,7 +70,7 @@ func (e *local) Exec(ctx context.Context, step *types.Step) error {
 		}
 	}
 
-	command := []string{}
+	var command []string
 	if step.Image == constant.DefaultCloneImage {
 		// Default clone step
 		env = append(env, "CI_WORKSPACE="+e.workingdir+"/"+step.Environment["CI_REPO"])
@@ -80,9 +81,10 @@ func (e *local) Exec(ctx context.Context, step *types.Step) error {
 		command = append(command, "-c")
 
 		// TODO: use commands directly
-		script := common.GenerateScript(step.Commands)
+		script, _ := base64.StdEncoding.DecodeString(common.GenerateScript(step.Commands))
+		scriptStr := string(script)
 		// Deleting the initial lines removes netrc support but adds compatibility for more shells like fish
-		command = append(command, string(script)[strings.Index(string(script), "\n\n")+2:])
+		command = append(command, scriptStr[strings.Index(scriptStr, "\n\n")+2:])
 	}
 
 	// Prepare command

--- a/pipeline/backend/ssh/ssh.go
+++ b/pipeline/backend/ssh/ssh.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -108,9 +109,10 @@ func (e *ssh) Exec(ctx context.Context, step *types.Step) error {
 		command = append(command, "-c")
 
 		// TODO: use commands directly
-		script := common.GenerateScript(step.Commands)
+		script, _ := base64.StdEncoding.DecodeString(common.GenerateScript(step.Commands))
+		scriptStr := string(script)
 		// Deleting the initial lines removes netrc support but adds compatibility for more shells like fish
-		command = append(command, "cd "+e.workingdir+"/"+step.Environment["CI_REPO"]+" && "+string(script)[strings.Index(string(script), "\n\n")+2:])
+		command = append(command, "cd "+e.workingdir+"/"+step.Environment["CI_REPO"]+" && "+scriptStr[strings.Index(scriptStr, "\n\n")+2:])
 	}
 
 	// Prepare command


### PR DESCRIPTION
Base64-encoded string was not decoded.