### PR TITLE
Add backend label to agents

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -53,21 +53,6 @@ func loop(c *cli.Context) error {
 
 	platform := runtime.GOOS + "/" + runtime.GOARCH
 
-	labels := map[string]string{
-		"hostname": hostname,
-		"platform": platform,
-		"repo":     "*", // allow all repos by default
-	}
-
-	for _, v := range c.StringSlice("filter") {
-		parts := strings.SplitN(v, "=", 2)
-		labels[parts[0]] = parts[1]
-	}
-
-	filter := rpc.Filter{
-		Labels: labels,
-	}
-
 	if c.Bool("pretty") {
 		log.Logger = log.Output(
 			zerolog.ConsoleWriter{
@@ -188,6 +173,22 @@ func loop(c *cli.Context) error {
 	agentID, err = client.RegisterAgent(ctx, platform, engine.Name(), version.String(), parallel)
 	if err != nil {
 		return err
+	}
+
+	labels := map[string]string{
+		"hostname": hostname,
+		"platform": platform,
+		"backend":  engine.Name(),
+		"repo":     "*", // allow all repos by default
+	}
+
+	for _, v := range c.StringSlice("filter") {
+		parts := strings.SplitN(v, "=", 2)
+		labels[parts[0]] = parts[1]
+	}
+
+	filter := rpc.Filter{
+		Labels: labels,
 	}
 
 	log.Debug().Msgf("Agent registered with ID %d", agentID)

--- a/docs/docs/20-usage/20-pipeline-syntax.md
+++ b/docs/docs/20-usage/20-pipeline-syntax.md
@@ -626,7 +626,7 @@ pipeline:
 
 You can set labels for your pipeline to select an agent to execute the pipeline on. An agent will pick up and run a pipeline when **every** label assigned to a pipeline matches the agents labels.
 
-To set additional agent labels check the [agent configuration options](../30-administration/15-agent-config.md#woodpecker_filter_labels). Agents will have at least three default labels: `platform=agent-os/agent-arch`, `hostname=my-agent` and `repo=*`. Agents can use a `*` as a wildcard for a label. For example `repo=*` will match every repo.
+To set additional agent labels check the [agent configuration options](../30-administration/15-agent-config.md#woodpecker_filter_labels). Agents will have at least four default labels: `platform=agent-os/agent-arch`, `hostname=my-agent`, `backend=docker` (type of the agent backend) and `repo=*`. Agents can use a `*` as a wildcard for a label. For example `repo=*` will match every repo.
 
 Pipeline labels with an empty value will be ignored.
 By default each pipeline has at least the `repo=your-user/your-repo-name` label. If you have set the [platform attribute](#platform) for your pipeline it will have a label like `platform=your-os/your-arch` as well.


### PR DESCRIPTION
closes #708 

Allows users to filter for a specific backend type.