### PR TITLE
Fix docs duplicate WOODPECKER_HOST assignment

### DIFF
--- a/docs/versioned_docs/version-1.0/30-administration/00-setup.md
+++ b/docs/versioned_docs/version-1.0/30-administration/00-setup.md
@@ -93,8 +93,7 @@ services:
     environment:
       - [...]
 +     - WOODPECKER_HOST=${WOODPECKER_HOST}
-+     - WOODPECKER_HOST=${WOODPECKER_HOST}
-```
+é```
 
 Woodpecker can also have its port's configured. It uses a separate port for gRPC and for HTTP. The agent performs gRPC calls and connects to the gRPC port.
 They can be configured with ADDR variables:

--- a/docs/versioned_docs/version-1.0/30-administration/00-setup.md
+++ b/docs/versioned_docs/version-1.0/30-administration/00-setup.md
@@ -93,7 +93,7 @@ services:
     environment:
       - [...]
 +     - WOODPECKER_HOST=${WOODPECKER_HOST}
-é```
+```
 
 Woodpecker can also have its port's configured. It uses a separate port for gRPC and for HTTP. The agent performs gRPC calls and connects to the gRPC port.
 They can be configured with ADDR variables:


### PR DESCRIPTION
Seems to only be a small typo on https://woodpecker-ci.org/docs/administration/setup#docker-compose, where the `+     - WOODPECKER_HOST=${WOODPECKER_HOST}` line is repeated!