### PR TITLE
Return 204 not 500 on filtered pipeline

### DIFF
--- a/server/pipeline/approve.go
+++ b/server/pipeline/approve.go
@@ -29,7 +29,7 @@ import (
 // and start them afterward
 func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipeline, user *model.User, repo *model.Repo) (*model.Pipeline, error) {
 	if currentPipeline.Status != model.StatusBlocked {
-		return nil, &ErrBadRequest{Msg: fmt.Sprintf("cannot decline a pipeline with status %s", currentPipeline.Status)}
+		return nil, ErrBadRequest{Msg: fmt.Sprintf("cannot decline a pipeline with status %s", currentPipeline.Status)}
 	}
 
 	// fetch the pipeline file from the database
@@ -37,7 +37,7 @@ func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipe
 	if err != nil {
 		msg := fmt.Sprintf("failure to get pipeline config for %s. %s", repo.FullName, err)
 		log.Error().Msg(msg)
-		return nil, &ErrNotFound{Msg: msg}
+		return nil, ErrNotFound{Msg: msg}
 	}
 
 	if currentPipeline, err = UpdateToStatusPending(store, *currentPipeline, user.Login); err != nil {

--- a/server/pipeline/approve.go
+++ b/server/pipeline/approve.go
@@ -29,7 +29,7 @@ import (
 // and start them afterward
 func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipeline, user *model.User, repo *model.Repo) (*model.Pipeline, error) {
 	if currentPipeline.Status != model.StatusBlocked {
-		return nil, ErrBadRequest{Msg: fmt.Sprintf("cannot decline a pipeline with status %s", currentPipeline.Status)}
+		return nil, &ErrBadRequest{Msg: fmt.Sprintf("cannot decline a pipeline with status %s", currentPipeline.Status)}
 	}
 
 	// fetch the pipeline file from the database
@@ -37,7 +37,7 @@ func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipe
 	if err != nil {
 		msg := fmt.Sprintf("failure to get pipeline config for %s. %s", repo.FullName, err)
 		log.Error().Msg(msg)
-		return nil, ErrNotFound{Msg: msg}
+		return nil, &ErrNotFound{Msg: msg}
 	}
 
 	if currentPipeline, err = UpdateToStatusPending(store, *currentPipeline, user.Login); err != nil {

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -66,13 +66,13 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		filtered, parseErr = checkIfFiltered(repo, pipeline, forgeYamlConfigs)
 		if parseErr == nil {
 			if filtered {
-				err := ErrFiltered{Msg: "branch does not match restrictions defined in yaml"}
+				err := &ErrFiltered{Msg: "global when filter of all workflows do skip this pipeline"}
 				log.Debug().Str("repo", repo.FullName).Msgf("%v", err)
 				return nil, err
 			}
 
 			if zeroSteps(pipeline, forgeYamlConfigs) {
-				err := ErrFiltered{Msg: "step conditions yield zero runnable steps"}
+				err := &ErrFiltered{Msg: "step conditions yield zero runnable steps"}
 				log.Debug().Str("repo", repo.FullName).Msgf("%v", err)
 				return nil, err
 			}

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -66,13 +66,13 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		filtered, parseErr = checkIfFiltered(repo, pipeline, forgeYamlConfigs)
 		if parseErr == nil {
 			if filtered {
-				err := &ErrFiltered{Msg: "global when filter of all workflows do skip this pipeline"}
+				err := ErrFiltered{Msg: "global when filter of all workflows do skip this pipeline"}
 				log.Debug().Str("repo", repo.FullName).Msgf("%v", err)
 				return nil, err
 			}
 
 			if zeroSteps(pipeline, forgeYamlConfigs) {
-				err := &ErrFiltered{Msg: "step conditions yield zero runnable steps"}
+				err := ErrFiltered{Msg: "step conditions yield zero runnable steps"}
 				log.Debug().Str("repo", repo.FullName).Msgf("%v", err)
 				return nil, err
 			}

--- a/server/pipeline/errors.go
+++ b/server/pipeline/errors.go
@@ -18,22 +18,37 @@ type ErrNotFound struct {
 	Msg string
 }
 
-func (e ErrNotFound) Error() string {
+func (e *ErrNotFound) Error() string {
 	return e.Msg
+}
+
+func (e *ErrNotFound) Is(target error) bool {
+	_, ok := target.(*ErrNotFound) //nolint:errorlint
+	return ok
 }
 
 type ErrBadRequest struct {
 	Msg string
 }
 
-func (e ErrBadRequest) Error() string {
+func (e *ErrBadRequest) Error() string {
 	return e.Msg
+}
+
+func (e *ErrBadRequest) Is(target error) bool {
+	_, ok := target.(*ErrBadRequest) //nolint:errorlint
+	return ok
 }
 
 type ErrFiltered struct {
 	Msg string
 }
 
-func (e ErrFiltered) Error() string {
+func (e *ErrFiltered) Error() string {
 	return "ignoring hook: " + e.Msg
+}
+
+func (e *ErrFiltered) Is(target error) bool {
+	_, ok := target.(*ErrFiltered) //nolint:errorlint
+	return ok
 }

--- a/server/pipeline/errors.go
+++ b/server/pipeline/errors.go
@@ -18,12 +18,15 @@ type ErrNotFound struct {
 	Msg string
 }
 
-func (e *ErrNotFound) Error() string {
+func (e ErrNotFound) Error() string {
 	return e.Msg
 }
 
-func (e *ErrNotFound) Is(target error) bool {
-	_, ok := target.(*ErrNotFound) //nolint:errorlint
+func (e ErrNotFound) Is(target error) bool {
+	_, ok := target.(ErrNotFound) //nolint:errorlint
+	if !ok {
+		_, ok = target.(*ErrNotFound) //nolint:errorlint
+	}
 	return ok
 }
 
@@ -31,12 +34,15 @@ type ErrBadRequest struct {
 	Msg string
 }
 
-func (e *ErrBadRequest) Error() string {
+func (e ErrBadRequest) Error() string {
 	return e.Msg
 }
 
-func (e *ErrBadRequest) Is(target error) bool {
-	_, ok := target.(*ErrBadRequest) //nolint:errorlint
+func (e ErrBadRequest) Is(target error) bool {
+	_, ok := target.(ErrBadRequest) //nolint:errorlint
+	if !ok {
+		_, ok = target.(*ErrBadRequest) //nolint:errorlint
+	}
 	return ok
 }
 
@@ -44,11 +50,14 @@ type ErrFiltered struct {
 	Msg string
 }
 
-func (e *ErrFiltered) Error() string {
+func (e ErrFiltered) Error() string {
 	return "ignoring hook: " + e.Msg
 }
 
 func (e *ErrFiltered) Is(target error) bool {
-	_, ok := target.(*ErrFiltered) //nolint:errorlint
+	_, ok := target.(ErrFiltered) //nolint:errorlint
+	if !ok {
+		_, ok = target.(*ErrFiltered) //nolint:errorlint
+	}
 	return ok
 }


### PR DESCRIPTION
the error check always failed, as the custom errors did not have the `Is(error) bool` interface implemented

backport bugfix part of  #2216