### PR TITLE
Refresh token when running cron

### DIFF
--- a/server/cron/cron.go
+++ b/server/cron/cron.go
@@ -22,6 +22,7 @@ import (
 	"github.com/robfig/cron"
 	"github.com/rs/zerolog/log"
 
+	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/forge"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/pipeline"
@@ -105,7 +106,7 @@ func runCron(store store.Store, forge forge.Forge, cron *model.Cron, now time.Ti
 	return err
 }
 
-func CreatePipeline(ctx context.Context, store store.Store, forge forge.Forge, cron *model.Cron) (*model.Repo, *model.Pipeline, error) {
+func CreatePipeline(ctx context.Context, store store.Store, f forge.Forge, cron *model.Cron) (*model.Repo, *model.Pipeline, error) {
 	repo, err := store.GetRepo(cron.RepoID)
 	if err != nil {
 		return nil, nil, err
@@ -121,7 +122,23 @@ func CreatePipeline(ctx context.Context, store store.Store, forge forge.Forge, c
 		return nil, nil, err
 	}
 
-	commit, err := forge.BranchHead(ctx, creator, repo, cron.Branch)
+	// if the forge has a refresh token, the current access token
+	// may be stale. Therefore, we should refresh prior to dispatching
+	// the pipeline.
+	if refresher, ok := server.Config.Services.Forge.(forge.Refresher); ok {
+		refreshed, err := refresher.Refresh(ctx, creator)
+		log.Debug().Msgf("token refreshed: %s", refreshed)
+		if err != nil {
+			log.Error().Err(err).Msgf("failed to refresh oauth2 token for creator: %s", creator.Login)
+		} else if refreshed {
+			if err := store.UpdateUser(creator); err != nil {
+				log.Error().Err(err).Msgf("error while updating creator: %s", creator.Login)
+				// move forward
+			}
+		}
+	}
+
+	commit, err := f.BranchHead(ctx, creator, repo, cron.Branch)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/cron/cron.go
+++ b/server/cron/cron.go
@@ -126,7 +126,7 @@ func CreatePipeline(ctx context.Context, store store.Store, f forge.Forge, cron 
 	// the pipeline.
 	if refresher, ok := f.(forge.Refresher); ok {
 		refreshed, err := refresher.Refresh(ctx, creator)
-		log.Debug().Msgf("token refreshed: %s", refreshed)
+		log.Debug().Msgf("token refreshed: %t", refreshed)
 		if err != nil {
 			log.Error().Err(err).Msgf("failed to refresh oauth2 token for creator: %s", creator.Login)
 		} else if refreshed {

--- a/server/cron/cron.go
+++ b/server/cron/cron.go
@@ -22,7 +22,6 @@ import (
 	"github.com/robfig/cron"
 	"github.com/rs/zerolog/log"
 
-	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/forge"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 	"github.com/woodpecker-ci/woodpecker/server/pipeline"
@@ -125,7 +124,7 @@ func CreatePipeline(ctx context.Context, store store.Store, f forge.Forge, cron 
 	// if the forge has a refresh token, the current access token
 	// may be stale. Therefore, we should refresh prior to dispatching
 	// the pipeline.
-	if refresher, ok := server.Config.Services.Forge.(forge.Refresher); ok {
+	if refresher, ok := f.(forge.Refresher); ok {
 		refreshed, err := refresher.Refresh(ctx, creator)
 		log.Debug().Msgf("token refreshed: %s", refreshed)
 		if err != nil {


### PR DESCRIPTION
Before accessing a repo during a cron job the users token is refreshed like it is done for e.g. create pipeline. User in this context means the creator of the cron job.

fixes #1431

If the scheduled delay between two executions of a cron job is larger than the exiration time of the oauth2 refresh token (provided by the forge) this will fail and the cron job will not be run. But this is the best one can do.