### PR TITLE
Add Kubernetes Plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -122,12 +122,17 @@
     {
       "name": "TODO-Checker",
       "docs": "https://codeberg.org/Epsilon_02/todo-checker/raw/branch/main/README.md",
-      "verfied": false
+      "verified": false
     },
     {
       "name": "Nextcloud Upload",
       "docs": "https://raw.githubusercontent.com/Ellpeck/WoodpeckerPlugins/main/nextcloud-upload/README.md",
-      "verfied": false
+      "verified": false
+    },
+    {
+      "name": "Kubernetes Deployment or StatefulSet Update",
+      "docs": "https://raw.githubusercontent.com/euryecetelecom/woodpeckerci-kubernetes/master/README.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
Add kubernetes Deployment/StatefulSet update plugin.

Based on unmaintened Drone Kubernetes plugin.

I took the StatefulSet management update and added wait capabilities (to allow performing automatic service tests after deployment is finished)