### PR TITLE
Remove repo pass netrc option from repos

### DIFF
--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -88,7 +88,6 @@ type Compiler struct {
 	reslimit          ResourceLimit
 	defaultCloneImage string
 	trustedPipeline   bool
-	netrcOnlyTrusted  bool
 }
 
 // New creates a new Compiler with options.
@@ -187,7 +186,7 @@ func (c *Compiler) Compile(conf *yaml_types.Workflow) (*backend_types.Config, er
 			step := c.createProcess(name, container, backend_types.StepTypeClone)
 
 			// only inject netrc if it's a trusted repo or a trusted plugin
-			if !c.netrcOnlyTrusted || c.trustedPipeline || (container.IsPlugin() && container.IsTrustedCloneImage()) {
+			if c.trustedPipeline || (container.IsPlugin() && container.IsTrustedCloneImage()) {
 				for k, v := range c.cloneEnv {
 					step.Environment[k] = v
 				}

--- a/pipeline/frontend/yaml/compiler/option.go
+++ b/pipeline/frontend/yaml/compiler/option.go
@@ -209,13 +209,6 @@ func WithTrusted(trusted bool) Option {
 	}
 }
 
-// WithNetrcOnlyTrusted configures the compiler with the netrcOnlyTrusted repo option
-func WithNetrcOnlyTrusted(only bool) Option {
-	return func(compiler *Compiler) {
-		compiler.netrcOnlyTrusted = only
-	}
-}
-
 type ProxyOptions struct {
 	NoProxy    string
 	HTTPProxy  string

--- a/pipeline/stepBuilder.go
+++ b/pipeline/stepBuilder.go
@@ -284,7 +284,6 @@ func (b *StepBuilder) toInternalRepresentation(parsed *yaml_types.Workflow, envi
 		compiler.WithWorkspaceFromURL("/woodpecker", b.Repo.Link),
 		compiler.WithMetadata(metadata),
 		compiler.WithTrusted(b.Repo.IsTrusted),
-		compiler.WithNetrcOnlyTrusted(b.Repo.NetrcOnlyTrusted),
 	).Compile(parsed)
 }
 

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -80,7 +80,6 @@ func PostRepo(c *gin.Context) {
 	} else {
 		repo = from
 		repo.AllowPull = true
-		repo.NetrcOnlyTrusted = true
 		repo.CancelPreviousPipelineEvents = server.Config.Pipeline.DefaultCancelPreviousPipelineEvents
 	}
 	repo.IsActive = true
@@ -221,9 +220,6 @@ func PatchRepo(c *gin.Context) {
 	}
 	if in.CancelPreviousPipelineEvents != nil {
 		repo.CancelPreviousPipelineEvents = *in.CancelPreviousPipelineEvents
-	}
-	if in.NetrcOnlyTrusted != nil {
-		repo.NetrcOnlyTrusted = *in.NetrcOnlyTrusted
 	}
 	if in.Visibility != nil {
 		switch *in.Visibility {

--- a/server/model/repo.go
+++ b/server/model/repo.go
@@ -47,7 +47,6 @@ type Repo struct {
 	Hash                         string         `json:"-"                               xorm:"varchar(500) 'repo_hash'"`
 	Perm                         *Perm          `json:"-"                               xorm:"-"`
 	CancelPreviousPipelineEvents []WebhookEvent `json:"cancel_previous_pipeline_events" xorm:"json 'cancel_previous_pipeline_events'"`
-	NetrcOnlyTrusted             bool           `json:"netrc_only_trusted"              xorm:"NOT NULL DEFAULT true 'netrc_only_trusted'"`
 } //	@name Repo
 
 // TableName return database table name for xorm
@@ -111,7 +110,6 @@ type RepoPatch struct {
 	Visibility                   *string         `json:"visibility,omitempty"`
 	AllowPull                    *bool           `json:"allow_pr,omitempty"`
 	CancelPreviousPipelineEvents *[]WebhookEvent `json:"cancel_previous_pipeline_events"`
-	NetrcOnlyTrusted             *bool           `json:"netrc_only_trusted"`
 } //	@name RepoPatch
 
 type ForgeRemoteID string

--- a/woodpecker-go/woodpecker/types.go
+++ b/woodpecker-go/woodpecker/types.go
@@ -46,7 +46,6 @@ type (
 		AllowPullRequests            bool     `json:"allow_pr"`
 		Config                       string   `json:"config_file"`
 		CancelPreviousPipelineEvents []string `json:"cancel_previous_pipeline_events"`
-		NetrcOnlyTrusted             bool     `json:"netrc_only_trusted"`
 	}
 
 	// RepoPatch defines a repository patch request.


### PR DESCRIPTION
Not trusted clone plugins should never get our credentials as an attacker could simply replace the clone step by a malicious one and therefore gather netrc credentials.