### PR TITLE
Support for k8s serviceAccount and nodeSelector

### DIFF
--- a/docs/docs/30-administration/22-backends/40-kubernetes.md
+++ b/docs/docs/30-administration/22-backends/40-kubernetes.md
@@ -40,9 +40,22 @@ Additional labels to apply to worker pods. Must be a YAML object, e.g. `{"exampl
 
 Additional annotations to apply to worker pods. Must be a YAML object, e.g. `{"example.com/test-annotation":"test-value"}`.
 
-## Resources
+## Job specific configuration
+
+### Resources
 
 The kubernetes backend also allows for specifying requests and limits on a per-step basic, most commonly for CPU and memory.
+See the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information on using resources.
+
+### ServiceAccountName
+
+Specify the name of the ServiceAccount which the build pod will mount. This serviceAccount must be created externally.
+See the [kubernetes documentation](https://kubernetes.io/docs/concepts/security/service-accounts/) for more information on using serviceAccounts.
+
+### nodeSelector
+
+Specify the label which is used to select the node where the job should be executed.
+See the [kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more information on using nodeSelector.
 
 Example pipeline configuration:
 ```yaml
@@ -55,12 +68,13 @@ steps:
       - go test
     backend_options:
       kubernetes:
+        serviceAccountName: 'my-service-account'
         resources:
           requests:
             memory: 128Mi
             cpu: 1000m
           limits:
             memory: 256Mi
+        nodeSelector:
+          beta.kubernetes.io/instance-type: p3.8xlarge
 ```
-
-See the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information on using resources.

--- a/pipeline/backend/types/backend_kubernetes.go
+++ b/pipeline/backend/types/backend_kubernetes.go
@@ -3,6 +3,8 @@ package types
 // KubernetesBackendOptions defines all the advanced options for the kubernetes backend
 type KubernetesBackendOptions struct {
 	Resources Resources `json:"resouces,omitempty"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	NodeSelector map[string]string `json:"nodeSelector,omitEmpty"`
 }
 
 // Resources defines two maps for kubernetes resource definitions

--- a/pipeline/schema/schema.json
+++ b/pipeline/schema/schema.json
@@ -521,6 +521,25 @@
         "type": "string"
       }
     },
+    "step_backend_kubernetes_service_account": {
+      "description": "serviceAccountName to be use by job. Read more: https://woodpecker-ci.org/docs/administration/backends/kubernetes",
+      "type": "object",
+      "properties": {
+        "requests": {
+          "$ref": "#/definitions/step_kubernetes_service_account_object"
+        },
+        "limits": {
+          "$ref": "#/definitions/step_kubernetes_service_account_object"
+        }
+      }
+    },
+    "step_kubernetes_service_account_object": {
+      "description": "A list of kubernetes resource mappings",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "services": {
       "description": "Read more: https://woodpecker-ci.org/docs/usage/services",
       "type": "object",


### PR DESCRIPTION
Add the possiblity to specify the Kubernetes serviceAccount and/or nodeSelector to be used on individual steps for Kubernetes executor