### PR TITLE
PipelineLog.vue: Make it possible to link to a log line

### DIFF
--- a/web/src/components/repo/pipeline/PipelineLog.vue
+++ b/web/src/components/repo/pipeline/PipelineLog.vue
@@ -36,7 +36,7 @@
         ref="consoleElement"
         class="w-full max-w-full grid grid-cols-[min-content,1fr,min-content] auto-rows-min flex-grow p-2 gap-x-2 overflow-x-hidden overflow-y-auto"
       >
-        <div v-for="line in log" :key="line.index" class="contents font-mono">
+        <div v-for="line in log" :key="line.index" :id="`L${line.index}`" class="contents font-mono">
           <span class="text-gray-500 whitespace-nowrap select-none text-right">{{ line.index + 1 }}</span>
           <!-- eslint-disable-next-line vue/no-v-html -->
           <span class="align-top text-color whitespace-pre-wrap break-words" v-html="line.text" />

--- a/web/src/components/repo/pipeline/PipelineLog.vue
+++ b/web/src/components/repo/pipeline/PipelineLog.vue
@@ -36,7 +36,7 @@
         ref="consoleElement"
         class="w-full max-w-full grid grid-cols-[min-content,1fr,min-content] auto-rows-min flex-grow p-2 gap-x-2 overflow-x-hidden overflow-y-auto"
       >
-        <div v-for="line in log" :key="line.index" :id="`L${line.index}`" class="contents font-mono">
+        <div v-for="line in log" :id="`L${line.index}`" :key="line.index" class="contents font-mono">
           <span class="text-gray-500 whitespace-nowrap select-none text-right">{{ line.index + 1 }}</span>
           <!-- eslint-disable-next-line vue/no-v-html -->
           <span class="align-top text-color whitespace-pre-wrap break-words" v-html="line.text" />


### PR DESCRIPTION
Set id attribute of lines to make it possible to link to a pipeline line, like it was in version 0.9. For instance https://woodpecker.example.com/org/repo/1#L7