### PR TITLE
Switch to upstream ttlcache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/google/tink/go v1.7.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/securecookie v1.1.1
+	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/joho/godotenv v1.5.1
-	github.com/lafriks/ttlcache/v3 v3.2.0
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/melbahja/goph v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
+github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -270,8 +272,6 @@ github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/lafriks/ttlcache/v3 v3.2.0 h1:F0+t8giTLeTfuEksG6hII57dowQzaRLM+k4bSWqV6Bc=
-github.com/lafriks/ttlcache/v3 v3.2.0/go.mod h1:oxu8nlxF496noT0VKBf2gDQWHA6VDjoGFnn4qw9wAac=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/server/cache/membership.go
+++ b/server/cache/membership.go
@@ -22,7 +22,7 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server/forge"
 	"github.com/woodpecker-ci/woodpecker/server/model"
 
-	"github.com/lafriks/ttlcache/v3"
+	"github.com/jellydator/ttlcache/v3"
 )
 
 // MembershipService is a service to check for user membership.
@@ -49,8 +49,7 @@ func NewMembershipService(f forge.Forge) MembershipService {
 // Get returns if the user is a member of the organization.
 func (c *membershipCache) Get(ctx context.Context, u *model.User, org string) (*model.OrgPerm, error) {
 	key := fmt.Sprintf("%s-%s", u.ForgeRemoteID, org)
-	// Error can be safely ignored, as cache can only return error from loaders.
-	item, _ := c.cache.Get(key)
+	item := c.cache.Get(key)
 	if item != nil && !item.IsExpired() {
 		return item.Value(), nil
 	}


### PR DESCRIPTION
We've been using https://github.com/lafriks/ttlcache but it's archived. It does work with the upstream library too, so its better to use it.