### PR TITLE
Use min/max width for pipeline step list

### DIFF
--- a/web/src/components/repo/pipeline/PipelineStepList.vue
+++ b/web/src/components/repo/pipeline/PipelineStepList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col w-full md:w-md md:ml-2 text-wp-text-100 gap-2 pb-2">
+  <div class="flex flex-col w-full md:w-3/12 md:max-w-md md:min-w-xs md:ml-2 text-wp-text-100 gap-2 pb-2">
     <div
       class="flex flex-wrap p-4 gap-1 justify-between flex-shrink-0 md:rounded-md border bg-wp-background-100 border-wp-background-400 dark:bg-wp-background-200"
     >


### PR DESCRIPTION
I've also added a min-width to keep the sidebar a bit more readable before the breakpoint is reached:

Before: 
![image](https://github.com/woodpecker-ci/woodpecker/assets/3391958/4e76f487-0bfd-416b-9969-9aca42aed629)

After:
![image](https://github.com/woodpecker-ci/woodpecker/assets/3391958/f936c44e-9952-4eb0-8dc3-95d8c48e8dfb)