### PR TITLE
fix SetupConsoleLogger which is a noop

### DIFF
--- a/cmd/cli/app.go
+++ b/cmd/cli/app.go
@@ -65,7 +65,9 @@ func newApp() *cli.App {
 			Out: os.Stderr,
 		},
 	)
-	app.Before = common.SetupConsoleLogger
+	for _, command := range app.Commands {
+		command.Before = common.SetupConsoleLogger
+	}
 
 	return app
 }


### PR DESCRIPTION
When App.Before is called the options are not parsed yet, use Command.Before instead.