### PR TITLE
Show secrets (#1552)

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -544,4 +544,9 @@ var flags = []cli.Flag{
 		Name:    "encryption-disable-flag",
 		Usage:   "Flag to decrypt all encrypted data and disable encryption on server",
 	},
+	&cli.BoolFlag{
+		EnvVars: []string{"WOODPECKER_SECRET_ALLOW_SHOW_VALUE"},
+		Name:    "secret-allow-show-value",
+		Usage:   "Allow to show secret value",
+	},
 }

--- a/server/api/global_secret.go
+++ b/server/api/global_secret.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/model"
@@ -31,11 +32,15 @@ func GetGlobalSecretList(c *gin.Context) {
 		c.String(http.StatusInternalServerError, "Error getting global secret list. %s", err)
 		return
 	}
-	// copy the secret detail to remove the sensitive
-	// password and token fields.
-	for i, secret := range list {
-		list[i] = secret.Copy()
+
+	if os.Getenv("WOODPECKER_SECRET_ALLOW_SHOW_VALUE") != "true" {
+		// copy the secret detail to remove the sensitive
+		// password and token fields.
+		for i, secret := range list {
+			list[i] = secret.Copy()
+		}
 	}
+
 	c.JSON(http.StatusOK, list)
 }
 

--- a/server/api/org_secret.go
+++ b/server/api/org_secret.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/woodpecker-ci/woodpecker/server"
 	"github.com/woodpecker-ci/woodpecker/server/model"
@@ -47,11 +48,15 @@ func GetOrgSecretList(c *gin.Context) {
 		c.String(http.StatusInternalServerError, "Error getting secret list for %q. %s", owner, err)
 		return
 	}
-	// copy the secret detail to remove the sensitive
-	// password and token fields.
-	for i, secret := range list {
-		list[i] = secret.Copy()
+
+	if os.Getenv("WOODPECKER_SECRET_ALLOW_SHOW_VALUE") != "true" {
+		// copy the secret detail to remove the sensitive
+		// password and token fields.
+		for i, secret := range list {
+			list[i] = secret.Copy()
+		}
 	}
+
 	c.JSON(http.StatusOK, list)
 }
 

--- a/server/api/repo_secret.go
+++ b/server/api/repo_secret.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -118,11 +119,15 @@ func GetSecretList(c *gin.Context) {
 		c.String(500, "Error getting secret list. %s", err)
 		return
 	}
-	// copy the secret detail to remove the sensitive
-	// password and token fields.
-	for i, secret := range list {
-		list[i] = secret.Copy()
+
+	if os.Getenv("WOODPECKER_SECRET_ALLOW_SHOW_VALUE") != "true" {
+		// copy the secret detail to remove the sensitive
+		// password and token fields.
+		for i, secret := range list {
+			list[i] = secret.Copy()
+		}
 	}
+
 	c.JSON(200, list)
 }
 

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -283,6 +283,8 @@
                 "deleted": "Organization secret deleted",
                 "created": "Organization secret created",
                 "saved": "Organization secret saved",
+                "toggle": "Afficher/Masquer",
+                "copy": "Copier",
                 "images": {
                     "images": "Available for following images",
                     "desc": "Comma separated list of images where this secret is available, leave empty to allow all images"
@@ -307,6 +309,8 @@
                 "add": "Add secret",
                 "save": "Save secret",
                 "show": "Show secrets",
+                "toggle": "Afficher/Masquer",
+                "copy": "Copier",
                 "name": "Name",
                 "value": "Value",
                 "deleted": "Global secret deleted",

--- a/web/src/assets/locales/fr.json
+++ b/web/src/assets/locales/fr.json
@@ -62,7 +62,9 @@
         "saved": "Secret d'organisation enregistré",
         "secrets": "Secrets",
         "show": "Afficher les secrets",
-        "value": "Valeur"
+        "value": "Valeur",
+        "toggle": "Afficher/Masquer",
+        "copy": "Copier"
       },
       "settings": "Réglages"
     }
@@ -345,7 +347,9 @@
         "saved": "Secret enregistré",
         "secrets": "Secrets",
         "show": "Afficher les secrets",
-        "value": "Valeur"
+        "value": "Valeur",
+        "toggle": "Afficher/Masquer",
+        "copy": "Copier"
       },
       "settings": "Paramètres"
     },

