### PR TITLE
Database migrations run in seperate sessions and commit on success right away

### DIFF
--- a/server/store/datastore/migration/017_remove_machine_col.go
+++ b/server/store/datastore/migration/017_remove_machine_col.go
@@ -23,6 +23,10 @@ type oldStep017 struct {
 	Machine string `xorm:"step_machine"`
 }
 
+func (oldStep017) TableName() string {
+	return "steps"
+}
+
 var removeMachineCol = task{
 	name: "remove-machine-col",
 	fn: func(sess *xorm.Session) error {

--- a/server/store/datastore/migration/017_remove_machine_col.go
+++ b/server/store/datastore/migration/017_remove_machine_col.go
@@ -18,9 +18,18 @@ import (
 	"xorm.io/xorm"
 )
 
+type oldStep017 struct {
+	ID      int64  `xorm:"pk autoincr 'step_id'"`
+	Machine string `xorm:"step_machine"`
+}
+
 var removeMachineCol = task{
 	name: "remove-machine-col",
 	fn: func(sess *xorm.Session) error {
+		// make sure step_machine column exists
+		if err := sess.Sync(new(oldStep017)); err != nil {
+			return err
+		}
 		return dropTableColumns(sess, "steps", "step_machine")
 	},
 }

--- a/server/store/datastore/migration/migration.go
+++ b/server/store/datastore/migration/migration.go
@@ -94,6 +94,8 @@ func initNew(sess *xorm.Session) error {
 }
 
 func Migrate(e *xorm.Engine) error {
+	e.SetDisableGlobalCache(true)
+
 	if err := e.Sync(new(migrations)); err != nil {
 		return err
 	}
@@ -125,9 +127,7 @@ func Migrate(e *xorm.Engine) error {
 		return err
 	}
 
-	if err := e.ClearCache(allBeans...); err != nil {
-		return err
-	}
+	e.SetDisableGlobalCache(false)
 
 	return syncAll(e)
 }

--- a/server/store/datastore/migration/migration.go
+++ b/server/store/datastore/migration/migration.go
@@ -150,7 +150,7 @@ func runTasks(e *xorm.Engine, tasks []*task) error {
 		}
 
 		log.Trace().Msgf("start migration task '%s'", task.name)
-		sess := e.NewSession()
+		sess := e.NewSession().NoCache()
 		defer sess.Close()
 		if err := sess.Begin(); err != nil {
 			return err


### PR DESCRIPTION
This isolates single migration tasks from each other.
The migration itself is now not atomic anymore but each single migration now on it's own. 
This takes load away from databases, as new sessions have a committed schema available.

We also disable xorm.cache, as the speed improvements are minor but invalid cache caused by schema changes did happen already in the past. 

---
Reverts #1817
Closes #1821