### PR TITLE
fix(server/api/repo): Fix repair webhook host (#2372)

### DIFF
--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -420,7 +420,7 @@ func RepairRepo(c *gin.Context) {
 	}
 
 	// reconstruct the link
-	host := server.Config.Server.Host
+	host := server.Config.Server.WebhookHost
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
 		host,


### PR DESCRIPTION
Backports #2372 to release 1.0

Fixes https://github.com/woodpecker-ci/woodpecker/issues/2371