### PR TITLE
Fix missing table name

### DIFF
--- a/server/store/datastore/migration/017_remove_machine_col.go
+++ b/server/store/datastore/migration/017_remove_machine_col.go
@@ -23,6 +23,10 @@ type oldStep017 struct {
 	Machine string `xorm:"step_machine"`
 }
 
+func (oldStep017) TableName() string {
+	return "steps"
+}
+
 var removeMachineCol = task{
 	name: "remove-machine-col",
 	fn: func(sess *xorm.Session) error {

--- a/server/store/datastore/migration/017_remove_machine_col.go
+++ b/server/store/datastore/migration/017_remove_machine_col.go
@@ -18,22 +18,9 @@ import (
 	"xorm.io/xorm"
 )
 
-type oldStep017 struct {
-	ID      int64  `xorm:"pk autoincr 'step_id'"`
-	Machine string `xorm:"step_machine"`
-}
-
-func (oldStep017) TableName() string {
-	return "steps"
-}
-
 var removeMachineCol = task{
 	name: "remove-machine-col",
 	fn: func(sess *xorm.Session) error {
-		// make sure step_machine column exists
-		if err := sess.Sync(new(oldStep017)); err != nil {
-			return err
-		}
 		return dropTableColumns(sess, "steps", "step_machine")
 	},
 }


### PR DESCRIPTION
Bug from #1806 

We don't need the sync because the step_machine is there since the model was added the first time so it mill *always* be in the table