### PR TITLE
Change token logging to trace level (#2247)

### DIFF
--- a/agent/rpc/auth_interceptor.go
+++ b/agent/rpc/auth_interceptor.go
@@ -2,9 +2,9 @@ package rpc
 
 import (
 	"context"
-	"log"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -93,7 +93,7 @@ func (interceptor *AuthInterceptor) refreshToken() error {
 	}
 
 	interceptor.accessToken = accessToken
-	log.Printf("Token refreshed: %v", accessToken)
+	log.Trace().Str("token", accessToken).Msg("Token refreshed")
 
 	return nil
 }


### PR DESCRIPTION
Changed from `info` to `trace`.

Backport of #2247.

Tested on v1.0.2.

Info level:
```
{"level":"info","time":"2023-08-18T17:10:28Z","message":"no agent config found at '/etc/woodpecker/agent.conf', start with defaults"}
{"level":"error","error":"open /etc/woodpecker/agent.conf: no such file or directory","time":"2023-08-18T17:10:28Z","message":"could not persist agent config at '/etc/woodpecker/agent.conf'"}
{"level":"info","time":"2023-08-18T17:10:28Z","message":"Starting Woodpecker agent with version 'next-d3b96f38' and backend 'kubernetes' using platform 'linux/amd64' running up to 1 pipelines in parallel"}
```

Trace level:
```
{"level":"info","time":"2023-08-18T17:06:12Z","caller":"/src/cmd/agent/config.go:41","message":"no agent config found at '/etc/woodpecker/agent.conf', start with defaults"}
{"level":"trace","token":"eyJh...VCJ9.eyJp...1MH0.DHYi...3VIc","time":"2023-08-18T17:06:12Z","caller":"/src/agent/rpc/auth_interceptor.go:96","message":"Token refreshed"}
{"level":"error","error":"open /etc/woodpecker/agent.conf: no such file or directory","time":"2023-08-18T17:06:12Z","caller":"/src/cmd/agent/config.go:70","message":"could not persist agent config at '/etc/woodpecker/agent.conf'"}
{"level":"debug","time":"2023-08-18T17:06:12Z","caller":"/src/cmd/agent/agent.go:200","message":"Agent registered with ID 50"}
{"level":"debug","time":"2023-08-18T17:06:12Z","caller":"/src/cmd/agent/agent.go:223","message":"loaded kubernetes backend engine"}
{"level":"info","time":"2023-08-18T17:06:12Z","caller":"/src/cmd/agent/agent.go:247","message":"Starting Woodpecker agent with version 'next-d3b96f38' and backend 'kubernetes' using platform 'linux/amd64' running up to 1 pipelines in parallel"}
{"level":"debug","time":"2023-08-18T17:06:12Z","caller":"/src/cmd/agent/agent.go:231","message":"created new runner 0"}
{"level":"debug","time":"2023-08-18T17:06:12Z","caller":"/src/cmd/agent/agent.go:238","message":"polling new steps"}
{"level":"debug","time":"2023-08-18T17:06:12Z","caller":"/src/agent/runner.go:54","message":"request next execution"}
```