### PR TITLE
web: use i18n-t to avoid v-html directive

### DIFF
--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -82,7 +82,8 @@
                 "pipeline_path": {
                     "path": "Pipeline path",
                     "default": "By default: .woodpecker/*.yml -> .woodpecker.yml -> .drone.yml",
-                    "desc": "Path to your pipeline config (for example <span class=\"bg-gray-300 dark:bg-dark-700 rounded-md px-1\">my/path/</span>). Folders should end with a <span class=\"bg-gray-300 dark:bg-dark-700 rounded-md px-1\">/</span>."
+                    "desc": "Path to your pipeline config (for example {0}). Folders should end with a {1}.",
+                    "desc_path_example": "my/path/"
                 },
                 "allow_pr": {
                     "allow": "Allow Pull Requests",

--- a/web/src/components/repo/settings/GeneralTab.vue
+++ b/web/src/components/repo/settings/GeneralTab.vue
@@ -15,8 +15,12 @@
           :placeholder="$t('repo.settings.general.pipeline_path.default')"
         />
         <template #description>
-          <!-- eslint-disable-next-line vue/no-v-html -->
-          <p class="text-sm text-color-alt" v-html="$t('repo.settings.general.pipeline_path.desc')" />
+          <i18n-t keypath="repo.settings.general.pipeline_path.desc" tag="p" class="text-sm text-color-alt">
+            <span class="bg-gray-300 dark:bg-dark-700 rounded-md px-1">{{
+              $t('repo.settings.general.pipeline_path.desc_path_example')
+            }}</span>
+            <span class="bg-gray-300 dark:bg-dark-700 rounded-md px-1">/</span>
+          </i18n-t>
         </template>
       </InputField>
 


### PR DESCRIPTION
Use i18n-t component to avoid v-html directive
and to make localization easier