### PR TITLE
Add makefile to make container and .pnpn-store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ docker-compose.yml
 *.sqlite
 *.out
 /.env
+/.pnpm-store
 extras/
 /build/
 /dist/

--- a/docker/Dockerfile.make
+++ b/docker/Dockerfile.make
@@ -7,6 +7,7 @@ RUN apk add --no-cache --update make gcc binutils-gold musl-dev && \
 
 # Build packages.
 COPY --from=golang_image /usr/local/go /usr/local/go
+COPY Makefile /
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Cache tools


### PR DESCRIPTION
Running `make in_docker ...` on a fresh system failed:

```
 => CACHED [stage-1 3/6] COPY --from=golang_image /usr/local/go /usr/local/go                                                                                                                                                                            0.0s
 => ERROR [stage-1 4/6] RUN make install-tools &&   mv /root/go/bin/* /usr/local/go/bin/ &&   chmod 755 /usr/local/go/bin/*                                                                                                                              0.1s
------                                                                                                                                                                                                                                                        
 > [stage-1 4/6] RUN make install-tools &&   mv /root/go/bin/* /usr/local/go/bin/ &&   chmod 755 /usr/local/go/bin/*:
0.132 make: *** No rule to make target 'install-tools'.  Stop.
------
Dockerfile.make:14
--------------------
  13 |     # Cache tools
  14 | >>> RUN make install-tools && \
  15 | >>>   mv /root/go/bin/* /usr/local/go/bin/ && \
  16 | >>>   chmod 755 /usr/local/go/bin/*
  17 |     
--------------------
```