### PR TITLE
docs: change broken twitter url

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Here are some places where people mention Woodpecker:
 
 - [GitHub](https://github.com/topics/WoodpeckerCI)
 - [Codeberg](https://codeberg.org/explore/repos?q=woodpeckerci&topic=1)
-- [Twitter](https://twitter.com/hashtag/WoodpeckerCI?f=live)
+- [Twitter](https://twitter.com/search?q=%23WoodpeckerCI&src=typed_query)
 - [Fediverse](https://mastodon.social/tags/WoodpeckerCI)
 
 ## ✨ Stars over time


### PR DESCRIPTION
Looks like the Twitter URL has changed and `https://twitter.com/hashtag/WoodpeckerCI?f=live` no longer works:

<img width="599" alt="image" src="https://user-images.githubusercontent.com/426437/235372826-0588327c-8edf-4ae5-ae94-5ca1298afb36.png">


PR fixes the URL:

<img width="614" alt="image" src="https://user-images.githubusercontent.com/426437/235372841-5a857fb6-4733-4ada-956b-ec7cd8e04c31.png">
 

