### PR TITLE
Fix broken link to 3rd party plugin library

### DIFF
--- a/docs/docs/20-usage/51-plugins/10-plugins.md
+++ b/docs/docs/20-usage/51-plugins/10-plugins.md
@@ -40,7 +40,7 @@ For official plugins, you can use the Woodpecker plugin index:
 There are also other plugin lists with additional plugins. Keep in mind that [Drone](https://www.drone.io/) plugins are generally supported, but could need some adjustments and tweaking.
 
 - [Drone Plugins](http://plugins.drone.io)
-- [The Geek Lab Drone Plugins](https://drone-plugin-index.geekdocs.de/plugins/drone-matrix/)
+- [Geeklab Woodpecker Plugins](https://woodpecker-plugins.geekdocs.de/)
 :::
 
 ## Creating a plugin


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/2493