### PR TITLE
Clarify env var `CI` in docs

### DIFF
--- a/docs/docs/20-usage/50-environment.md
+++ b/docs/docs/20-usage/50-environment.md
@@ -48,7 +48,7 @@ This is the reference list of all environment variables available to your pipeli
 
 | NAME                             | Description                                                                                  |
 | -------------------------------- | -------------------------------------------------------------------------------------------- |
-| `CI`                             | environment (default: `woodpecker`)                                                          |
+| `CI`                             | CI environment name (value: `woodpecker`)                                                          |
 |                                  | **Repository**                                                                               |
 | `CI_REPO`                        | repository full name `<owner>/<name>`                                                        |
 | `CI_REPO_OWNER`                  | repository owner                                                                             |

--- a/docs/docs/20-usage/50-environment.md
+++ b/docs/docs/20-usage/50-environment.md
@@ -48,7 +48,7 @@ This is the reference list of all environment variables available to your pipeli
 
 | NAME                             | Description                                                                                  |
 | -------------------------------- | -------------------------------------------------------------------------------------------- |
-| `CI=woodpecker`                  | environment is woodpecker                                                                    |
+| `CI`                             | environment (default: `woodpecker`)                                                          |
 |                                  | **Repository**                                                                               |
 | `CI_REPO`                        | repository full name `<owner>/<name>`                                                        |
 | `CI_REPO_OWNER`                  | repository owner                                                                             |


### PR DESCRIPTION
The "name" column should only list the name - otherwise it's confusing, also WRT to the other vars listed in this table.