### PR TITLE
CLI repo sync: Show `forge-remote-id`

### DIFF
--- a/cli/repo/repo_list.go
+++ b/cli/repo/repo_list.go
@@ -53,4 +53,4 @@ func repoList(c *cli.Context) error {
 }
 
 // template for repository list items
-var tmplRepoList = "\x1b[33m{{ .FullName }}\x1b[0m (id: {{ .ID }})"
+var tmplRepoList = "\x1b[33m{{ .FullName }}\x1b[0m (id: {{ .ID }}, forgeRemoteID: {{ .ForgeRemoteID }})"


### PR DESCRIPTION
Backport #2103 

Because you need the `forge-remote-id` to supply as an argument to `repo add`