### PR TITLE
fix: global registry docs

### DIFF
--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -101,9 +101,12 @@ version: '3'
 services:
   woodpecker-server:
     [...]
+    volumes:
+      - [...]
++     - /home/user/.docker/config.json:/root/.docker/config.json:ro
     environment:
       - [...]
-+     - WOODPECKER_DOCKER_CONFIG=/home/user/.docker/config.json
++     - WOODPECKER_DOCKER_CONFIG=/root/.docker/config.json
 ```
 
 ## Handling sensitive data in docker-compose and docker-swarm


### PR DESCRIPTION
The [docs](https://woodpecker-ci.org/docs/administration/server-config#global-registry-setting) for global registry are missing the part that shows that the docker config must be mounted.

I mounted to `root`'s home directory, as that is the user running the container.