### PR TITLE
Fix wrong repo url used by badges

### DIFF
--- a/web/src/components/repo/settings/BadgeTab.vue
+++ b/web/src/components/repo/settings/BadgeTab.vue
@@ -93,7 +93,9 @@ export default defineComponent({
     const badgeUrl = computed(
       () => `/api/badges/${repo.value.id}/status.svg${branch.value !== '' ? `?branch=${branch.value}` : ''}`,
     );
-    const repoUrl = computed(() => `/repos/${repo.value.id}${branch.value !== '' ? `/branches/${branch.value}` : ''}`);
+    const repoUrl = computed(
+      () => `/repos/${repo.value.id}${branch.value !== '' ? `/branches/${encodeURIComponent(branch.value)}` : ''}`,
+    );
 
     const badgeContent = computed(() => {
       if (!repo) {

--- a/web/src/components/repo/settings/BadgeTab.vue
+++ b/web/src/components/repo/settings/BadgeTab.vue
@@ -93,7 +93,7 @@ export default defineComponent({
     const badgeUrl = computed(
       () => `/api/badges/${repo.value.id}/status.svg${branch.value !== '' ? `?branch=${branch.value}` : ''}`,
     );
-    const repoUrl = computed(() => `/${repo.value.id}${branch.value !== '' ? `/branches/${branch.value}` : ''}`);
+    const repoUrl = computed(() => `/repos/${repo.value.id}${branch.value !== '' ? `/branches/${branch.value}` : ''}`);
 
     const badgeContent = computed(() => {
       if (!repo) {


### PR DESCRIPTION
The current URL doesn't work

![image](https://github.com/woodpecker-ci/woodpecker/assets/3391958/13318c05-919a-4405-bbbb-7c6cd3505bda)
