### PR TITLE
Don't show badge without information

### DIFF
--- a/web/src/components/admin/settings/AdminAgentsTab.vue
+++ b/web/src/components/admin/settings/AdminAgentsTab.vue
@@ -24,9 +24,9 @@
         <span>{{ agent.name || `Agent ${agent.id}` }}</span>
         <span class="ml-auto">
           <span class="hidden md:inline-block space-x-2">
-            <Badge :label="$t('admin.settings.agents.platform.badge')" :value="agent.platform || '???'" />
-            <Badge :label="$t('admin.settings.agents.backend.badge')" :value="agent.backend || '???'" />
-            <Badge :label="$t('admin.settings.agents.capacity.badge')" :value="agent.capacity || '???'" />
+            <Badge v-if="agent.platform" :label="$t('admin.settings.agents.platform.badge')" :value="agent.platform" />
+            <Badge v-if="agent.backend" :label="$t('admin.settings.agents.backend.badge')" :value="agent.backend" />
+            <Badge v-if="agent.capacity" :label="$t('admin.settings.agents.capacity.badge')" :value="agent.capacity" />
           </span>
           <span class="ml-2">{{ agent.last_contact ? timeAgo.format(agent.last_contact * 1000) : 'never' }}</span>
         </span>


### PR DESCRIPTION
Was requested [here](https://github.com/woodpecker-ci/woodpecker/issues/1314#issuecomment-1477858832) for queue, but this also applies to agents: Do not show badges that only show `???` because they don't provide any useful information.