### PR TITLE
Added Woodpecker Host Config used for Webhooks

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -46,6 +46,11 @@ var flags = []cli.Flag{
 		Usage:   "server fully qualified url (<scheme>://<host>)",
 	},
 	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_WEBHOOK_HOST"},
+		Name:    "server-webhook-host",
+		Usage:   "server fully qualified url for forge's Webhooks (<scheme>://<host>)",
+	},
+	&cli.StringFlag{
 		EnvVars: []string{"WOODPECKER_ROOT_URL"},
 		Name:    "root-url",
 		Usage:   "server url root (used for statics loading when having a url path prefix)",

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -341,7 +341,11 @@ func setupEvilGlobals(c *cli.Context, v store.Store, f forge.Forge) {
 	server.Config.Server.Key = c.String("server-key")
 	server.Config.Server.AgentToken = c.String("agent-secret")
 	server.Config.Server.Host = c.String("server-host")
-	server.Config.Server.WebhookHost = c.String("server-webhook-host")
+	if c.IsSet("server-webhook-host") {
+		server.Config.Server.WebhookHost = c.String("server-webhook-host")
+	} else {
+		server.Config.Server.WebhookHost = c.String("server-host")
+	}
 	if c.IsSet("server-dev-oauth-host") {
 		server.Config.Server.OAuthHost = c.String("server-dev-oauth-host")
 	} else {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -341,6 +341,7 @@ func setupEvilGlobals(c *cli.Context, v store.Store, f forge.Forge) {
 	server.Config.Server.Key = c.String("server-key")
 	server.Config.Server.AgentToken = c.String("agent-secret")
 	server.Config.Server.Host = c.String("server-host")
+	server.Config.Server.WebhookHost = c.String("server-webhook-host")
 	if c.IsSet("server-dev-oauth-host") {
 		server.Config.Server.OAuthHost = c.String("server-dev-oauth-host")
 	} else {

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -132,7 +132,7 @@ Server fully qualified URL of the user-facing hostname.
 Example: `WOODPECKER_HOST=http://woodpecker.example.org`
 
 ### `WOODPECKER_WEBHOOK_HOST`
-> Default: empty
+> Default: value from `WOODPECKER_HOST` config env
 
 Server fully qualified URL of the Webhook-facing hostname.
 

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -131,6 +131,13 @@ Server fully qualified URL of the user-facing hostname.
 
 Example: `WOODPECKER_HOST=http://woodpecker.example.org`
 
+### `WOODPECKER_WEBHOOK_HOST`
+> Default: empty
+
+Server fully qualified URL of the Webhook-facing hostname.
+
+Example: `WOODPECKER_HOST=http://woodpecker-server.cicd.svc.cluster.local:8000`
+
 ### `WOODPECKER_SERVER_ADDR`
 > Default: `:8000`
 

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -136,7 +136,7 @@ Example: `WOODPECKER_HOST=http://woodpecker.example.org`
 
 Server fully qualified URL of the Webhook-facing hostname.
 
-Example: `WOODPECKER_HOST=http://woodpecker-server.cicd.svc.cluster.local:8000`
+Example: `WOODPECKER_WEBHOOK_HOST=http://woodpecker-server.cicd.svc.cluster.local:8000`
 
 ### `WOODPECKER_SERVER_ADDR`
 > Default: `:8000`

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -108,9 +108,13 @@ func PostRepo(c *gin.Context) {
 		return
 	}
 
+	wpHost := server.Config.Server.WebhookHost
+	if wpHost == "" {
+		wpHost = server.Config.Server.Host
+	}
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
-		server.Config.Server.Host,
+		wpHost,
 		sig,
 	)
 

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -108,13 +108,9 @@ func PostRepo(c *gin.Context) {
 		return
 	}
 
-	wpHost := server.Config.Server.WebhookHost
-	if wpHost == "" {
-		wpHost = server.Config.Server.Host
-	}
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
-		wpHost,
+		server.Config.Server.WebhookHost,
 		sig,
 	)
 

--- a/server/config.go
+++ b/server/config.go
@@ -59,6 +59,7 @@ var Config = struct {
 		Cert                string
 		OAuthHost           string
 		Host                string
+		WebhookHost         string
 		Port                string
 		PortTLS             string
 		AgentToken          string


### PR DESCRIPTION
When SCM and Woodpecker are deployed in the same cluster, I want that SCM requests Woodpecker directly by internal URL.

![Webhook-host-diagram](https://github.com/woodpecker-ci/woodpecker/assets/127358482/c4689d55-839a-4731-95b3-5734ba561e5f)
 
This PR adds optional URL used for Webhook calls.