### PR TITLE
Forge Github Org: Use `login` instead of `name` (#2104)

### DIFF
--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -354,20 +354,22 @@ func (c *client) Org(ctx context.Context, u *model.User, owner string) (*model.O
 	client := c.newClientToken(ctx, u.Token)
 
 	user, _, err := client.Users.Get(ctx, owner)
+	log.Trace().Msgf("Github user for owner %s = %v", owner, user)
 	if user != nil && err == nil {
 		return &model.Org{
-			Name:   user.GetName(),
+			Name:   user.GetLogin(),
 			IsUser: true,
 		}, nil
 	}
 
 	org, _, err := client.Organizations.Get(ctx, owner)
+	log.Trace().Msgf("Github organization for owner %s = %v", owner, org)
 	if err != nil {
 		return nil, err
 	}
 
 	return &model.Org{
-		Name: org.GetName(),
+		Name: org.GetLogin(),
 	}, nil
 }
 

--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -717,7 +717,7 @@ func (g *GitLab) Org(ctx context.Context, u *model.User, owner string) (*model.O
 	}
 
 	return &model.Org{
-		Name:    groups[0].Name,
+		Name:    groups[0].FullPath,
 		Private: groups[0].Visibility != gitlab.PublicVisibility,
 	}, nil
 }


### PR DESCRIPTION
Backport #2104

For "woodpecker-ci" the `name` is "Woodpecker CI"
 and the `login` is "woodpecker-ci"

Fixes #2092

This was causing the organization lookup to fail, because it looks up using the `login`, when it did not find the organization, it would try to create it. The creation would fail, because it uses the `name`, and an organization with that `name` already exists.
Resulting in:

```
pq: duplicate key value violates unique constraint "UQE_orgs_name"
```