### PR TITLE
feat: UI should confirm secret deletion

### DIFF
--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -125,6 +125,7 @@
                 "show": "Show secrets",
                 "name": "Name",
                 "value": "Value",
+                "delete_confirm": "Do you really want to delete this secret?",
                 "deleted": "Secret deleted",
                 "created": "Secret created",
                 "saved": "Secret saved",

--- a/web/src/components/secrets/SecretList.vue
+++ b/web/src/components/secrets/SecretList.vue
@@ -32,6 +32,7 @@
 
 <script lang="ts" setup>
 import { toRef } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import IconButton from '~/components/atomic/IconButton.vue';
 import ListItem from '~/components/atomic/ListItem.vue';
@@ -48,6 +49,8 @@ const emit = defineEmits<{
   (event: 'delete', secret: Secret): void;
 }>();
 
+const i18n = useI18n();
+
 const secrets = toRef(props, 'modelValue');
 
 function editSecret(secret: Secret) {
@@ -55,6 +58,11 @@ function editSecret(secret: Secret) {
 }
 
 function deleteSecret(secret: Secret) {
+  // TODO use proper dialog
+  // eslint-disable-next-line no-alert, no-restricted-globals
+  if (!confirm(i18n.t('repo.settings.secrets.delete_confirm'))) {
+    return;
+  }
   emit('delete', secret);
 }
 </script>


### PR DESCRIPTION
Closes https://github.com/woodpecker-ci/woodpecker/issues/1483

PR adds a confirmation dialog that warns user before deleting a secret. 

https://user-images.githubusercontent.com/426437/222985225-9e14ddac-6c5a-4aed-ac89-cc6562180ac6.mov


Using just basic [window.Confirm](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) since it is used in [other](https://github.com/search?q=repo%3Awoodpecker-ci%2Fwoodpecker+confirm%28&type=code) places. Any objections to switch to proper dialog component in a separate PR?