### PR TITLE
Fix bitbucket forge add repo

### DIFF
--- a/server/forge/bitbucket/bitbucket.go
+++ b/server/forge/bitbucket/bitbucket.go
@@ -157,6 +157,17 @@ func (c *config) Repo(ctx context.Context, u *model.User, remoteID model.ForgeRe
 	if remoteID.IsValid() {
 		name = string(remoteID)
 	}
+	repos, err := c.Repos(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+	if len(owner) == 0 {
+		for _, repo := range repos {
+			if string(repo.ForgeRemoteID) == name {
+				owner = repo.Owner
+			}
+		}
+	}
 	client := c.newClient(ctx, u)
 	repo, err := client.FindRepo(owner, name)
 	if err != nil {

--- a/server/forge/bitbucket/bitbucket.go
+++ b/server/forge/bitbucket/bitbucket.go
@@ -165,6 +165,7 @@ func (c *config) Repo(ctx context.Context, u *model.User, remoteID model.ForgeRe
 		for _, repo := range repos {
 			if string(repo.ForgeRemoteID) == name {
 				owner = repo.Owner
+				break
 			}
 		}
 	}


### PR DESCRIPTION
The workspace is a required field for ivoking bitbucket's API. While workspace is not available it must be fetched through the Repos func.

Fixes #1882