### PR TITLE
Bump default clone image version to 2.1.0

### DIFF
--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -32,7 +32,7 @@ var DefaultConfigOrder = [...]string{
 
 const (
 	// DefaultCloneImage can be changed by 'WOODPECKER_DEFAULT_CLONE_IMAGE' at runtime
-	DefaultCloneImage = "docker.io/woodpeckerci/plugin-git:2.0.3"
+	DefaultCloneImage = "docker.io/woodpeckerci/plugin-git:2.1.0"
 )
 
 var TrustedCloneImages = []string{


### PR DESCRIPTION
With 2.0.3, at least my environment stopped working because of the missing `CI_REPO_CLONE_URL` variable, introduced in  2.1.0