### PR TITLE
Move "skip ci" logic into global pipeline conditions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
   "prettier.configPath": "./web/.prettierrc.js",
   "prettier.ignorePath": "./web/.prettierignore",
   "cSpell.words": [
+    "Curr",
     "doublestar",
     "multierr"
   ]

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ test-server-datastore-coverage: ## Test server datastore with coverage report
 
 test-ui: ui-dependencies ## Test UI code
 	(cd web/; pnpm run lint)
-	(cd web/; pnpm run formatcheck)
+	(cd web/; pnpm run format:check)
 	(cd web/; pnpm run typecheck)
 	(cd web/; pnpm run test)
 

--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -102,11 +102,6 @@ func (when *When) Match(metadata metadata.Metadata, global bool, env map[string]
 		}
 	}
 
-	if when.IsEmpty() {
-		// test against default Constraints
-		empty := &Constraint{}
-		return empty.Match(metadata, global, env)
-	}
 	return false, nil
 }
 

--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -102,6 +102,11 @@ func (when *When) Match(metadata metadata.Metadata, global bool, env map[string]
 		}
 	}
 
+	if when.IsEmpty() {
+		// test against default Constraints
+		empty := &Constraint{}
+		return empty.Match(metadata, global, env)
+	}
 	return false, nil
 }
 

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -35,6 +35,7 @@ import (
 	"github.com/woodpecker-ci/woodpecker/shared/token"
 )
 
+// TODO: move this into the global when filter
 var skipRe = regexp.MustCompile(`\[(?i:ci *skip|skip *ci)\]`)
 
 // GetQueueInfo
@@ -170,6 +171,7 @@ func PostHook(c *gin.Context) {
 		}
 	}
 
+	// TODO: we should only update and/or create a redirect for repos after the hook was token was validated
 	repo.Update(tmpRepo)
 	err = _store.UpdateRepo(repo)
 	if err != nil {

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -34,9 +33,6 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server/store"
 	"github.com/woodpecker-ci/woodpecker/shared/token"
 )
-
-// TODO: move this into the global when filter
-var skipRe = regexp.MustCompile(`\[(?i:ci *skip|skip *ci)\]`)
 
 // GetQueueInfo
 //
@@ -138,21 +134,6 @@ func PostHook(c *gin.Context) {
 		msg := "failure to ascertain repo from hook"
 		log.Debug().Msg(msg)
 		c.String(http.StatusBadRequest, msg)
-		return
-	}
-
-	//
-	// Skip if commit message contains skip-ci
-	// TODO: move into global pipeline conditions logic
-	//
-
-	// skip the tmpPipeline if any case-insensitive combination of the words "skip" and "ci"
-	// wrapped in square brackets appear in the commit message
-	skipMatch := skipRe.FindString(tmpPipeline.Message)
-	if len(skipMatch) > 0 {
-		msg := fmt.Sprintf("ignoring hook: %s found in %s", skipMatch, tmpPipeline.Commit)
-		log.Debug().Msg(msg)
-		c.String(http.StatusNoContent, msg)
 		return
 	}
 

