### PR TITLE
Allow adding additional labels/annotations to kubernetes worker pods

### DIFF
--- a/charts/woodpecker-agent/values.yaml
+++ b/charts/woodpecker-agent/values.yaml
@@ -14,6 +14,8 @@ env:
   WOODPECKER_BACKEND_K8S_STORAGE_CLASS: ""
   WOODPECKER_BACKEND_K8S_VOLUME_SIZE: 10G
   WOODPECKER_BACKEND_K8S_STORAGE_RWX: true
+  WOODPECKER_BACKEND_K8S_POD_LABELS: ""
+  WOODPECKER_BACKEND_K8S_POD_ANNOTATIONS: ""
 
 # Docker-in-Docker is normally not needed as Woodpecker natively supports Kubernetes
 dind:

--- a/cli/exec/flags.go
+++ b/cli/exec/flags.go
@@ -295,4 +295,16 @@ var flags = []cli.Flag{
 		Usage:   "backend k8s storage access mode, should ReadWriteMany (RWX) instead of ReadWriteOnce (RWO) be used? (default: true)",
 		Value:   true,
 	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_BACKEND_K8S_POD_LABELS"},
+		Name:    "backend-k8s-pod-labels",
+		Usage:   "backend k8s additional worker pod labels",
+		Value:   "",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_BACKEND_K8S_POD_ANNOTATIONS"},
+		Name:    "backend-k8s-pod-annotations",
+		Usage:   "backend k8s additional worker pod annotations",
+		Value:   "",
+	},
 }

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -141,4 +141,16 @@ var flags = []cli.Flag{
 		Usage:   "backend k8s storage access mode, should ReadWriteMany (RWX) instead of ReadWriteOnce (RWO) be used? (default: true)",
 		Value:   true,
 	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_BACKEND_K8S_POD_LABELS"},
+		Name:    "backend-k8s-pod-labels",
+		Usage:   "backend k8s additional worker pod labels",
+		Value:   "",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_BACKEND_K8S_POD_ANNOTATIONS"},
+		Name:    "backend-k8s-pod-annotations",
+		Usage:   "backend k8s additional worker pod annotations",
+		Value:   "",
+	},
 }

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -249,7 +249,7 @@ func (e *kube) Tail(ctx context.Context, step *types.Step) (io.ReadCloser, error
 	<-up
 
 	opts := &v1.PodLogOptions{
-		Follow: true,
+		Follow:    true,
 		Container: podName,
 	}
 

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -250,6 +250,7 @@ func (e *kube) Tail(ctx context.Context, step *types.Step) (io.ReadCloser, error
 
 	opts := &v1.PodLogOptions{
 		Follow: true,
+		Container: podName,
 	}
 
 	logs, err := e.client.CoreV1().RESTClient().Get().

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Pod(namespace string, step *types.Step, labels map[string]string, annotations map[string]string) *v1.Pod {
+func Pod(namespace string, step *types.Step, labels, annotations map[string]string) *v1.Pod {
 	var (
 		vols       []v1.Volume
 		volMounts  []v1.VolumeMount

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Pod(namespace string, step *types.Step) *v1.Pod {
+func Pod(namespace string, step *types.Step, labels map[string]string, annotations map[string]string) *v1.Pod {
 	var (
 		vols       []v1.Volume
 		volMounts  []v1.VolumeMount
@@ -88,13 +88,14 @@ func Pod(namespace string, step *types.Step) *v1.Pod {
 		},
 	}
 
+	labels["step"] = podName(step)
+
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName(step),
-			Namespace: namespace,
-			Labels: map[string]string{
-				"step": podName(step),
-			},
+			Name:        podName(step),
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,


### PR DESCRIPTION
The issue I'm actually trying to fix is that the Istio service mesh injects sidecar containers into the worker pods which A) confuses the log fetcher since it doesn't know which container is correct and B) doesn't seem to properly clean up pods (since the sidecar runs forever). I fixed A because it's simple and non-impactful, but even if B could be fixed I'm sure there are other landmines waiting.

This solution should also be general enough to be useful for other edge cases. I personally don't need annotations, just figured it was easy to add while I was mucking around in the right areas.

Example agent environment configuration using the new value:
```yaml
  - env:
    - name: WOODPECKER_BACKEND
      value: kubernetes
    - name: WOODPECKER_BACKEND_K8S_NAMESPACE
      value: default
    - name: WOODPECKER_BACKEND_K8S_POD_LABELS
      value: '{"sidecar.istio.io/inject":"false"}'
```