### PR TITLE
Add flexible `ImagePullSecrets` support

### DIFF
--- a/cli/exec/flags.go
+++ b/cli/exec/flags.go
@@ -375,4 +375,10 @@ var flags = []cli.Flag{
 		Usage:   "backend k8s additional worker pod annotations",
 		Value:   "",
 	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_BACKEND_K8S_IMAGE_PULL_SECRETS"},
+		Name:    "backend-k8s-pod-image-pull-secrets",
+		Usage:   "backend k8s pull secrets for private registries",
+		Value:   "regcred",
+	},
 }

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -190,6 +190,12 @@ var flags = []cli.Flag{
 		Usage:   "backend k8s additional worker pod annotations",
 		Value:   "",
 	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_BACKEND_K8S_IMAGE_PULL_SECRETS"},
+		Name:    "backend-k8s-pod-image-pull-secrets",
+		Usage:   "backend k8s pull secrets for private registries",
+		Value:   "regcred",
+	},
 	&cli.IntFlag{
 		EnvVars: []string{"WOODPECKER_CONNECT_RETRY_COUNT"},
 		Name:    "connect-retry-count",

--- a/docs/docs/30-administration/80-kubernetes.md
+++ b/docs/docs/30-administration/80-kubernetes.md
@@ -53,3 +53,9 @@ helm upgrade --install woodpecker-agent --namespace <namespace> woodpecker/woodp
 # Uninstall
 helm delete woodpecker-agent
 ```
+
+## ImagePullSecrets
+
+By default pods look for a secret named "regcred" in the respective namespace.
+Existing secrets can be used by overwriting the default secret name Woodpecker is looking for via the k8s backend option `backend-k8s-pod-image-pull-secret`.
+Multiple secrets can be referenced!

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Pod(namespace string, step *types.Step, labels, annotations map[string]string) (*v1.Pod, error) {
+func Pod(namespace string, step *types.Step, labels, annotations map[string]string, ImagePullSecrets) (*v1.Pod, error) {
 	var (
 		vols       []v1.Volume
 		volMounts  []v1.VolumeMount
@@ -132,7 +132,7 @@ func Pod(namespace string, step *types.Step, labels, annotations map[string]stri
 					Privileged: &step.Privileged,
 				},
 			}},
-			ImagePullSecrets: []v1.LocalObjectReference{{Name: "regcred"}},
+			ImagePullSecrets: ImagePullSecrets,
 			Volumes:          vols,
 		},
 	}


### PR DESCRIPTION
Currently `ImagePullSecrets` is hardcoded to a secret named `regcred`: https://github.com/woodpecker-ci/woodpecker/blob/e1c31df6c6e28eade007c6a6fc24bf6b9d26e203/pipeline/backend/kubernetes/pod.go#L135

This PR aims to make it more flexible and let users specify multiple secrets via a server-wide k8s backend option, similar to labels and annotations.

@woodpecker-ci/maintainers 

My golang skils are limited and I've added some `FIXME`s in places where I need help for a "proper" implementation.
