### PR TITLE
Move hook and events-stream routes to use `/api` prefix

### DIFF
--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -114,7 +114,7 @@ func PostRepo(c *gin.Context) {
 	}
 
 	link := fmt.Sprintf(
-		"%s/hook?access_token=%s",
+		"%s/api/hook?access_token=%s",
 		server.Config.Server.WebhookHost,
 		sig,
 	)
@@ -437,7 +437,7 @@ func RepairRepo(c *gin.Context) {
 	// reconstruct the link
 	host := server.Config.Server.Host
 	link := fmt.Sprintf(
-		"%s/hook?access_token=%s",
+		"%s/api/hook?access_token=%s",
 		host,
 		sig,
 	)
@@ -551,7 +551,7 @@ func MoveRepo(c *gin.Context) {
 	// reconstruct the link
 	host := server.Config.Server.Host
 	link := fmt.Sprintf(
-		"%s/hook?access_token=%s",
+		"%s/api/hook?access_token=%s",
 		host,
 		sig,
 	)

--- a/server/router/api.go
+++ b/server/router/api.go
@@ -194,6 +194,7 @@ func apiRoutes(e *gin.RouterGroup) {
 				session.SetPerm(),
 				session.MustPull,
 				api.LogStreamSSE)
+			stream.GET("/events", api.EventStreamSSE)
 		}
 
 		if zerolog.GlobalLevel() <= zerolog.DebugLevel {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -305,7 +305,7 @@ export default class WoodpeckerClient extends ApiClient {
 
   // eslint-disable-next-line promise/prefer-await-to-callbacks
   on(callback: (data: { pipeline?: Pipeline; repo?: Repo; step?: PipelineWorkflow }) => void): EventSource {
-    return this._subscribe('/stream/events', callback, {
+    return this._subscribe('/api/stream/events', callback, {
       reconnect: true,
     });
   }


### PR DESCRIPTION
- move hook and events-stream routes to use `/api` prefix
- rename build to pipeline