### PR TITLE
client.go: Fix RepoPost path

### DIFF
--- a/woodpecker-go/woodpecker/client.go
+++ b/woodpecker-go/woodpecker/client.go
@@ -28,6 +28,7 @@ import (
 const (
 	pathSelf           = "%s/api/user"
 	pathRepos          = "%s/api/user/repos"
+	pathRepoPost       = "%s/api/repos?forge_remote_id=%d"
 	pathRepo           = "%s/api/repos/%d"
 	pathRepoLookup     = "%s/api/repos/lookup/%s"
 	pathRepoMove       = "%s/api/repos/%d/move?to=%s"
@@ -174,7 +175,7 @@ func (c *client) RepoListOpts(sync, all bool) ([]*Repo, error) {
 // RepoPost activates a repository.
 func (c *client) RepoPost(forgeRemoteID int64) (*Repo, error) {
 	out := new(Repo)
-	uri := fmt.Sprintf(pathRepo, c.addr, forgeRemoteID)
+	uri := fmt.Sprintf(pathRepoPost, c.addr, forgeRemoteID)
 	err := c.post(uri, nil, out)
 	return out, err
 }


### PR DESCRIPTION
Closes https://github.com/woodpecker-ci/woodpecker/issues/2088