### PR TITLE
Add Kubernetes and Dockle Plugins

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -122,12 +122,22 @@
     {
       "name": "TODO-Checker",
       "docs": "https://codeberg.org/Epsilon_02/todo-checker/raw/branch/main/README.md",
-      "verfied": false
+      "verified": false
     },
     {
       "name": "Nextcloud Upload",
       "docs": "https://raw.githubusercontent.com/Ellpeck/WoodpeckerPlugins/main/nextcloud-upload/README.md",
-      "verfied": false
+      "verified": false
+    },
+    {
+      "name": "Kubernetes Deployment or StatefulSet Update",
+      "docs": "https://raw.githubusercontent.com/euryecetelecom/woodpeckerci-kubernetes/master/README.md",
+      "verified": false
+    },
+    {
+      "name": "Dockle",
+      "docs": "https://raw.githubusercontent.com/euryecetelecom/woodpeckerci-dockle/master/README.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
Add Kubernetes Deployments and StatefulSet update and Dockle Scan Plugins.

For Kubernetes plugin, I based on the Drone unmaintened Kubernetes plugin and took the statefulset management evolutions. I added sync/wait and force redeploy capabilities + updates dependencies

For Dockle plugin, I took example on Trivy plugin.