### PR TITLE
Fix button loading spinner when activating repos

### DIFF
--- a/web/src/views/RepoAdd.vue
+++ b/web/src/views/RepoAdd.vue
@@ -17,7 +17,7 @@
           v-if="!repo.active"
           class="ml-auto"
           :text="$t('repo.enable.enable')"
-          :is-loading="isActivatingRepo && repoToActivate?.id === repo.id"
+          :is-loading="isActivatingRepo && repoToActivate?.forge_remote_id === repo.forge_remote_id"
           @click="activateRepo(repo)"
         />
       </ListItem>


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/2234

There is no internal `repo.id` for not enabled repos. Use the remote forge repo id instead. 