### PR TITLE
fix: docker backend should not close 'engine.Tail' result

### DIFF
--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -226,7 +226,6 @@ func (e *docker) Tail(ctx context.Context, step *backend.Step) (io.ReadCloser, e
 		_, _ = stdcopy.StdCopy(wc, wc, logs)
 		_ = logs.Close()
 		_ = wc.Close()
-		_ = rc.Close()
 	}()
 	return rc, nil
 }


### PR DESCRIPTION
Closes https://github.com/woodpecker-ci/woodpecker/issues/1615

The error described in https://github.com/woodpecker-ci/woodpecker/issues/1615 is happening because `Tail` method of the docker backend closes the instance of `io.ReadCloser` it returns in `defer` function. As a result anything that try to read data returned by `Tail` method eventually will attempt to read from closes reader and get an error:

https://github.com/woodpecker-ci/woodpecker/blob/2171212c5a31bfffc8f882716bdd503c65413eee/pipeline/backend/docker/docker.go#L229

The fix is just don't close returned reader and let the consumer of `Tail` method do it. Good thing is that `Tail` is used only in one place and reader is correctly closed:

https://github.com/woodpecker-ci/woodpecker/blob/2171212c5a31bfffc8f882716bdd503c65413eee/pipeline/pipeline.go#L231-L237

Example of `woodpecker exec` output using pipeline from https://github.com/woodpecker-ci/woodpecker/issues/1615 with the fix: 

```
woodpecker exec .woodpecker.yaml
[step1:L0:0s] + echo step1
[step1:L1:0s] step1
[step2:L0:0s] + echo step2
[step2:L1:0s] step2
```