### PR TITLE
Update golangci-linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,14 +4,13 @@ linters-settings:
   misspell:
     locale: US
   gofumpt:
-    lang-version: "1.16"
+    lang-version: "1.19"
     extra-rules: true
 
 linters:
   disable-all: true
   enable:
     - bidichk
-    - deadcode
     - errcheck
     - gofmt
     - goimports
@@ -21,15 +20,14 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - whitespace
     - gofumpt
 
 run:
   timeout: 5m
+  go: '1.19'
 
 issues:
   exclude-rules:


### PR DESCRIPTION
to remove deprecated and enforce v1.19 golang syntax