### PR TITLE
Drop ".drone.yml" as default pipeline config

### DIFF
--- a/docs/docs/20-usage/71-project-settings.md
+++ b/docs/docs/20-usage/71-project-settings.md
@@ -6,7 +6,7 @@ As the owner of a project in Woodpecker you can change project related settings 
 
 ## Pipeline path
 
-The path to the pipeline config file or folder. By default it is left empty which will use the following configuration resolution `.woodpecker/*.yml` -> `.woodpecker/*.yaml` -> `.woodpecker.yml` -> `.woodpecker.yaml` -> `.drone.yml`. If you set a custom path Woodpecker tries to load your configuration or fails if no configuration could be found at the specified location. To use a [multiple workflows](./25-workflows.md) with a custom path you have to change it to a folder path ending with a `/` like `.woodpecker/`.
+The path to the pipeline config file or folder. By default it is left empty which will use the following configuration resolution `.woodpecker/*.yml` -> `.woodpecker/*.yaml` -> `.woodpecker.yml` -> `.woodpecker.yaml`. If you set a custom path Woodpecker tries to load your configuration or fails if no configuration could be found at the specified location. To use a [multiple workflows](./25-workflows.md) with a custom path you have to change it to a folder path ending with a `/` like `.woodpecker/`.
 
 ## Repository hooks
 

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -14,7 +14,7 @@ Some versions need some changes to the server configuration or the pipeline conf
 - Updated Prometheus gauge `build_*` to `pipeline_*`
 - Updated Prometheus gauge `*_job_*` to `*_step_*`
 - Renamed config env `WOODPECKER_MAX_PROCS` to `WOODPECKER_MAX_WORKFLOWS` (still available as fallback)
-- The pipelines are now also read from `.yaml` files, the new default order is `.woodpecker/*.yml` and `.woodpecker/*.yaml` (without any prioritization) -> `.woodpecker.yml` ->  `.woodpecker.yaml` -> `.drone.yml`
+- The pipelines are now also read from `.yaml` files, the new default order is `.woodpecker/*.yml` and `.woodpecker/*.yaml` (without any prioritization) -> `.woodpecker.yml` ->  `.woodpecker.yaml`
 - Dropped support for [Coding](https://coding.net/) and [Gogs](https://gogs.io).
 - `/api/queue/resume` & `/api/queue/pause` endpoint methods were changed from `GET` to `POST`
 

--- a/server/forge/configFetcher_test.go
+++ b/server/forge/configFetcher_test.go
@@ -144,11 +144,11 @@ func TestFetch(t *testing.T) {
 			name:       "Use old config on 204 response",
 			repoConfig: "",
 			files: []file{{
-				name: ".drone.yml",
+				name: ".woodpecker.yaml",
 				data: dummyData,
 			}},
 			expectedFileNames: []string{
-				".drone.yml",
+				".woodpecker.yaml",
 			},
 			expectedError: false,
 		},
@@ -202,11 +202,11 @@ func TestFetch(t *testing.T) {
 				name: ".woodpecker.yml",
 				data: nil,
 			}, {
-				name: ".drone.yml",
+				name: ".woodpecker.yaml",
 				data: dummyData,
 			}},
 			expectedFileNames: []string{
-				".drone.yml",
+				".woodpecker.yaml",
 			},
 			expectedError: false,
 		},
@@ -220,7 +220,7 @@ func TestFetch(t *testing.T) {
 				name: ".woodpecker.yml",
 				data: dummyData,
 			}, {
-				name: ".drone.yml",
+				name: ".woodpecker.yaml",
 				data: dummyData,
 			}, {
 				name: ".my-ci-folder/test.yml",
@@ -384,7 +384,7 @@ func TestFetchFromConfigService(t *testing.T) {
 				name: ".woodpecker.yml",
 				data: nil,
 			}, {
-				name: ".drone.yml",
+				name: ".woodpecker.yaml",
 				data: dummyData,
 			}},
 			expectedFileNames: []string{},
