### PR TITLE
add support for DRONE_COMMIT_SHA alias

### DIFF
--- a/pipeline/frontend/drone_compatibility.go
+++ b/pipeline/frontend/drone_compatibility.go
@@ -33,6 +33,7 @@ func (m *Metadata) setDroneEnviron(env map[string]string) {
 	env["DRONE_BUILD_FINISHED"] = env["CI_PIPELINE_FINISHED"]
 	// commit
 	env["DRONE_COMMIT"] = env["CI_COMMIT_SHA"]
+	env["DRONE_COMMIT_SHA"] = env["CI_COMMIT_SHA"]
 	env["DRONE_COMMIT_BEFORE"] = env["CI_PREV_COMMIT_SHA"]
 	env["DRONE_COMMIT_REF"] = env["CI_COMMIT_REF"]
 	env["DRONE_COMMIT_BRANCH"] = env["CI_COMMIT_BRANCH"]


### PR DESCRIPTION
[The docker plugin uses](https://github.com/woodpecker-ci/plugin-docker/blob/d0e7d7f01ba6f2029b37394b436a5dc9ed7a01aa/cmd/drone-docker/main.go#L43) the `DRONE_COMMIT_SHA` variant. According to [drone reference](https://docs.drone.io/pipeline/environment/reference/) doc, `DRONE_COMMIT_SHA` and `DRONE_COMMIT` are the same thing (although the default value in the docker plugin suggests the 8-char short form).