### PR TITLE
Add minimum usage for CLI v0.15.x to docs

### DIFF
--- a/docs/versioned_docs/version-0.15/40-cli.md
+++ b/docs/versioned_docs/version-0.15/40-cli.md
@@ -1,3 +1,34 @@
 # CLI
 
-TODO
+```docker run --rm woodpeckerci/woodpecker-cli:v0.15```
+```bash
+NAME:
+   woodpecker-cli - command line utility
+
+USAGE:
+   woodpecker-cli [global options] command [command options] [arguments...]
+
+VERSION:
+   next-fc7aacb6
+
+COMMANDS:
+   build      manage builds
+   log        manage logs
+   deploy     deploy code
+   exec       execute a local build
+   info       show information about the current user
+   registry   manage registries
+   secret     manage secrets
+   repo       manage repositories
+   user       manage users
+   lint       lint a pipeline configuration file
+   log-level  get the logging level of the server, or set it with [level]
+   help, h    Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --token value, -t value   server auth token [$WOODPECKER_TOKEN]
+   --server value, -s value  server address [$WOODPECKER_SERVER]
+   --log-level value         set logging level [$WOODPECKER_LOG_LEVEL]
+   --help, -h                show help (default: false)
+   --version, -v             print the version (default: false)
+```

--- a/docs/versioned_docs/version-0.15/40-cli.md
+++ b/docs/versioned_docs/version-0.15/40-cli.md
@@ -12,10 +12,10 @@ VERSION:
    v0.15.x
 
 COMMANDS:
-   build      manage builds
+   build      manage pipelines
    log        manage logs
    deploy     deploy code
-   exec       execute a local build
+   exec       execute a pipeline locally
    info       show information about the current user
    registry   manage registries
    secret     manage secrets

--- a/docs/versioned_docs/version-0.15/40-cli.md
+++ b/docs/versioned_docs/version-0.15/40-cli.md
@@ -9,7 +9,7 @@ USAGE:
    woodpecker-cli [global options] command [command options] [arguments...]
 
 VERSION:
-   next-fc7aacb6
+   v0.15.x
 
 COMMANDS:
    build      manage builds


### PR DESCRIPTION
Minimum effort documentation, better than none.
Covers:
* Fetching the tool
* Running the tool
* Basic usage help output