--- a/server/pipeline/approve.go
+++ b/server/pipeline/approve.go
@@ -29,7 +29,7 @@ import (
 // and start them afterward
 func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipeline, user *model.User, repo *model.Repo) (*model.Pipeline, error) {
 	if currentPipeline.Status != model.StatusBlocked {
-		return nil, &ErrBadRequest{Msg: fmt.Sprintf("cannot decline a pipeline with status %s", currentPipeline.Status)}
+		return nil, ErrBadRequest{Msg: fmt.Sprintf("cannot decline a pipeline with status %s", currentPipeline.Status)}
 	}
 
 	// fetch the pipeline file from the database
@@ -37,7 +37,7 @@ func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipe
 	if err != nil {
 		msg := fmt.Sprintf("failure to get pipeline config for %s. %s", repo.FullName, err)
 		log.Error().Msg(msg)
-		return nil, &ErrNotFound{Msg: msg}
+		return nil, ErrNotFound{Msg: msg}
 	}
 
 	if currentPipeline, err = UpdateToStatusPending(store, *currentPipeline, user.Login); err != nil {

--- a/server/pipeline/approve.go
+++ b/server/pipeline/approve.go
@@ -29,7 +29,7 @@ import (
 // and start them afterward
 func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipeline, user *model.User, repo *model.Repo) (*model.Pipeline, error) {
 	if currentPipeline.Status != model.StatusBlocked {
-		return nil, ErrBadRequest{Msg: fmt.Sprintf("cannot decline a pipeline with status %s", currentPipeline.Status)}
+		return nil, &ErrBadRequest{Msg: fmt.Sprintf("cannot decline a pipeline with status %s", currentPipeline.Status)}
 	}
 
 	// fetch the pipeline file from the database
@@ -37,7 +37,7 @@ func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipe
 	if err != nil {
 		msg := fmt.Sprintf("failure to get pipeline config for %s. %s", repo.FullName, err)
 		log.Error().Msg(msg)
-		return nil, ErrNotFound{Msg: msg}
+		return nil, &ErrNotFound{Msg: msg}
 	}
 
 	if currentPipeline, err = UpdateToStatusPending(store, *currentPipeline, user.Login); err != nil {

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -66,13 +66,13 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		filtered, parseErr = checkIfFiltered(repo, pipeline, forgeYamlConfigs)
 		if parseErr == nil {
 			if filtered {
-				err := ErrFiltered{Msg: "branch does not match restrictions defined in yaml"}
+				err := &ErrFiltered{Msg: "global when filter of all workflows do skip this pipeline"}
 				log.Debug().Str("repo", repo.FullName).Msgf("%v", err)
 				return nil, err
 			}
 
 			if zeroSteps(pipeline, forgeYamlConfigs) {
-				err := ErrFiltered{Msg: "step conditions yield zero runnable steps"}
+				err := &ErrFiltered{Msg: "step conditions yield zero runnable steps"}
 				log.Debug().Str("repo", repo.FullName).Msgf("%v", err)
 				return nil, err
 			}

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -66,13 +66,13 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		filtered, parseErr = checkIfFiltered(repo, pipeline, forgeYamlConfigs)
 		if parseErr == nil {
 			if filtered {
-				err := &ErrFiltered{Msg: "global when filter of all workflows do skip this pipeline"}
+				err := ErrFiltered{Msg: "global when filter of all workflows do skip this pipeline"}
 				log.Debug().Str("repo", repo.FullName).Msgf("%v", err)
 				return nil, err
 			}
 
 			if zeroSteps(pipeline, forgeYamlConfigs) {
-				err := &ErrFiltered{Msg: "step conditions yield zero runnable steps"}
+				err := ErrFiltered{Msg: "step conditions yield zero runnable steps"}
 				log.Debug().Str("repo", repo.FullName).Msgf("%v", err)
 				return nil, err
 			}

--- a/server/pipeline/errors.go
+++ b/server/pipeline/errors.go
@@ -18,22 +18,37 @@ type ErrNotFound struct {
 	Msg string
 }
 
-func (e ErrNotFound) Error() string {
+func (e *ErrNotFound) Error() string {
 	return e.Msg
+}
+
+func (e *ErrNotFound) Is(target error) bool {
+	_, ok := target.(*ErrNotFound) //nolint:errorlint
+	return ok
 }
 
 type ErrBadRequest struct {
 	Msg string
 }
 
-func (e ErrBadRequest) Error() string {
+func (e *ErrBadRequest) Error() string {
 	return e.Msg
+}
+
+func (e *ErrBadRequest) Is(target error) bool {
+	_, ok := target.(*ErrBadRequest) //nolint:errorlint
+	return ok
 }
 
 type ErrFiltered struct {
 	Msg string
 }
 
-func (e ErrFiltered) Error() string {
+func (e *ErrFiltered) Error() string {
 	return "ignoring hook: " + e.Msg
+}
+
+func (e *ErrFiltered) Is(target error) bool {
+	_, ok := target.(*ErrFiltered) //nolint:errorlint
+	return ok
 }

--- a/server/pipeline/errors.go
+++ b/server/pipeline/errors.go
@@ -18,12 +18,15 @@ type ErrNotFound struct {
 	Msg string
 }
 
-func (e *ErrNotFound) Error() string {
+func (e ErrNotFound) Error() string {
 	return e.Msg
 }
 
-func (e *ErrNotFound) Is(target error) bool {
-	_, ok := target.(*ErrNotFound) //nolint:errorlint
+func (e ErrNotFound) Is(target error) bool {
+	_, ok := target.(ErrNotFound) //nolint:errorlint
+	if !ok {
+		_, ok = target.(*ErrNotFound) //nolint:errorlint
+	}
 	return ok
 }
 
@@ -31,12 +34,15 @@ type ErrBadRequest struct {
 	Msg string
 }
 
-func (e *ErrBadRequest) Error() string {
+func (e ErrBadRequest) Error() string {
 	return e.Msg
 }
 
-func (e *ErrBadRequest) Is(target error) bool {
-	_, ok := target.(*ErrBadRequest) //nolint:errorlint
+func (e ErrBadRequest) Is(target error) bool {
+	_, ok := target.(ErrBadRequest) //nolint:errorlint
+	if !ok {
+		_, ok = target.(*ErrBadRequest) //nolint:errorlint
+	}
 	return ok
 }
 
@@ -44,11 +50,14 @@ type ErrFiltered struct {
 	Msg string
 }
 
-func (e *ErrFiltered) Error() string {
+func (e ErrFiltered) Error() string {
 	return "ignoring hook: " + e.Msg
 }
 
 func (e *ErrFiltered) Is(target error) bool {
-	_, ok := target.(*ErrFiltered) //nolint:errorlint
+	_, ok := target.(ErrFiltered) //nolint:errorlint
+	if !ok {
+		_, ok = target.(*ErrFiltered) //nolint:errorlint
+	}
 	return ok
 }


### PR DESCRIPTION
... and make custom errors follow std err conventions

this fix a 500 response if the whole pipeline is filtered out