### PR TITLE
Use fix width for pipeline step list

### DIFF
--- a/web/src/components/repo/pipeline/PipelineStepList.vue
+++ b/web/src/components/repo/pipeline/PipelineStepList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col w-full md:w-3/12 md:ml-2 text-wp-text-100 gap-2 pb-2">
+  <div class="flex flex-col w-full md:w-md md:ml-2 text-wp-text-100 gap-2 pb-2">
     <div
       class="flex flex-wrap p-4 gap-1 justify-between flex-shrink-0 md:rounded-md border bg-wp-background-100 border-wp-background-400 dark:bg-wp-background-200"
     >


### PR DESCRIPTION
On larger monitors using dynamic width in percent, the step list can become very wide which makes it hard to read.