### PR TITLE
Bump default git clone plugin (#2215)

### DIFF
--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -20,6 +20,7 @@ var PrivilegedPlugins = []string{
 	"plugins/gcr",
 	"plugins/ecr",
 	"woodpeckerci/plugin-docker-buildx",
+	"codeberg.org/woodpecker-plugins/docker-buildx",
 }
 
 // DefaultConfigOrder represent the priority in witch woodpecker search for a pipeline config by default
@@ -32,9 +33,10 @@ var DefaultConfigOrder = [...]string{
 
 const (
 	// DefaultCloneImage can be changed by 'WOODPECKER_DEFAULT_CLONE_IMAGE' at runtime
-	DefaultCloneImage = "docker.io/woodpeckerci/plugin-git:2.0.3"
+	DefaultCloneImage = "docker.io/woodpeckerci/plugin-git:2.1.1"
 )
 
 var TrustedCloneImages = []string{
 	DefaultCloneImage,
+	"quay.io/woodpeckerci/plugin-git",
 }


### PR DESCRIPTION
Backport #2215

- and add alternate quay registry to trusted clone image
- add alternate registry for buildx plugin