### PR TITLE
docs: Environment Variable Seems to be `DOCKER_HOST`, not `DOCKER_SOCK`

### DIFF
--- a/docs/docs/30-administration/22-backends/10-docker.md
+++ b/docs/docs/30-administration/22-backends/10-docker.md
@@ -34,7 +34,7 @@ RUN apk add -U --no-cache docker-credential-ecr-login
 
 ## Podman support
 
-While the agent was developed with Docker/Moby, Podman can also be used by setting the environment variable `DOCKER_SOCK` to point to the Podman socket. In order to work without workarounds, Podman 4.0 (or above) is required.
+While the agent was developed with Docker/Moby, Podman can also be used by setting the environment variable `DOCKER_HOST` to point to the Podman socket. In order to work without workarounds, Podman 4.0 (or above) is required.
 
 ## Image Cleanup
 

--- a/docs/versioned_docs/version-1.0/30-administration/22-backends/10-docker.md
+++ b/docs/versioned_docs/version-1.0/30-administration/22-backends/10-docker.md
@@ -34,7 +34,7 @@ RUN apk add -U --no-cache docker-credential-ecr-login
 
 ## Podman support
 
-While the agent was developed with Docker/Moby, Podman can also be used by setting the environment variable `DOCKER_SOCK` to point to the Podman socket. In order to work without workarounds, Podman 4.0 (or above) is required.
+While the agent was developed with Docker/Moby, Podman can also be used by setting the environment variable `DOCKER_HOST` to point to the Podman socket. In order to work without workarounds, Podman 4.0 (or above) is required.
 
 ## Image Cleanup
 


### PR DESCRIPTION
The docs suggest using the env  var `DOCKER_SOCK` to override the container system service socket. However setting that variable seems to do nothing. I get a series of `{"level":"error","error":"Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?","time":"2023-08-06T22:24:02Z","message":"could not kill container 'wp_01h76f6h0f917gcppc9ed8g52g_0_clone'"}` error messages even with (or without) `DOCKER_SOCK=unix:///run/podman/podman.sock` set as an environment variable on the docker-compose config.

Instead, setting the standard `DOCKER_HOST` variable does seem to change where it connects.