### PR TITLE
docs: add note about image cleanup

### DIFF
--- a/docs/docs/30-administration/15-agent-config.md
+++ b/docs/docs/30-administration/15-agent-config.md
@@ -132,26 +132,3 @@ See [Docker backend configuration](backends/docker/#configuration)
 ### `WOODPECKER_BACKEND_SSH_*`
 
 See [SSH backend configuration](backends/ssh/#configuration)
-
-
-## Image Cleanup
-
-The agent **will not** automatically remove images from the host. This task should be managed by the host system. For example, you can use a cron job to periodically do clean-up tasks for the CI runner.
-
-:::danger
-
-The following commands **are destructive** and **irreversible** it is highly recommended that you test these commands on your system before running them in production via a cron job or other automation.
-
-:::
-
-### Remove all unused images
-
-```sh
-docker image rm $(docker images --filter "dangling=true" -q --no-trunc)
-```
-
-### Remove Woodpecker Volumes
-
-```sh
-docker volume rm $(docker volume ls --filter name=^wp_* --filter dangling=true  -q)
-```

--- a/docs/docs/30-administration/15-agent-config.md
+++ b/docs/docs/30-administration/15-agent-config.md
@@ -132,3 +132,26 @@ See [Docker backend configuration](backends/docker/#configuration)
 ### `WOODPECKER_BACKEND_SSH_*`
 
 See [SSH backend configuration](backends/ssh/#configuration)
+
+
+## Image Cleanup
+
+The agent **will not** automatically remove images from the host. This task should be managed by the host system. For example, you can use a cron job to periodically do clean-up tasks for the CI runner.
+
+:::danger
+
+The following commands **are destructive** and **irreversible** it is highly recommended that you test these commands on your system before running them in production via a cron job or other automation.
+
+:::
+
+### Remove all unused images
+
+```sh
+docker image rm $(docker images --filter "dangling=true" -q --no-trunc)
+```
+
+### Remove Woodpecker Volumes
+
+```sh
+docker volume rm $(docker volume ls --filter name=^wp_* --filter dangling=true  -q)
+```

--- a/docs/docs/30-administration/22-backends/10-docker.md
+++ b/docs/docs/30-administration/22-backends/10-docker.md
@@ -35,3 +35,25 @@ RUN apk add -U --no-cache docker-credential-ecr-login
 ## Podman support
 
 While the agent was developed with Docker/Moby, Podman can also be used by setting the environment variable `DOCKER_SOCK` to point to the Podman socket. In order to work without workarounds, Podman 4.0 (or above) is required.
+
+## Image Cleanup
+
+The agent **will not** automatically remove images from the host. This task should be managed by the host system. For example, you can use a cron job to periodically do clean-up tasks for the CI runner.
+
+:::danger
+
+The following commands **are destructive** and **irreversible** it is highly recommended that you test these commands on your system before running them in production via a cron job or other automation.
+
+:::
+
+### Remove all unused images
+
+```sh
+docker image rm $(docker images --filter "dangling=true" -q --no-trunc)
+```
+
+### Remove Woodpecker Volumes
+
+```sh
+docker volume rm $(docker volume ls --filter name=^wp_* --filter dangling=true  -q)
+```


### PR DESCRIPTION
Closes #1532

Adds notes about images not being cleaned up by wood-pecker and provides examples on how you can automate the cleanup. Also provides a warning that these are destructive actions. 

<img width="1020" alt="CleanShot 2023-03-03 at 09 36 35@2x" src="https://user-images.githubusercontent.com/64056131/222800658-f610d488-f8ea-4aca-8ed0-f26e44be1884.png">
