### PR TITLE
Fix empty agent token

### DIFF
--- a/server/store/datastore/agent.go
+++ b/server/store/datastore/agent.go
@@ -15,6 +15,8 @@
 package datastore
 
 import (
+	"errors"
+
 	"github.com/woodpecker-ci/woodpecker/server/model"
 )
 
@@ -29,6 +31,10 @@ func (s storage) AgentFind(id int64) (*model.Agent, error) {
 }
 
 func (s storage) AgentFindByToken(token string) (*model.Agent, error) {
+	// Searching with an empty token would result in an empty where clause and therefore returning first item
+	if token == "" {
+		return nil, errors.New("Please provide a token")
+	}
 	agent := &model.Agent{
 		Token: token,
 	}

--- a/server/store/datastore/agent_test.go
+++ b/server/store/datastore/agent_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"testing"
+
+	"github.com/woodpecker-ci/woodpecker/server/model"
+)
+
+func TestAgentFindByToken(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Agent))
+	defer closer()
+
+	agent := &model.Agent{
+		ID:    int64(1),
+		Name:  "test",
+		Token: "secret-token",
+	}
+	if err := store.AgentCreate(agent); err != nil {
+		t.Errorf("Unexpected error: insert agent: %s", err)
+		return
+	}
+
+	_agent, err := store.AgentFindByToken(agent.Token)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if got, want := _agent.ID, int64(1); got != want {
+		t.Errorf("Want config id %d, got %d", want, got)
+	}
+
+	_agent, err = store.AgentFindByToken("")
+	if err == nil || err.Error() != "Please provide a token" {
+		t.Errorf("Expected to get an error for an empty token, but got %s", err)
+		return
+	}
+
+	if _agent != nil {
+		t.Errorf("Expected to not find an agent")
+		return
+	}
+}


### PR DESCRIPTION
Using an empty token for an agent was returning the first agent from the database as the orm is not adding where clauses for empty strings of a model when querying.

# Huge thanks for reporting and explaining the issue ❤️ 

- Dominik Heidler
- Timo Tomasini

```diff
$ git diff
diff --git a/cmd/agent/agent.go b/cmd/agent/agent.go
index fd5c06ca..3e24d9ea 100644
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -113,6 +113,8 @@ func run(c *cli.Context) error {

agentID := readAgentId(agentIdConfigPath)
agentToken := c.String("grpc-token")
+ agentToken = ""
+ agentID = 0
authClient := agentRpc.NewAuthGrpcClient(authConn, agentToken, agentID)
authInterceptor, err := agentRpc.NewAuthInterceptor(authClient, 30*time.Minute)
if err != nil {
@@ -175,7 +177,7 @@ func run(c *cli.Context) error {
return err
}

- agentID, err = client.RegisterAgent(ctx, platform, engine.Name(), version.String(), parallel)
+ agentID, err = client.RegisterAgent(ctx, platform, engine.Name(), "P0WN-client", parallel)
if err != nil {
return err
}
```

```bash
$ ./dist/woodpecker-agent --pretty
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -extldflags "-static" -X [github.com/woodpecker-ci/woodpecker/version.Version=next-fe5df230](https://github.com/woodpecker-ci/woodpecker/compare/github.com/woodpecker-ci/woodpecker/version.Version=next-fe5df230)' -o dist/woodpecker-agent [github.com/woodpecker-ci/woodpecker/cmd/agent](https://github.com/woodpecker-ci/woodpecker/compare/github.com/woodpecker-ci/woodpecker/cmd/agent)
2023/06/27 15:57:18 Token refreshed: [REDACTED JWT TOKEN HERE]
3:57PM DBG cmd/agent/agent.go:202 > Agent registered with ID 2
3:57PM INF cmd/agent/agent.go:249 > Starting Woodpecker agent with version 'next-fe5df230' and backend 'local' using platform 'linux/amd64' running up to 4 pipelines in parallel
3:57PM DBG cmd/agent/agent.go:233 > loaded local backend engine
3:57PM DBG cmd/agent/agent.go:233 > loaded local backend engine
3:57PM DBG cmd/agent/agent.go:233 > loaded local backend engine
3:57PM DBG cmd/agent/agent.go:240 > polling new steps
3:57PM DBG cmd/agent/agent.go:240 > polling new steps
3:57PM DBG cmd/agent/agent.go:240 > polling new steps
3:57PM DBG agent/runner.go:53 > request next execution
3:57PM DBG agent/runner.go:53 > request next execution
3:57PM DBG agent/runner.go:53 > request next execution
3:57PM DBG cmd/agent/agent.go:233 > loaded local backend engine
3:57PM DBG cmd/agent/agent.go:240 > polling new steps
3:57PM DBG agent/runner.go:53 > request next execution
```

```bash
# (on a different shell)
$ curl -s ${WOODPECKER_SERVER}/api/agents -H "Authorization: Bearer ${WOODPECKER_TOKEN}" | json_pp | grep P0WN
"version" : "P0WN-client"
"version" : "P0WN-client"
"version" : "P0WN-client"
```