### PR TITLE
Remove code to read agent-id.conf

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -112,11 +112,6 @@ func run(c *cli.Context) error {
 
 	agentConfig := readAgentConfig(agentConfigPath)
 
-	// deprecated
-	if agentConfig.AgentID == defaultAgentIDValue {
-		agentConfig.AgentID = readAgentID(c.String("agent-id-config-path"))
-	}
-
 	agentToken := c.String("grpc-token")
 	authClient := agentRpc.NewAuthGrpcClient(authConn, agentToken, agentConfig.AgentID)
 	authInterceptor, err := agentRpc.NewAuthInterceptor(authClient, 30*time.Minute)

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -71,24 +70,4 @@ func writeAgentConfig(conf AgentConfig, agentConfigPath string) {
 			log.Error().Err(err).Msgf("could not persist agent config at '%s'", agentConfigPath)
 		}
 	}
-}
-
-// deprecated
-func readAgentID(agentIDConfigPath string) int64 {
-	const defaultAgentIDValue = int64(-1)
-
-	rawAgentID, fileErr := os.ReadFile(agentIDConfigPath)
-	if fileErr != nil {
-		log.Debug().Err(fileErr).Msgf("could not open agent-id config file from %s", agentIDConfigPath)
-		return defaultAgentIDValue
-	}
-
-	strAgentID := strings.TrimSpace(string(rawAgentID))
-	agentID, parseErr := strconv.ParseInt(strAgentID, 10, 64)
-	if parseErr != nil {
-		log.Warn().Err(parseErr).Msg("could not parse agent-id config file content to int64")
-		return defaultAgentIDValue
-	}
-
-	return agentID
 }

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -30,17 +30,32 @@ func TestReadAgentIDFileExists(t *testing.T) {
 	if !assert.NoError(t, errTmpF) {
 		t.FailNow()
 	}
+	defer os.Remove(tmpF.Name())
 
+	// there is an existing config
 	errWrite := os.WriteFile(tmpF.Name(), []byte(`{"agent_id":3}`), 0o644)
 	if !assert.NoError(t, errWrite) {
 		t.FailNow()
 	}
 
+	// read existing config
 	actual := readAgentConfig(tmpF.Name())
 	assert.EqualValues(t, AgentConfig{3}, actual)
 
+	// update existing config and check
 	actual.AgentID = 33
 	writeAgentConfig(actual, tmpF.Name())
 	actual = readAgentConfig(tmpF.Name())
+	assert.EqualValues(t, 33, actual.AgentID)
+
+	tmpF2, errTmpF := os.CreateTemp("", "tmp_")
+	if !assert.NoError(t, errTmpF) {
+		t.FailNow()
+	}
+	defer os.Remove(tmpF2.Name())
+
+	// write new config
+	writeAgentConfig(actual, tmpF2.Name())
+	actual = readAgentConfig(tmpF2.Name())
 	assert.EqualValues(t, 33, actual.AgentID)
 }

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -208,13 +208,4 @@ var flags = []cli.Flag{
 		Usage:   "duration to wait before retrying to connect to the server",
 		Value:   time.Second * 2,
 	},
-
-	// DEPRECATED
-	&cli.StringFlag{
-		EnvVars: []string{"WOODPECKER_AGENT_ID_FILE"},
-		Name:    "agent-id-config-path",
-		Usage:   "agent-id config file path",
-		Value:   "/etc/woodpecker/agent-id.conf",
-		Hidden:  true,
-	},
 }


### PR DESCRIPTION
I want to have c805c87e9035898e712c918cbbdda9c4394013e5 published at least for 2 days ...
... so the migration did happen