### PR TITLE
Add Aptly publish plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -78,6 +78,11 @@
       "name": "Chart releaser",
       "docs": "https://raw.githubusercontent.com/woodpecker-ci/plugin-chart-releaser/master/docs.md",
       "verified": true
+    },
+    {
+      "name": "Aptly publish",
+      "docs": "https://gitea.zionetrix.net/bn8/aptly-publish/raw/branch/master/docs.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
A plugin to publish one (or more) Debian package on a Aptly repository using its API.