### PR TITLE
The WOODPECKER_ADMIN environment variable is singular.

### DIFF
--- a/server/model/user.go
+++ b/server/model/user.go
@@ -58,7 +58,7 @@ type User struct {
 
 	// Admin indicates the user is a system administrator.
 	//
-	// NOTE: If the username is part of the WOODPECKER_ADMINS
+	// NOTE: If the username is part of the WOODPECKER_ADMIN
 	// environment variable this value will be set to true on login.
 	Admin bool `json:"admin,omitempty" xorm:"user_admin"`
 


### PR DESCRIPTION
According to:

```
$ git grep WOODPECKER_ADMIN
.gitpod.yml:      WOODPECKER_ADMIN: woodpecker
cmd/server/flags.go:            EnvVars: []string{"WOODPECKER_ADMIN"},
docker-compose.example.yml:      - WOODPECKER_ADMIN=laszlocph
docs/docs/30-administration/10-server-config.md:+     - WOODPECKER_ADMIN=johnsmith,janedoe
docs/docs/30-administration/10-server-config.md:### `WOODPECKER_ADMIN`
docs/docs/30-administration/10-server-config.md:Example: `WOODPECKER_ADMIN=user1,user2`
docs/docs/30-administration/70-proxy.md:      - WOODPECKER_ADMIN=your_admin_user
docs/docs/92-development/01-getting-started.md:WOODPECKER_ADMIN=your-username
docs/versioned_docs/version-0.15/30-administration/10-server-config.md:+     - WOODPECKER_ADMIN=johnsmith,janedoe
docs/versioned_docs/version-0.15/30-administration/10-server-config.md:### `WOODPECKER_ADMIN`
docs/versioned_docs/version-0.15/30-administration/10-server-config.md:Example: `WOODPECKER_ADMIN=user1,user2`
docs/versioned_docs/version-0.15/30-administration/80-kubernetes.md:          - name: "WOODPECKER_ADMIN"
docs/versioned_docs/version-0.15/92-development/01-getting-started.md:WOODPECKER_ADMIN=your-username
server/model/user.go:   // NOTE: If the username is part of the WOODPECKER_ADMIN
Binary file server/store/datastore/migration/testfiles/sqlite.db matches
```

And (after this patch):
```
$ git grep WOODPECKER_ADMINS
$
```