### PR TITLE
Add a sentence regarding translations to the development docs (UI page)

### DIFF
--- a/docs/docs/92-development/03-ui.md
+++ b/docs/docs/92-development/03-ui.md
@@ -29,3 +29,10 @@ The following list contains some tools and frameworks used by the Woodpecker UI.
 - [eslint](https://eslint.org/)
 - [Volar & vue-tsc](https://github.com/johnsoncodehk/volar/) for type-checking in .vue file
   - use the take-over mode of Volar as described by [this guide](https://github.com/johnsoncodehk/volar/discussions/471)
+
+## Messages and Translations
+
+Woodpecker uses [Vue I18n](https://vue-i18n.intlify.dev/) as translation library. New message keys
+must be added at least to `web/src/assets/locales/en.json` otherwise they will be removed by weblate (a transaltion service) and everyone expects to translate from English to other languages
+
+For more information about transaltions see [Translations](./07-translations.md).

--- a/docs/docs/92-development/03-ui.md
+++ b/docs/docs/92-development/03-ui.md
@@ -32,7 +32,7 @@ The following list contains some tools and frameworks used by the Woodpecker UI.
 
 ## Messages and Translations
 
-Woodpecker uses [Vue I18n](https://vue-i18n.intlify.dev/) as translation library. New message keys
-must be added at least to `web/src/assets/locales/en.json` otherwise they will be removed by weblate (a transaltion service) and everyone expects to translate from English to other languages
+Woodpecker uses [Vue I18n](https://vue-i18n.intlify.dev/) as translation library.  New translations have to be added to `web/src/assets/locales/en.json`. The English source file will be automatically imported into [Weblate](https://translate.woodpecker-ci.org/) (the translation system used by Woodpecker) where all other languages will be translated by the community based on the English source.  
+You must not provide translations except English in PRs, otherwise weblate could put git into conflicts (when someone has translated in that language file and changes are not into master branch yet)
 
 For more information about transaltions see [Translations](./07-translations.md).

--- a/docs/docs/92-development/03-ui.md
+++ b/docs/docs/92-development/03-ui.md
@@ -35,4 +35,4 @@ The following list contains some tools and frameworks used by the Woodpecker UI.
 Woodpecker uses [Vue I18n](https://vue-i18n.intlify.dev/) as translation library.  New translations have to be added to `web/src/assets/locales/en.json`. The English source file will be automatically imported into [Weblate](https://translate.woodpecker-ci.org/) (the translation system used by Woodpecker) where all other languages will be translated by the community based on the English source.  
 You must not provide translations except English in PRs, otherwise weblate could put git into conflicts (when someone has translated in that language file and changes are not into master branch yet)
 
-For more information about transaltions see [Translations](./07-translations.md).
+For more information about translations see [Translations](./07-translations.md).


### PR DESCRIPTION
Make obvious, that at least an english message key has to be added to the message files

**Not covered:**
What is not clear to me is how weblate relates to branches i.e. the next branch.  And a link to https://translate.woodpecker-ci.org/engage/woodpecker-ci/ is missing on the Development/Translation page.
Is this intentional or an omission?
