### PR TITLE
Dedup pipeline compile code and unwind dependency issues

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -91,6 +91,7 @@ func runExec(c *cli.Context, file, repoPath string) error {
 		return err
 	}
 
+	// use pipeline.StepBuilder
 	axes, err := matrix.ParseString(string(dat))
 	if err != nil {
 		return fmt.Errorf("Parse matrix fail")
@@ -166,6 +167,7 @@ func execWithAxis(c *cli.Context, file, repoPath string, axis matrix.Axis) error
 	}
 
 	// lint the yaml file
+	// TODO: trusted = flag
 	if lerr := linter.New(linter.WithTrusted(true)).Lint(conf); lerr != nil {
 		return lerr
 	}

--- a/docs/docs/92-development/05-architecture.md
+++ b/docs/docs/92-development/05-architecture.md
@@ -8,13 +8,14 @@
 
 ### main package hierarchy
 
-| package    | meaning                                                      | imports
-|------------|--------------------------------------------------------------|----------
-| `cmd/**`   | parse command-line args & environment to stat server/cli/agent | all other
-| `agent/**` | code only agent (remote worker) will need                    | `pipeline`, `shared`
-| `cli/**`   | code only cli tool does need                                 | `pipeline`, `shared`, `woodpecker-go`
-| `server/**`| code only server will need                                   | `pipeline`, `shared`
-| `shared/**`| code shared for all three main tools (go help utils)         | only std and external libs
+| package       | meaning                                                      | imports
+|---------------|--------------------------------------------------------------|----------
+| `cmd/**`      | parse command-line args & environment to stat server/cli/agent | all other
+| `agent/**`    | code only agent (remote worker) will need                    | `pipeline`, `shared`
+| `cli/**`      | code only cli tool does need                                 | `pipeline`, `shared`, `woodpecker-go`
+| `pipeline/**` | code to parse, compile and run pipelines                     |  pipeline backend libs
+| `server/**`   | code only server will need                                   | `pipeline`, `shared`
+| `shared/**`   | code shared for all three main tools (go help utils)         | only std and external libs
 | `woodpecker-go/**` | go client for server rest api                        | std
 
 ### Server

--- a/pipeline/stepBuilder_test.go
+++ b/pipeline/stepBuilder_test.go
@@ -26,7 +26,7 @@ import (
 func TestGlobalEnvsubst(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Envs: map[string]string{
 			"KEY_K": "VALUE_V",
 			"IMAGE": "scratch",
@@ -60,7 +60,7 @@ pipeline:
 func TestMissingGlobalEnvsubst(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Envs: map[string]string{
 			"KEY_K":    "VALUE_V",
 			"NO_IMAGE": "scratch",
@@ -94,7 +94,7 @@ pipeline:
 func TestMultilineEnvsubst(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo: &model.Repo{},
 		Curr: &model.Pipeline{
 			Message: `aaa
@@ -131,7 +131,7 @@ pipeline:
 func TestMultiPipeline(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  &model.Pipeline{},
 		Last:  &model.Pipeline{},
@@ -165,7 +165,7 @@ pipeline:
 func TestDependsOn(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  &model.Pipeline{},
 		Last:  &model.Pipeline{},
@@ -211,7 +211,7 @@ depends_on:
 func TestRunsOn(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  &model.Pipeline{},
 		Last:  &model.Pipeline{},
@@ -247,7 +247,7 @@ runs_on:
 func TestPipelineName(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{Config: ".woodpecker"},
 		Curr:  &model.Pipeline{},
 		Last:  &model.Pipeline{},
@@ -282,7 +282,7 @@ pipeline:
 func TestBranchFilter(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  &model.Pipeline{Branch: "dev"},
 		Last:  &model.Pipeline{},
@@ -328,7 +328,7 @@ pipeline:
 func TestRootWhenFilter(t *testing.T) {
 	t.Parallel()
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  &model.Pipeline{Event: "tester"},
 		Last:  &model.Pipeline{},
@@ -376,7 +376,7 @@ func TestZeroSteps(t *testing.T) {
 
 	pipeline := &model.Pipeline{Branch: "dev"}
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  pipeline,
 		Last:  &model.Pipeline{},
@@ -410,7 +410,7 @@ func TestZeroStepsAsMultiPipelineDeps(t *testing.T) {
 
 	pipeline := &model.Pipeline{Branch: "dev"}
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  pipeline,
 		Last:  &model.Pipeline{},
@@ -458,7 +458,7 @@ func TestZeroStepsAsMultiPipelineTransitiveDeps(t *testing.T) {
 
 	pipeline := &model.Pipeline{Branch: "dev"}
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  pipeline,
 		Last:  &model.Pipeline{},
@@ -514,7 +514,7 @@ func TestTree(t *testing.T) {
 		Event: model.EventPush,
 	}
 
-	b := StepBuilder{
+	b := stepBuilder{
 		Repo:  &model.Repo{},
 		Curr:  pipeline,
 		Last:  &model.Pipeline{},

--- a/server/pipeline/filter.go
+++ b/server/pipeline/filter.go
@@ -27,16 +27,12 @@ import (
 )
 
 func zeroSteps(currentPipeline *model.Pipeline, forgeYamlConfigs []*forge_types.FileMeta) bool {
-	b := pipeline.StepBuilder{
-		Repo:  &model.Repo{},
-		Curr:  currentPipeline,
-		Last:  &model.Pipeline{},
-		Netrc: &model.Netrc{},
-		Secs:  []*model.Secret{},
-		Regs:  []*model.Registry{},
-		Link:  "",
-		Yamls: forgeYamlConfigs,
-	}
+	b := pipeline.NewStepBuilder(&model.Repo{}, currentPipeline, &model.Pipeline{},
+		&model.Netrc{}, []*model.Secret{}, []*model.Registry{},
+		"",
+		forgeYamlConfigs,
+		make(map[string]string),
+	)
 
 	pipelineItems, err := b.Build()
 	if err != nil {

--- a/server/pipeline/items.go
+++ b/server/pipeline/items.go
@@ -67,17 +67,12 @@ func createPipelineItems(ctx context.Context, store store.Store,
 		envs[k] = v
 	}
 
-	b := pipeline.StepBuilder{
-		Repo:  repo,
-		Curr:  currentPipeline,
-		Last:  last,
-		Netrc: netrc,
-		Secs:  secs,
-		Regs:  regs,
-		Envs:  envs,
-		Link:  server.Config.Server.Host,
-		Yamls: yamls,
-	}
+	b := pipeline.NewStepBuilder(repo, currentPipeline, last,
+		netrc, secs, regs,
+		server.Config.Server.Host,
+		yamls,
+		envs)
+
 	pipelineItems, err := b.Build()
 	if err != nil {
 		currentPipeline, uerr := UpdateToStatusError(store, *currentPipeline, err)
@@ -87,7 +82,7 @@ func createPipelineItems(ctx context.Context, store store.Store,
 		return currentPipeline, nil, err
 	}
 
-	currentPipeline = pipeline.SetPipelineStepsOnPipeline(b.Curr, pipelineItems)
+	currentPipeline = pipeline.SetPipelineStepsOnPipeline(b.CurrentPipeline(), pipelineItems)
 
 	return currentPipeline, pipelineItems, nil
 }


### PR DESCRIPTION
currently pipeline/* do depend on server/* (mostly models)