### PR TITLE
Fix usage of WOODPECKER_ROOT_PATH

### DIFF
--- a/server/api/badge.go
+++ b/server/api/badge.go
@@ -118,7 +118,7 @@ func GetCC(c *gin.Context) {
 		return
 	}
 
-	url := fmt.Sprintf("%s/%s/%d", server.Config.Server.Host, repo.FullName, pipelines[0].Number)
+	url := fmt.Sprintf("%s%s/%s/%d", server.Config.Server.Host, server.Config.Server.RootPath, repo.FullName, pipelines[0].Number)
 	cc := ccmenu.New(repo, pipelines[0], url)
 	c.XML(http.StatusOK, cc)
 }

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -112,9 +112,10 @@ func PostRepo(c *gin.Context) {
 		return
 	}
 
+	baseurl := server.Config.Server.WebhookHost + server.Config.Server.RootPath
 	link := fmt.Sprintf(
 		"%s/api/hook?access_token=%s",
-		server.Config.Server.WebhookHost,
+		baseurl,
 		sig,
 	)
 
@@ -389,7 +390,8 @@ func DeleteRepo(c *gin.Context) {
 		}
 	}
 
-	if err := server.Config.Services.Forge.Deactivate(c, user, repo, server.Config.Server.Host); err != nil {
+	baseurl := server.Config.Server.WebhookHost + server.Config.Server.RootPath
+	if err := server.Config.Services.Forge.Deactivate(c, user, repo, baseurl); err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
@@ -420,10 +422,10 @@ func RepairRepo(c *gin.Context) {
 	}
 
 	// reconstruct the link
-	host := server.Config.Server.WebhookHost
+	baseurl := server.Config.Server.WebhookHost + server.Config.Server.RootPath
 	link := fmt.Sprintf(
 		"%s/api/hook?access_token=%s",
-		host,
+		baseurl,
 		sig,
 	)
 
@@ -456,7 +458,7 @@ func RepairRepo(c *gin.Context) {
 		return
 	}
 
-	if err := forge.Deactivate(c, user, repo, host); err != nil {
+	if err := forge.Deactivate(c, user, repo, baseurl); err != nil {
 		log.Trace().Err(err).Msgf("deactivate repo '%s' to repair failed", repo.FullName)
 	}
 	if err := forge.Activate(c, user, repo, link); err != nil {
@@ -534,14 +536,14 @@ func MoveRepo(c *gin.Context) {
 	}
 
 	// reconstruct the link
-	host := server.Config.Server.Host
+	baseurl := server.Config.Server.WebhookHost + server.Config.Server.RootPath
 	link := fmt.Sprintf(
 		"%s/api/hook?access_token=%s",
-		host,
+		baseurl,
 		sig,
 	)
 
-	if err := forge.Deactivate(c, user, repo, host); err != nil {
+	if err := forge.Deactivate(c, user, repo, baseurl); err != nil {
 		log.Trace().Err(err).Msgf("deactivate repo '%s' for move to activate later, got an error", repo.FullName)
 	}
 	if err := forge.Activate(c, user, repo, link); err != nil {

--- a/server/forge/common/status.go
+++ b/server/forge/common/status.go
@@ -74,8 +74,8 @@ func GetPipelineStatusDescription(status model.StatusValue) string {
 
 func GetPipelineStatusLink(repo *model.Repo, pipeline *model.Pipeline, workflow *model.Workflow) string {
 	if workflow == nil {
-		return fmt.Sprintf("%s/repos/%d/pipeline/%d", server.Config.Server.Host, repo.ID, pipeline.Number)
+		return fmt.Sprintf("%s%s/repos/%d/pipeline/%d", server.Config.Server.Host, server.Config.Server.RootPath, repo.ID, pipeline.Number)
 	}
 
-	return fmt.Sprintf("%s/repos/%d/pipeline/%d/%d", server.Config.Server.Host, repo.ID, pipeline.Number, workflow.PID)
+	return fmt.Sprintf("%s%s/repos/%d/pipeline/%d/%d", server.Config.Server.Host, server.Config.Server.RootPath, repo.ID, pipeline.Number, workflow.PID)
 }


### PR DESCRIPTION
I had experienced some issues running Woodpecker behind a reverse-proxy, resulting from not defining the `WOODPECKER_ROOT_PATH` environment variable in #2477.

Specifying `WOODPECKER_ROOT_PATH=/foo` *mostly* solved the issue of running the woodpecker server at an url like `https://example.org/foo`.
However, the webhook urls and badge urls were generated excluding the configured `WOODPECKER_ROOT_PATH`.

This PR (mostly) fixes issues related to non-empty `WOODPECKER_ROOT_PATH`.