@@ -400,7 +400,7 @@ func TestFetchFromConfigService(t *testing.T) {
 				name: ".woodpecker.yml",
 				data: dummyData,
 			}, {
-				name: ".drone.yml",
+				name: ".woodpecker.yaml",
 				data: dummyData,
 			}, {
 				name: ".my-ci-folder/test.yml",

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -28,7 +28,6 @@ var DefaultConfigOrder = [...]string{
 	".woodpecker/",
 	".woodpecker.yaml",
 	".woodpecker.yml",
-	".drone.yml",
 }
 
 const (

--- a/web/src/assets/locales/de.json
+++ b/web/src/assets/locales/de.json
@@ -366,7 +366,7 @@
           "netrc_only_trusted": "Netrc-Zugangsdaten nur in vertrauenswürdigen Containern zum Klonen bereitstellen"
         },
         "pipeline_path": {
-          "default": "Standardmäßig: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yml -> .drone.yml",
+          "default": "Standardmäßig: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yml",
           "desc": "Pfad zu deiner Pipeline-Konfiguration (z. B. {0}). Verzeichnisse sollten mit einem {1} enden.",
           "desc_path_example": "mein/pfad/",
           "path": "Pipeline-Pfad"

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -81,7 +81,7 @@
                 "success": "Repository settings updated",
                 "pipeline_path": {
                     "path": "Pipeline path",
-                    "default": "By default: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml -> .drone.yml",
+                    "default": "By default: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml",
                     "desc": "Path to your pipeline config (for example {0}). Folders should end with a {1}.",
                     "desc_path_example": "my/path/"
                 },

--- a/web/src/assets/locales/es.json
+++ b/web/src/assets/locales/es.json
@@ -58,7 +58,7 @@
         },
         "general": "General",
         "pipeline_path": {
-          "default": "Por defecto: .woodpecker/*.yml -> .woodpecker.yml -> .drone.yml",
+          "default": "Por defecto: .woodpecker/*.yml -> .woodpecker.yml",
           "path": "Pasos del pipeline"
         },
         "project": "Configuración del proyecto",

--- a/web/src/assets/locales/fr.json
+++ b/web/src/assets/locales/fr.json
@@ -365,7 +365,7 @@
           "netrc_only_trusted": "Injecter les identifiants netrc uniquement dans des conteneurs de confiance"
         },
         "pipeline_path": {
-          "default": "Par défaut : .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml -> .drone.yml",
+          "default": "Par défaut : .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml",
           "desc": "Le chemin vers votre configuration de pipeline (par example {0}). Les dossiers doivent finir par {1}.",
           "desc_path_example": "mon/chemin/",
           "path": "Chemin vers le pipeline"

--- a/web/src/assets/locales/id.json
+++ b/web/src/assets/locales/id.json
@@ -322,7 +322,7 @@
           "netrc_only_trusted": "Hanya masukkan kredensial netrc ke kontainer yang terpercaya"
         },
         "pipeline_path": {
-          "default": "Secara bawaan: .woodpecker/*.{'{yaml,yml}'} → .woodpecker.yaml → .woodpecker.yml → .drone.yml",
+          "default": "Secara bawaan: .woodpecker/*.{'{yaml,yml}'} → .woodpecker.yaml → .woodpecker.yml",
           "desc": "Jalur ke konfigurasi jalur pipa Anda (misalnya {0}). Folder seharusnya berakhir dengan sebuah {1}.",
           "desc_path_example": "jalur/saya/",
           "path": "Jalur pipa"

--- a/web/src/assets/locales/it.json
+++ b/web/src/assets/locales/it.json
@@ -95,7 +95,7 @@
       "general": {
         "general": "Generale",
         "pipeline_path": {
-          "default": "Predefinito: .woodpecker/*.yml -> .woodpecker.yml -> .drone.yml",
+          "default": "Predefinito: .woodpecker/*.yml -> .woodpecker.yml",
           "path": "Percorso della pipeline"
         },
         "project": "Impostazioni del progetto",

--- a/web/src/assets/locales/lv.json
+++ b/web/src/assets/locales/lv.json
@@ -365,7 +365,7 @@
           "netrc_only_trusted": "Atļaut izmantot Git autorizāciju tikai uzticamiem konteineriem"
         },
         "pipeline_path": {
-          "default": "Pēc noklusējuma: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml -> .drone.yml",
+          "default": "Pēc noklusējuma: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml",
           "desc": "Ceļš uz konvejerdarba konfigurāciju, piemēram, {0}. Mapēm jābeidzas ar {0}.",
           "desc_path_example": "mans/ceļš/",
           "path": "Konvejerdarba ceļš"

--- a/web/src/assets/locales/pl.json
+++ b/web/src/assets/locales/pl.json
@@ -322,7 +322,7 @@
           "netrc_only_trusted": "Wstrzykuj poświadczenia netrc tylko do zaufanych kontenerów"
         },
         "pipeline_path": {
-          "default": "Domyślnie: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml -> .drone.yml",
+          "default": "Domyślnie: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml",
           "desc": "Ścieżka do konfiguracji Twojego potoku (na przykład {0}). Foldery powinny kończyć się znakiem {1}.",
           "desc_path_example": "moja/ścieżka/",
           "path": "Ścieżka do pliku potoku"

--- a/web/src/assets/locales/ru.json
+++ b/web/src/assets/locales/ru.json
@@ -322,7 +322,7 @@
           "netrc_only_trusted": "Вводите учетные данные netrc только внутри контейнеров которым вы доверяете"
         },
         "pipeline_path": {
-          "default": "По умолчанию: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml -> .drone.yml",
+          "default": "По умолчанию: .woodpecker/*.{'{yaml,yml}'} -> .woodpecker.yaml -> .woodpecker.yml",
           "desc": "Путь к конфигурации вашего конвейера (например: {0}). При указании директории путь должен заканчиваться символом {1}.",
           "desc_path_example": "мой/путь/",
           "path": "Конфигурация конвейера"

--- a/web/src/assets/locales/uk.json
+++ b/web/src/assets/locales/uk.json
@@ -209,7 +209,7 @@
         },
         "general": "Генерал",
         "pipeline_path": {
-          "default": "За замовчуванням: .woodpecker/*.yml -> .woodpecker.yml -> .drone.yml",
+          "default": "За замовчуванням: .woodpecker/*.yml -> .woodpecker.yml",
           "path": "Траса трубопроводу"
         },
         "project": "Налаштування проекту",

--- a/web/src/assets/locales/zh-Hans.json
+++ b/web/src/assets/locales/zh-Hans.json
@@ -217,7 +217,7 @@
         },
         "general": "基本设置",
         "pipeline_path": {
-          "default": "默认: .woodpecker/*.yml -> .woodpecker.yml -> .drone.yml",
+          "default": "默认: .woodpecker/*.yml -> .woodpecker.yml",
           "path": "流水线路径"
         },
         "project": "项目设置",


### PR DESCRIPTION
it did make sense to have it still supported within v0.15.0,

but as we move future away and with the release of v1.0.0
we should not give the appearance of still support the original drone v0.8 config