### PR TITLE
Change token logging to trace level

### DIFF
--- a/agent/rpc/auth_interceptor.go
+++ b/agent/rpc/auth_interceptor.go
@@ -107,7 +107,7 @@ func (interceptor *AuthInterceptor) refreshToken() error {
 	}
 
 	interceptor.accessToken = accessToken
-	log.Debug().Msgf("Token refreshed: %v", accessToken)
+	log.Trace().Str("token", accessToken).Msg("Token refreshed")
 
 	return nil
 }


### PR DESCRIPTION
Changed from `debug` to `trace`.

In [cron.go](https://github.com/woodpecker-ci/woodpecker/blob/d9e06696bf85f260a0550d58301ac396874b32e3/server/cron/cron.go#L129) only boolean flag is logged. Therefore, is left as is.

