### PR TITLE
Fix usage text of cli sub-command 'cron'

### DIFF
--- a/cli/cron/cron_add.go
+++ b/cli/cron/cron_add.go
@@ -13,7 +13,7 @@ import (
 
 var cronCreateCmd = &cli.Command{
 	Name:      "add",
-	Usage:     "adds a cron",
+	Usage:     "add a cron job",
 	ArgsUsage: "[repo/name]",
 	Action:    cronCreate,
 	Flags: append(common.GlobalFlags,

--- a/cli/cron/cron_info.go
+++ b/cli/cron/cron_info.go
@@ -12,7 +12,7 @@ import (
 
 var cronInfoCmd = &cli.Command{
 	Name:      "info",
-	Usage:     "display cron info",
+	Usage:     "display info about a cron job",
 	ArgsUsage: "[repo/name]",
 	Action:    cronInfo,
 	Flags: append(common.GlobalFlags,

--- a/cli/cron/cron_list.go
+++ b/cli/cron/cron_list.go
@@ -26,7 +26,7 @@ import (
 
 var cronListCmd = &cli.Command{
 	Name:      "ls",
-	Usage:     "list registries",
+	Usage:     "list cron jobs",
 	ArgsUsage: "[repo/name]",
 	Action:    cronList,
 	Flags: append(common.GlobalFlags,

--- a/cli/cron/cron_rm.go
+++ b/cli/cron/cron_rm.go
@@ -11,7 +11,7 @@ import (
 
 var cronDeleteCmd = &cli.Command{
 	Name:      "rm",
-	Usage:     "remove a cron",
+	Usage:     "remove a cron job",
 	ArgsUsage: "[repo/name]",
 	Action:    cronDelete,
 	Flags: append(common.GlobalFlags,

--- a/cli/cron/cron_update.go
+++ b/cli/cron/cron_update.go
@@ -13,7 +13,7 @@ import (
 
 var cronUpdateCmd = &cli.Command{
 	Name:      "update",
-	Usage:     "update a cron",
+	Usage:     "update a cron job",
 	ArgsUsage: "[repo/name]",
 	Action:    cronUpdate,
 	Flags: append(common.GlobalFlags,


### PR DESCRIPTION
This PR provides some better usage texts for the woodpecker-cli sub-command `cron` and fixes a false text in the usage description for `woodpecker-cli cron ls --help` 