### PR TITLE
Missed deprecation

### DIFF
--- a/agent/tracer.go
+++ b/agent/tracer.go
@@ -75,6 +75,7 @@ func (r *Runner) createTracer(ctxmeta context.Context, logger zerolog.Logger, wo
 		state.Pipeline.Step.Environment["CI_STEP_STATUS"] = "success"
 		state.Pipeline.Step.Environment["CI_STEP_STARTED"] = strconv.FormatInt(state.Pipeline.Time, 10)
 		state.Pipeline.Step.Environment["CI_STEP_FINISHED"] = strconv.FormatInt(time.Now().Unix(), 10)
+
 		state.Pipeline.Step.Environment["CI_SYSTEM_PLATFORM"] = runtime.GOOS + "/" + runtime.GOARCH
 
 		// DEPRECATED

--- a/agent/tracer.go
+++ b/agent/tracer.go
@@ -75,8 +75,7 @@ func (r *Runner) createTracer(ctxmeta context.Context, logger zerolog.Logger, wo
 		state.Pipeline.Step.Environment["CI_STEP_STATUS"] = "success"
 		state.Pipeline.Step.Environment["CI_STEP_STARTED"] = strconv.FormatInt(state.Pipeline.Time, 10)
 		state.Pipeline.Step.Environment["CI_STEP_FINISHED"] = strconv.FormatInt(time.Now().Unix(), 10)
-
-		state.Pipeline.Step.Environment["CI_SYSTEM_ARCH"] = runtime.GOOS + "/" + runtime.GOARCH
+		state.Pipeline.Step.Environment["CI_SYSTEM_PLATFORM"] = runtime.GOOS + "/" + runtime.GOARCH
 
 		// DEPRECATED
 		state.Pipeline.Step.Environment["CI_BUILD_STATUS"] = "success"
@@ -85,6 +84,7 @@ func (r *Runner) createTracer(ctxmeta context.Context, logger zerolog.Logger, wo
 		state.Pipeline.Step.Environment["CI_JOB_STATUS"] = "success"
 		state.Pipeline.Step.Environment["CI_JOB_STARTED"] = strconv.FormatInt(state.Pipeline.Time, 10)
 		state.Pipeline.Step.Environment["CI_JOB_FINISHED"] = strconv.FormatInt(time.Now().Unix(), 10)
+		state.Pipeline.Step.Environment["CI_SYSTEM_ARCH"] = runtime.GOOS + "/" + runtime.GOARCH
 
 		if state.Pipeline.Error != nil {
 			state.Pipeline.Step.Environment["CI_PIPELINE_STATUS"] = "failure"

--- a/docs/docs/30-administration/22-backends/40-kubernetes.md
+++ b/docs/docs/30-administration/22-backends/40-kubernetes.md
@@ -55,7 +55,7 @@ See the [kubernetes documentation](https://kubernetes.io/docs/concepts/security/
 ### nodeSelector
 
 Specify the label which is used to select the node where the job should be executed. Labels defined here will be appended to a list already containing "kubernetes.io/arch".
-By default the pod will use "kubernetes.io/arch" inferred from top-level "platform" setting which is deducted from the agents' environment variable CI_SYSTEM_ARCH. To overwrite this, you need to specify this label in the nodeSelector section.
+By default the pod will use "kubernetes.io/arch" inferred from top-level "platform" setting which is deducted from the agents' environment variable CI_SYSTEM_PLATFORM. To overwrite this, you need to specify this label in the nodeSelector section.
 See the [kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more information on using nodeSelector.
 
 Example pipeline configuration:

--- a/docs/versioned_docs/version-1.0/30-administration/22-backends/40-kubernetes.md
+++ b/docs/versioned_docs/version-1.0/30-administration/22-backends/40-kubernetes.md
@@ -55,7 +55,7 @@ See the [kubernetes documentation](https://kubernetes.io/docs/concepts/security/
 ### nodeSelector
 
 Specify the label which is used to select the node where the job should be executed. Labels defined here will be appended to a list already containing "kubernetes.io/arch".
-By default the pod will use "kubernetes.io/arch" inferred from top-level "platform" setting which is deducted from the agents' environment variable CI_SYSTEM_ARCH. To overwrite this, you need to specify this label in the nodeSelector section.
+By default the pod will use "kubernetes.io/arch" inferred from top-level "platform" setting which is deducted from the agents' environment variable CI_SYSTEM_PLATFORM. To overwrite this, you need to specify this label in the nodeSelector section.
 See the [kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more information on using nodeSelector.
 
 Example pipeline configuration:

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -95,7 +95,7 @@ func Pod(namespace string, step *types.Step, labels, annotations map[string]stri
 	labels["step"] = podName
 
 	var nodeSelector map[string]string
-	platform, exist := step.Environment["CI_SYSTEM_ARCH"]
+	platform, exist := step.Environment["CI_SYSTEM_PLATFORM"]
 	if exist && platform != "" {
 		arch := strings.Split(platform, "/")[1]
 		nodeSelector = map[string]string{v1.LabelArchStable: arch}


### PR DESCRIPTION
in the refactoring we did move from CI_SYSTEM_ARCH to CI_SYSTEM_PLATFORM

but we missed to set the var in the agent pipeline tracer, so the Kubernetes backend did not work with it.

this fix it and also make it  deprecated as intended