### PR TITLE
01-getting-started.md: fix WOODPECKER_HOST example

### DIFF
--- a/docs/docs/92-development/01-getting-started.md
+++ b/docs/docs/92-development/01-getting-started.md
@@ -48,7 +48,7 @@ WOODPECKER_OPEN=true
 WOODPECKER_ADMIN=your-username
 
 # if you want to test webhooks with an online forge like GitHub this address needs to be accessible from public server
-WOODPECKER_HOST=http://your-dev-address.com/
+WOODPECKER_HOST=http://your-dev-address.com
 
 # github (sample for a forge config - see /docs/administration/forge/overview for other forges)
 WOODPECKER_GITHUB=true


### PR DESCRIPTION
When trying to run it, it says

```
{"level":"fatal","time":"2023-06-12T14:58:31+02:00","message":"WOODPECKER_HOST must not have trailing slash"}
```