### PR TITLE
Store agent ID in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ __debug_bin
 web/dist/**
 !web/dist/.gitkeep
 web/node_modules/
-web/package-lock.json
 web/*.log
 web/.env
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ __debug_bin
 web/dist/**
 !web/dist/.gitkeep
 web/node_modules/
+web/package-lock.json
 web/*.log
 web/.env
 

--- a/cmd/agent/agent_test.go
+++ b/cmd/agent/agent_test.go
@@ -16,9 +16,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringSliceAddToMap(t *testing.T) {
@@ -126,6 +127,7 @@ func TestWriteAgentIDFileNotExists(t *testing.T) {
 	}
 	assert.EqualValues(t, "42\n", actual)
 }
+
 func TestWriteAgentIDFileExists(t *testing.T) {
 	parameters := []struct {
 		fileInput  string

--- a/cmd/agent/agent_test.go
+++ b/cmd/agent/agent_test.go
@@ -15,9 +15,10 @@
 package main
 
 import (
-	"testing"
-
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
 )
 
 func TestStringSliceAddToMap(t *testing.T) {
@@ -70,6 +71,93 @@ func TestStringSliceAddToMap(t *testing.T) {
 			} else {
 				assert.EqualValues(t, tt.expected, tt.m)
 			}
+		})
+	}
+}
+
+func TestReadAgentIDFileNotExists(t *testing.T) {
+	assert.EqualValues(t, -1, readAgentID("foobar.conf"))
+}
+
+func TestReadAgentIDFileExists(t *testing.T) {
+	parameters := []struct {
+		input    string
+		expected int64
+	}{
+		{"42", 42},
+		{"42\n", 42},
+		{"  \t42\t\r\t", 42},
+		{"0", 0},
+		{"-1", -1},
+		{"foo", -1},
+		{"1f", -1},
+		{"", -1},
+		{"-42", -42},
+	}
+
+	for i := range parameters {
+		t.Run(fmt.Sprintf("Testing [%v]", i), func(t *testing.T) {
+			tmpF, errTmpF := os.CreateTemp("", "tmp_")
+			if !assert.NoError(t, errTmpF) {
+				t.FailNow()
+			}
+
+			errWrite := os.WriteFile(tmpF.Name(), []byte(parameters[i].input), 0o644)
+			if !assert.NoError(t, errWrite) {
+				t.FailNow()
+			}
+
+			actual := readAgentID(tmpF.Name())
+			assert.EqualValues(t, parameters[i].expected, actual)
+		})
+	}
+}
+
+func TestWriteAgentIDFileNotExists(t *testing.T) {
+	tmpF, errTmpF := os.CreateTemp("", "tmp_")
+	if !assert.NoError(t, errTmpF) {
+		t.FailNow()
+	}
+
+	writeAgentID(42, tmpF.Name())
+	actual, errRead := os.ReadFile(tmpF.Name())
+	if !assert.NoError(t, errRead) {
+		t.FailNow()
+	}
+	assert.EqualValues(t, "42\n", actual)
+}
+func TestWriteAgentIDFileExists(t *testing.T) {
+	parameters := []struct {
+		fileInput  string
+		writeInput int64
+		expected   string
+	}{
+		{"", 42, "42\n"},
+		{"\n", 42, "42\n"},
+		{"41\n", 42, "42\n"},
+		{"0", 42, "42\n"},
+		{"-1", 42, "42\n"},
+		{"foöbar", 42, "42\n"},
+	}
+
+	for i := range parameters {
+		t.Run(fmt.Sprintf("Testing [%v]", i), func(t *testing.T) {
+			tmpF, errTmpF := os.CreateTemp("", "tmp_")
+			if !assert.NoError(t, errTmpF) {
+				t.FailNow()
+			}
+
+			errWrite := os.WriteFile(tmpF.Name(), []byte(parameters[i].fileInput), 0o644)
+			if !assert.NoError(t, errWrite) {
+				t.FailNow()
+			}
+
+			writeAgentID(parameters[i].writeInput, tmpF.Name())
+			actual, errRead := os.ReadFile(tmpF.Name())
+			if !assert.NoError(t, errRead) {
+				t.FailNow()
+			}
+			assert.EqualValues(t, parameters[i].expected, actual)
 		})
 	}
 }

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -68,7 +68,7 @@ var flags = []cli.Flag{
 		Usage:   "agent hostname",
 	},
 	&cli.StringFlag{
-		EnvVars: []string{"WOODPECKER_AGENT_ID_CONFIG_PATH"},
+		EnvVars: []string{"WOODPECKER_AGENT_ID_FILE"},
 		Name:    "agent-id-config-path",
 		Usage:   "agent-id config file path",
 		Value:   "/etc/woodpecker/agent-id.conf",

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -67,6 +67,12 @@ var flags = []cli.Flag{
 		Name:    "hostname",
 		Usage:   "agent hostname",
 	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_AGENT_ID_CONFIG_PATH"},
+		Name:    "agent-id-config-path",
+		Usage:   "agent-id config file path",
+		Value:   "/etc/agent-id.conf",
+	},
 	&cli.StringSliceFlag{
 		EnvVars: []string{"WOODPECKER_FILTER_LABELS"},
 		Name:    "filter",

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -71,7 +71,7 @@ var flags = []cli.Flag{
 		EnvVars: []string{"WOODPECKER_AGENT_ID_CONFIG_PATH"},
 		Name:    "agent-id-config-path",
 		Usage:   "agent-id config file path",
-		Value:   "/etc/agent-id.conf",
+		Value:   "/etc/woodpecker/agent-id.conf",
 	},
 	&cli.StringSliceFlag{
 		EnvVars: []string{"WOODPECKER_FILTER_LABELS"},

--- a/docker/Dockerfile.agent.alpine.multiarch
+++ b/docker/Dockerfile.agent.alpine.multiarch
@@ -6,6 +6,7 @@ ARG TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     make build-agent
+RUN mkdir -p /etc/woodpecker
 
 FROM alpine:3.18
 RUN apk add -U --no-cache ca-certificates
@@ -13,6 +14,7 @@ ENV GODEBUG=netdns=go
 EXPOSE 3000
 
 COPY --from=build /src/dist/woodpecker-agent /bin/
+COPY --from=build /etc/woodpecker /etc
 
 HEALTHCHECK CMD ["/bin/woodpecker-agent", "ping"]
 ENTRYPOINT ["/bin/woodpecker-agent"]

--- a/docker/Dockerfile.agent.alpine.multiarch
+++ b/docker/Dockerfile.agent.alpine.multiarch
@@ -6,7 +6,6 @@ ARG TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     make build-agent
-RUN mkdir -p /etc/woodpecker
 
 FROM alpine:3.18
 RUN apk add -U --no-cache ca-certificates
@@ -14,7 +13,7 @@ ENV GODEBUG=netdns=go
 EXPOSE 3000
 
 COPY --from=build /src/dist/woodpecker-agent /bin/
-COPY --from=build /etc/woodpecker /etc
+RUN mkdir -p /etc/woodpecker
 
 HEALTHCHECK CMD ["/bin/woodpecker-agent", "ping"]
 ENTRYPOINT ["/bin/woodpecker-agent"]

--- a/docker/Dockerfile.agent.multiarch
+++ b/docker/Dockerfile.agent.multiarch
@@ -6,6 +6,7 @@ ARG TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     make build-agent
+RUN mkdir -p /etc/woodpecker
 
 FROM scratch
 ENV GODEBUG=netdns=go
@@ -15,6 +16,7 @@ EXPOSE 3000
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 # copy agent binary
 COPY --from=build /src/dist/woodpecker-agent /bin/
+COPY --from=build /etc/woodpecker /etc
 
 HEALTHCHECK CMD ["/bin/woodpecker-agent", "ping"]
 ENTRYPOINT ["/bin/woodpecker-agent"]

--- a/docs/docs/30-administration/15-agent-config.md
+++ b/docs/docs/30-administration/15-agent-config.md
@@ -58,7 +58,7 @@ A shared secret used by server and agents to authenticate communication. A secre
 ### `WOODPECKER_AGENT_SECRET_FILE`
 > Default: empty
 
-Read the value for `WOODPECKER_AGENT_SECRET` from the specified filepath
+Read the value for `WOODPECKER_AGENT_SECRET` from the specified filepath, e.g. `/etc/woodpecker/agent-secret.conf`
 
 ### `WOODPECKER_LOG_LEVEL`
 > Default: empty

--- a/docs/docs/30-administration/15-agent-config.md
+++ b/docs/docs/30-administration/15-agent-config.md
@@ -80,7 +80,7 @@ Disable colored debug output.
 
 Configures the agent hostname.
 
-### `WOODPECKER_AGENT_ID_CONFIG_PATH`
+### `WOODPECKER_AGENT_ID_FILE`
 > Default: `/etc/woodpecker/agent-id.conf`
 
 Configures the path of the agent-id.conf file.

--- a/docs/docs/30-administration/15-agent-config.md
+++ b/docs/docs/30-administration/15-agent-config.md
@@ -80,6 +80,11 @@ Disable colored debug output.
 
 Configures the agent hostname.
 
+### `WOODPECKER_AGENT_ID_CONFIG_PATH`
+> Default: `/etc/woodpecker/agent-id.conf`
+
+Configures the path of the agent-id.conf file.
+
 ### `WOODPECKER_MAX_WORKFLOWS`
 > Default: `1`
 

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -342,6 +342,7 @@
                 "agents": "Agents",
                 "desc": "Agents registered for this server",
                 "none": "There are no agents yet.",
+                "id": "ID",
                 "add": "Add agent",
                 "save": "Save agent",
                 "show": "Show agents",

--- a/web/src/components/admin/settings/AdminAgentsTab.vue
+++ b/web/src/components/admin/settings/AdminAgentsTab.vue
@@ -67,7 +67,7 @@
           </InputField>
 
           <InputField :label="$t('admin.settings.agents.id')">
-            <TextField v-model="selectedAgent.id" disabled />
+            <TextField :model-value="selectedAgent.id?.toString()" disabled />
           </InputField>
 
           <InputField

--- a/web/src/components/admin/settings/AdminAgentsTab.vue
+++ b/web/src/components/admin/settings/AdminAgentsTab.vue
@@ -66,6 +66,10 @@
             <TextField v-model="selectedAgent.token" :placeholder="$t('admin.settings.agents.token')" disabled />
           </InputField>
 
+          <InputField :label="$t('admin.settings.agents.id')">
+            <TextField v-model="selectedAgent.id" disabled />
+          </InputField>
+
           <InputField
             :label="$t('admin.settings.agents.backend.backend')"
             docs-url="docs/next/administration/backends/docker"


### PR DESCRIPTION
This PR solves the following TODO in `/cmd/agent/agent.go`:
https://github.com/woodpecker-ci/woodpecker/blob/1fa021273126ddf2700a8dea0a3e990ede344a90/cmd/agent/agent.go#L112

It ensures that the agent ID is persisted in a file and can then, for example, also be bind-mounted in a Docker container. The new ~`WOODPECKER_AGENT_ID_CONFIG_PATH`~ `WOODPECKER_AGENT_ID_FILE` environment variable makes it possible to configure the file path.