### PR TITLE
Fix faulty hardlink in release tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,6 @@ release-tarball: ## Create tarball for release
 		web/package.json \
 		web/public \
 		web/src \
-		web/package.json \
 		web/tsconfig.* \
 		web/*.ts \
 		web/pnpm-lock.yaml \


### PR DESCRIPTION
Fixes #1664 

The cause was a duplicate entry in the `tar` makefile invocation, as well as `tar` itself happily producing an additional bogus hardlink in the archive.