### PR TITLE
let generic datastore error include func name

### DIFF
--- a/server/store/datastore/helper.go
+++ b/server/store/datastore/helper.go
@@ -31,6 +31,7 @@ func wrapGet(exist bool, err error) error {
 		err = types.RecordNotExist
 	}
 	if err != nil {
+		// we only ask for the function's name if needed, as it's not as preformatted as to just execute it
 		fnName := callerName(2)
 		return fmt.Errorf("%s: %w", fnName, err)
 	}
@@ -43,6 +44,7 @@ func wrapDelete(c int64, err error) error {
 		err = types.RecordNotExist
 	}
 	if err != nil {
+		// we only ask for the function's name if needed, as it's not as preformatted as to just execute it
 		fnName := callerName(2)
 		return fmt.Errorf("%s: %w", fnName, err)
 	}

--- a/server/store/datastore/helper.go
+++ b/server/store/datastore/helper.go
@@ -17,6 +17,7 @@ package datastore
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"xorm.io/xorm"
 
@@ -66,5 +67,10 @@ func callerName(skip int) string {
 	if !ok {
 		return ""
 	}
-	return runtime.FuncForPC(pc).Name()
+	fnName := runtime.FuncForPC(pc).Name()
+	pIndex := strings.LastIndex(fnName, ".")
+	if pIndex != -1 {
+		fnName = fnName[pIndex+1:]
+	}
+	return fnName
 }


### PR DESCRIPTION
error logs like:
```
{"level":"warn","error":"sql: no rows in result set","time":"2023-07-25T21:29:56Z"}
```

have to less context to be helpfull.
this will cange it as the message now looks like:

```
{"level":"warn","error":"GetPipelineLast: sql: no rows in result set", "time":"2023-07-27T02:54:25+02:00"}
```