### PR TITLE
Add option to configure the vite dev server host

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,8 +16,9 @@ function woodpeckerInfoPlugin() {
     name: 'woodpecker-info',
     configureServer() {
       const info =
-        'Please add `WOODPECKER_DEV_WWW_PROXY=http://localhost:8010` to your `.env` file.\n' +
-        'After starting the woodpecker server as well you should now be able to access the UI at http://localhost:8000/';
+        '1) Please add `WOODPECKER_DEV_WWW_PROXY=http://localhost:8010` to your `.env` file.\n' +
+        'After starting the woodpecker server as well you should now be able to access the UI at http://localhost:8000/\n\n' +
+        '2) If you want to run the vite dev server (`pnpm start`) within a container please set `VITE_DEV_SERVER_HOST=0.0.0.0`.';
       // eslint-disable-next-line no-console
       console.log(info);
     },
@@ -71,6 +72,7 @@ export default defineConfig({
   },
   logLevel: 'warn',
   server: {
+    host: process.env.VITE_DEV_SERVER_HOST || '127.0.0.1',
     port: 8010,
   },
 });


### PR DESCRIPTION
If you want to run the vite dev server in a container, it needs to be exposed to `0.0.0.0`. 