### PR TITLE
make WOODPECKER_MIGRATIONS_ALLOW_LONG have an actuall effect

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -90,6 +90,7 @@ func run(c *cli.Context) error {
 		log.Fatal().Err(err).Msg("")
 	}
 
+	server.Config.Server.Migrations.AllowLong = c.Bool("migrations-allow-long")
 	_store, err := setupStore(c)
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
@@ -354,7 +355,6 @@ func setupEvilGlobals(c *cli.Context, v store.Store, f forge.Forge) {
 	server.Config.Pipeline.Networks = c.StringSlice("network")
 	server.Config.Pipeline.Volumes = c.StringSlice("volume")
 	server.Config.Pipeline.Privileged = c.StringSlice("escalate")
-	server.Config.Server.Migrations.AllowLong = c.Bool("migrations-allow-long")
 	server.Config.Server.EnableSwagger = c.Bool("enable-swagger")
 
 	// prometheus

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -90,7 +90,6 @@ func run(c *cli.Context) error {
 		log.Fatal().Err(err).Msg("")
 	}
 
-	server.Config.Server.Migrations.AllowLong = c.Bool("migrations-allow-long")
 	_store, err := setupStore(c)
 	if err != nil {
 		log.Fatal().Err(err).Msg("")

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -52,6 +52,8 @@ import (
 )
 
 func setupStore(c *cli.Context) (store.Store, error) {
+	// TODO: find a better way than global var to pass down to allow long migrations
+	server.Config.Server.Migrations.AllowLong = c.Bool("migrations-allow-long")
 	datasource := c.String("datasource")
 	driver := c.String("driver")
 	xorm := store.XORM{


### PR DESCRIPTION
close #2079

as we sett the global vars **after** migrations we did never had a chance to propagate a **true** in WOODPECKER_MIGRATIONS_ALLOW_LONG to the migrations ...