--- a/web/src/components/atomic/Icon.vue
+++ b/web/src/components/atomic/Icon.vue
@@ -42,6 +42,8 @@
   <i-ic-baseline-file-download v-else-if="name === 'auto-scroll'" class="h-6 w-6" />
   <i-ic-baseline-file-download-off v-else-if="name === 'auto-scroll-off'" class="h-6 w-6" />
   <i-ic-baseline-play-arrow v-else-if="name === 'play'" class="h-6 w-6" />
+  <i-bx-show v-else-if="name === 'show'" class="h-6 w-6" />
+  <i-material-symbols-content-copy v-else-if="name === 'copy'" class="h-6 w-6" />
   <div v-else-if="name === 'blank'" class="h-6 w-6" />
 </template>
 

--- a/web/src/components/secrets/SecretEdit.vue
+++ b/web/src/components/secrets/SecretEdit.vue
@@ -11,7 +11,7 @@
       </InputField>
 
       <InputField :label="$t(i18nPrefix + 'value')">
-        <TextField v-model="innerValue.value" :placeholder="$t(i18nPrefix + 'value')" :lines="5" required />
+        <TextField v-model="innerValue.value" :placeholder="$t(i18nPrefix + 'value')" :lines="5" />
       </InputField>
 
       <InputField :label="$t(i18nPrefix + 'images.images')">

--- a/web/src/components/secrets/SecretList.vue
+++ b/web/src/components/secrets/SecretList.vue
@@ -2,6 +2,28 @@
   <div class="space-y-4 text-color">
     <ListItem v-for="secret in secrets" :key="secret.id" class="items-center">
       <span>{{ secret.name }}</span>
+
+      <div v-if="secret.value" class="ml-auto">
+        <span v-if="secret.showSecret" class="secret-value secret-value--visible" v-text="secret.value">
+        </span>
+        <span v-else class="secret-value secret-value--hidden">
+          ****************
+        </span>
+        <IconButton
+          icon="copy"
+          class="ml-2 w-8 h-8 secret-action secret-action--copy"
+          :class="{invisible: !secret.showSecret}"
+          :title="$t('repo.settings.secrets.copy')"
+          @click="copySecret(secret)"
+        />
+        <IconButton
+          icon="show"
+          class="ml-2 w-8 h-8 secret-action"
+          :title="$t('repo.settings.secrets.toggle')"
+          @click="toggleSecret(secret)"
+        />
+      </div>
+
       <div class="ml-auto">
         <span
           v-for="event in secret.event"
@@ -57,4 +79,46 @@ function editSecret(secret: Secret) {
 function deleteSecret(secret: Secret) {
   emit('delete', secret);
 }
+
+function toggleSecret(secret: Secret) {
+  secret.showSecret = !secret.showSecret
+}
+
+function copySecret(secret: Secret) {
+  navigator.clipboard.writeText(secret.value)
+}
 </script>
+
+<style scoped>
+.secret-value {
+  width: 120px;
+  max-width: 120px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: monospace;
+  white-space: nowrap;
+}
+
+.secret-action {
+  display: inline-block !important;
+}
+
+.secret-action--copy:active {
+  border: 1px solid var(--fbc-secondary-text);
+  border-radius: 100%;
+  padding: 3px;
+}
+
+.secret-value--visible {
+  color: var(--fbc-secondary-text);
+}
+
+.secret-value--hidden {
+  opacity: 0.5;
+}
+
+.invisible {
+  visibility: hidden;
+}
+</style>


### PR DESCRIPTION
Fix #1552 

### New features

* Add new flag: `WOODPECKER_SECRET_ALLOW_SHOW_VALUE`
* Allow to toggle and copy to clipboard a secret from the list
* Allow editing the value

### Screenshots

* Add a secret (nothing new): https://upload.deblan.org/u/2023-01/63c9bdcb.png
* Display of secret value toggler: https://upload.deblan.org/u/2023-01/63c9bdd4.png
* The secret is displayed, we can copy it to the clipboard: https://upload.deblan.org/u/2023-01/63c9bddc.png
* The value can be modified in the form: https://upload.deblan.org/u/2023-01/63c9bded.png