### PR TITLE
Handle parsed hooks that should be ignored

### DIFF
--- a/server/forge/gitea/gitea.go
+++ b/server/forge/gitea/gitea.go
@@ -489,7 +489,7 @@ func (c *Gitea) Hook(ctx context.Context, r *http.Request) (*model.Repo, *model.
 		return nil, nil, err
 	}
 
-	if pipeline.Event == model.EventPull && len(pipeline.ChangedFiles) == 0 {
+	if pipeline != nil && pipeline.Event == model.EventPull && len(pipeline.ChangedFiles) == 0 {
 		index, err := strconv.ParseInt(strings.Split(pipeline.Ref, "/")[2], 10, 64)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Currently it would fail with panic:

```
runtime error: invalid memory address or nil pointer dereference
...
/woodpecker/src/github.com/woodpecker-ci/woodpecker/server/forge/gitea/gitea.go:492 (0xdfb32e)
```