### PR TITLE
Get workflow id from clone steps

### DIFF
--- a/pipeline/backend/local/local.go
+++ b/pipeline/backend/local/local.go
@@ -220,12 +220,23 @@ func (e *local) Destroy(_ context.Context, c *types.Config) error {
 }
 
 func (e *local) getWorkflowIDFromStep(step *types.Step) (string, error) {
-	prefix := strings.Split(step.Name, "_stage_")
-	if len(prefix) < 2 {
-		return "", fmt.Errorf("invalid step name %s", step.Name)
+	sep := "_step_"
+	if strings.Contains(step.Name, sep) {
+		prefix := strings.Split(step.Name, sep)
+		if len(prefix) == 2 {
+			return prefix[0], nil
+		}
 	}
 
-	return prefix[0], nil
+	sep = "_clone"
+	if strings.Contains(step.Name, sep) {
+		prefix := strings.Split(step.Name, sep)
+		if len(prefix) == 2 {
+			return prefix[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("invalid step name (%s) %s", sep, step.Name)
 }
 
 func (e *local) getWorkflowIDFromConfig(c *types.Config) (string, error) {


### PR DESCRIPTION
When in local mode, `getWorkflowIDFromStep` can handle normal steps with a name like `wp_01h2a6qggwz68zekrkbwqq9rny_0_step_0`.

However, it will fail on clone (unless `skip_clone: true`) with an `invalid step name` error.

```
invalid step name wp_01h2a2ebppp43bwjdfdsyj1m6m_0_clone
```

This patch handles either `_stage_` or `_clone` as the separator that the local backend can use to extract the workflowID.