### PR TITLE
Adding Android CI example to awesome woodpecker

### DIFF
--- a/docs/docs/92-awesome.md
+++ b/docs/docs/92-awesome.md
@@ -12,6 +12,7 @@ If you have some missing resources, please feel free to [open a pull-request](ht
   - [Docusaurus & publishing to GitHub Pages](https://github.com/woodpecker-ci/woodpecker/blob/master/.woodpecker/docs.yml)
   - [Docker container building](https://github.com/woodpecker-ci/woodpecker/blob/master/.woodpecker/docker.yml)
   - [Helm chart linting & releasing](https://github.com/woodpecker-ci/woodpecker/blob/master/.woodpecker/helm.yml)
+  - [Android Jetpack compose linting and building](https://github.com/dessalines/thumb-key/blob/main/.woodpecker.yml)
 
 ## Projects using Woodpecker
 

--- a/docs/docs/92-awesome.md
+++ b/docs/docs/92-awesome.md
@@ -12,12 +12,12 @@ If you have some missing resources, please feel free to [open a pull-request](ht
   - [Docusaurus & publishing to GitHub Pages](https://github.com/woodpecker-ci/woodpecker/blob/master/.woodpecker/docs.yml)
   - [Docker container building](https://github.com/woodpecker-ci/woodpecker/blob/master/.woodpecker/docker.yml)
   - [Helm chart linting & releasing](https://github.com/woodpecker-ci/woodpecker/blob/master/.woodpecker/helm.yml)
-  - [Android Jetpack compose linting and building](https://github.com/dessalines/thumb-key/blob/main/.woodpecker.yml)
 
 ## Projects using Woodpecker
 
 - [Woodpecker-CI](https://github.com/woodpecker-ci/woodpecker/tree/master/.woodpecker) itself
 - [All official plugins](https://github.com/woodpecker-ci?q=plugin&type=all)
+- [dessalines/thumb-key](https://github.com/dessalines/thumb-key/blob/main/.woodpecker.yml) - Android Jetpack compose linting and building
 
 ## Tools
 


### PR DESCRIPTION
This shows an example of how to use woodpecker to lint and build android projects.