### PR TITLE
Added Nextcloud Upload plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -123,6 +123,11 @@
       "name": "TODO-Checker",
       "docs": "https://codeberg.org/Epsilon_02/todo-checker/raw/branch/main/README.md",
       "verfied": false
+    },
+    {
+      "name": "Nextcloud Upload",
+      "docs": "https://raw.githubusercontent.com/Ellpeck/WoodpeckerPlugins/main/nextcloud-upload/README.md",
+      "verfied": false
     }
   ]
 }


### PR DESCRIPTION
Hi! This pull request adds my plugin [Nextcloud Upload](https://github.com/Ellpeck/WoodpeckerPlugins/tree/main/nextcloud-upload) to the official plugin list. 

I'm aware that there's already an official plugin that allows uploading files using WebDAV, but my plugin has two Nextcloud-specific additions that aren't part of the regular WebDAV spec:
- The ability to chunk uploads, which is necessary for larger files if Nextcloud is hosted behind Cloudflare (which restricts uploads to a maximum of 100MB)
- The ability to apply Nextcloud tags, which allows automatically categorizing items and using Nextcloud's Retention plugin to easily auto-remove older artifacts.

Please let me know if you have any additional questions or if there's anything I forgot or need to change. I searched for documentation on adding plugins to the list, but couldn't seem to find any - so if there's something I overlooked, please let me know! ❤️