### PR TITLE
Add breaking note for `command:` removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Access repos by their IDs (#1691)
   * Drop "coding" support (#1644)
   * Add queue details UI for admins (#1632)
+  * Remove `command:` from steps (#1032)
   * Remove old `build` API routes (#1283)
   * Let single line command be a single command (#1009)
   * Drop deprecated environment vars (#920)

--- a/docs/docs/20-usage/20-pipeline-syntax.md
+++ b/docs/docs/20-usage/20-pipeline-syntax.md
@@ -908,6 +908,6 @@ Woodpecker gives the ability to configure privileged mode in the YAML. You can u
  services:
    docker:
      image: docker:dind
-     command: [ "--storage-driver=vfs", "--tls=false" ]
+     commands: dockerd-entrypoint.sh --storage-driver=vfs --tls=false
 +    privileged: true
 ```

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -35,9 +35,9 @@ Some versions need some changes to the server configuration or the pipeline conf
   - To find the id of orgs use the `/api/orgs/lookup/{org_full_name}` endpoint.
   - The UI urls for a organization changed from `/org/{owner}/...` to `/orgs/{org-id}/...`. You will be redirected automatically when using the old url.
   - The woodpecker-go api-client is now using the `org-id` instead of `org name` for all functions
-- The `command:` field was removed from steps. If you did use it you have to check if the entrypoint of the image you did use is a shell.
-  - If it is a shell, just rename `command:` to `commands:`
-  - If it's not, you have to prepend the entrypoint before and also rename it to `commands:` (e.g. `commands: <entrypoint> <cmd>`)
+- The `command:` field has been removed from steps. If you were using it, please check if the entrypoint of the image you used is a shell.
+  - If it is a shell, simply rename `command:` to `commands:`.
+  - If it's not, you need to prepend the entrypoint before and also rename it (e.g., `commands: <entrypoint> <cmd>`).
 
 ## 0.15.0
 

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -35,6 +35,9 @@ Some versions need some changes to the server configuration or the pipeline conf
   - To find the id of orgs use the `/api/orgs/lookup/{org_full_name}` endpoint.
   - The UI urls for a organization changed from `/org/{owner}/...` to `/orgs/{org-id}/...`. You will be redirected automatically when using the old url.
   - The woodpecker-go api-client is now using the `org-id` instead of `org name` for all functions
+- The `command:` field was removed. If you did use it you have to check if the entrypoint of the image you did use is a shell.
+  - If it is a shell, just rename `command:` to `commands:`
+  - If it's not, you have to prepend the entrypoint before and also rename it to `commands:` (e.g. `commands: <entrypoint> <cmd>`)
 
 ## 0.15.0
 

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -35,7 +35,7 @@ Some versions need some changes to the server configuration or the pipeline conf
   - To find the id of orgs use the `/api/orgs/lookup/{org_full_name}` endpoint.
   - The UI urls for a organization changed from `/org/{owner}/...` to `/orgs/{org-id}/...`. You will be redirected automatically when using the old url.
   - The woodpecker-go api-client is now using the `org-id` instead of `org name` for all functions
-- The `command:` field was removed. If you did use it you have to check if the entrypoint of the image you did use is a shell.
+- The `command:` field was removed from steps. If you did use it you have to check if the entrypoint of the image you did use is a shell.
   - If it is a shell, just rename `command:` to `commands:`
   - If it's not, you have to prepend the entrypoint before and also rename it to `commands:` (e.g. `commands: <entrypoint> <cmd>`)
 

--- a/docs/versioned_docs/version-1.0/20-usage/20-pipeline-syntax.md
+++ b/docs/versioned_docs/version-1.0/20-usage/20-pipeline-syntax.md
@@ -908,6 +908,6 @@ Woodpecker gives the ability to configure privileged mode in the YAML. You can u
  services:
    docker:
      image: docker:dind
-     command: [ "--storage-driver=vfs", "--tls=false" ]
+     commands: dockerd-entrypoint.sh --storage-driver=vfs --tls=false
 +    privileged: true
 ```

--- a/docs/versioned_docs/version-1.0/91-migrations.md
+++ b/docs/versioned_docs/version-1.0/91-migrations.md
@@ -35,7 +35,7 @@ No breaking changes
   - To find the id of orgs use the `/api/orgs/lookup/{org_full_name}` endpoint.
   - The UI urls for a organization changed from `/org/{owner}/...` to `/orgs/{org-id}/...`. You will be redirected automatically when using the old url.
   - The woodpecker-go api-client is now using the `org-id` instead of `org name` for all functions
-- The `command:` field was removed. If you did use it you have to check if the entrypoint of the image you did use is a shell.
+- The `command:` field was removed from steps. If you did use it you have to check if the entrypoint of the image you did use is a shell.
   - If it is a shell, just rename `command:` to `commands:`
   - If it's not, you have to prepend the entrypoint before and also rename it to `commands:` (e.g. `commands: <entrypoint> <cmd>`)
 

--- a/docs/versioned_docs/version-1.0/91-migrations.md
+++ b/docs/versioned_docs/version-1.0/91-migrations.md
@@ -35,9 +35,9 @@ No breaking changes
   - To find the id of orgs use the `/api/orgs/lookup/{org_full_name}` endpoint.
   - The UI urls for a organization changed from `/org/{owner}/...` to `/orgs/{org-id}/...`. You will be redirected automatically when using the old url.
   - The woodpecker-go api-client is now using the `org-id` instead of `org name` for all functions
-- The `command:` field was removed from steps. If you did use it you have to check if the entrypoint of the image you did use is a shell.
-  - If it is a shell, just rename `command:` to `commands:`
-  - If it's not, you have to prepend the entrypoint before and also rename it to `commands:` (e.g. `commands: <entrypoint> <cmd>`)
+- The `command:` field has been removed from steps. If you were using it, please check if the entrypoint of the image you used is a shell.
+  - If it is a shell, simply rename `command:` to `commands:`.
+  - If it's not, you need to prepend the entrypoint before and also rename it (e.g., `commands: <entrypoint> <cmd>`).
 
 ## 0.15.0
 

--- a/docs/versioned_docs/version-1.0/91-migrations.md
+++ b/docs/versioned_docs/version-1.0/91-migrations.md
@@ -35,6 +35,9 @@ No breaking changes
   - To find the id of orgs use the `/api/orgs/lookup/{org_full_name}` endpoint.
   - The UI urls for a organization changed from `/org/{owner}/...` to `/orgs/{org-id}/...`. You will be redirected automatically when using the old url.
   - The woodpecker-go api-client is now using the `org-id` instead of `org name` for all functions
+- The `command:` field was removed. If you did use it you have to check if the entrypoint of the image you did use is a shell.
+  - If it is a shell, just rename `command:` to `commands:`
+  - If it's not, you have to prepend the entrypoint before and also rename it to `commands:` (e.g. `commands: <entrypoint> <cmd>`)
 
 ## 0.15.0
 


### PR DESCRIPTION
close  #2054

as we missed at  #1032 that it was mentioned at one point in the docs and so it was a breaking change