### PR TITLE
client lib: remove useles "sync" option from RepoListOpts

### DIFF
--- a/cli/repo/repo_sync.go
+++ b/cli/repo/repo_sync.go
@@ -27,7 +27,7 @@ func repoSync(c *cli.Context) error {
 		return err
 	}
 
-	repos, err := client.RepoListOpts(true, true)
+	repos, err := client.RepoListOpts(true)
 	if err != nil || len(repos) == 0 {
 		return err
 	}

--- a/woodpecker-go/woodpecker/client.go
+++ b/woodpecker-go/woodpecker/client.go
@@ -28,7 +28,7 @@ import (
 const (
 	pathSelf           = "%s/api/user"
 	pathRepos          = "%s/api/user/repos"
-	pathRepoPost       = "%s/api/repos"
+	pathRepoPost       = "%s/api/repos?forge_remote_id=%d"
 	pathRepo           = "%s/api/repos/%d"
 	pathRepoLookup     = "%s/api/repos/lookup/%s"
 	pathRepoMove       = "%s/api/repos/%d/move?to=%s"
@@ -175,7 +175,7 @@ func (c *client) RepoListOpts(all bool) ([]*Repo, error) {
 // RepoPost activates a repository.
 func (c *client) RepoPost(forgeRemoteID int64) (*Repo, error) {
 	out := new(Repo)
-	uri := fmt.Sprintf(pathRepoPost+"?forge_remote_id=%d", c.addr, forgeRemoteID)
+	uri := fmt.Sprintf(pathRepoPost, c.addr, forgeRemoteID)
 	err := c.post(uri, nil, out)
 	return out, err
 }

--- a/woodpecker-go/woodpecker/client.go
+++ b/woodpecker-go/woodpecker/client.go
@@ -28,6 +28,7 @@ import (
 const (
 	pathSelf           = "%s/api/user"
 	pathRepos          = "%s/api/user/repos"
+	pathRepoPost       = "%s/api/repos"
 	pathRepo           = "%s/api/repos/%d"
 	pathRepoLookup     = "%s/api/repos/lookup/%s"
 	pathRepoMove       = "%s/api/repos/%d/move?to=%s"
@@ -164,9 +165,9 @@ func (c *client) RepoList() ([]*Repo, error) {
 
 // RepoListOpts returns a list of all repositories to which
 // the user has explicit access in the host system.
-func (c *client) RepoListOpts(sync, all bool) ([]*Repo, error) {
+func (c *client) RepoListOpts(all bool) ([]*Repo, error) {
 	var out []*Repo
-	uri := fmt.Sprintf(pathRepos+"?flush=%v&all=%v", c.addr, sync, all)
+	uri := fmt.Sprintf(pathRepos+"?all=%v", c.addr, all)
 	err := c.get(uri, &out)
 	return out, err
 }
@@ -174,7 +175,7 @@ func (c *client) RepoListOpts(sync, all bool) ([]*Repo, error) {
 // RepoPost activates a repository.
 func (c *client) RepoPost(forgeRemoteID int64) (*Repo, error) {
 	out := new(Repo)
-	uri := fmt.Sprintf(pathRepo, c.addr, forgeRemoteID)
+	uri := fmt.Sprintf(pathRepoPost+"?forge_remote_id=%d", c.addr, forgeRemoteID)
 	err := c.post(uri, nil, out)
 	return out, err
 }

--- a/woodpecker-go/woodpecker/interface.go
+++ b/woodpecker-go/woodpecker/interface.go
@@ -56,7 +56,7 @@ type Client interface {
 
 	// RepoListOpts returns a list of all repositories to which the user has
 	// explicit access in the host system.
-	RepoListOpts(bool, bool) ([]*Repo, error)
+	RepoListOpts(bool) ([]*Repo, error)
 
 	// RepoPost activates a repository.
 	RepoPost(forgeRemoteID int64) (*Repo, error)


### PR DESCRIPTION
Closes #2083 

This is breaking because I removed the old, unused `sync` parameter (#2083). Is it fine anyways to get this into 1.1.0 or should we wait for 2.0 with this?