### PR TITLE
fix #2514 correct mime type used also when no content sent

### DIFF
--- a/server/web/web.go
+++ b/server/web/web.go
@@ -72,19 +72,19 @@ func New() (*gin.Engine, error) {
 }
 
 func handleCustomFilesAndAssets(fs *prefixFS) func(ctx *gin.Context) {
-	serveFileOrEmptyContent := func(w http.ResponseWriter, r *http.Request, localFileName string) {
+	serveFileOrEmptyContent := func(w http.ResponseWriter, r *http.Request, localFileName string, contentTypeName string) {
 		if len(localFileName) > 0 {
 			http.ServeFile(w, r, localFileName)
 		} else {
 			// prefer zero content over sending a 404 Not Found
-			http.ServeContent(w, r, localFileName, time.Now(), bytes.NewReader([]byte{}))
+			http.ServeContent(w, r, contentTypeName, time.Now(), bytes.NewReader([]byte{}))
 		}
 	}
 	return func(ctx *gin.Context) {
 		if strings.HasSuffix(ctx.Request.RequestURI, "/assets/custom.js") {
-			serveFileOrEmptyContent(ctx.Writer, ctx.Request, server.Config.Server.CustomJsFile)
+			serveFileOrEmptyContent(ctx.Writer, ctx.Request, server.Config.Server.CustomJsFile, "file.js")
 		} else if strings.HasSuffix(ctx.Request.RequestURI, "/assets/custom.css") {
-			serveFileOrEmptyContent(ctx.Writer, ctx.Request, server.Config.Server.CustomCSSFile)
+			serveFileOrEmptyContent(ctx.Writer, ctx.Request, server.Config.Server.CustomCSSFile, "file.css")
 		} else {
 			serveFile(fs)(ctx)
 		}

--- a/server/web/web_test.go
+++ b/server/web/web_test.go
@@ -25,18 +25,27 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server"
 )
 
-func Test_custom_file_returns_OK_and_empty_content(t *testing.T) {
+func Test_custom_file_returns_OK_and_empty_content_and_fitting_mimetype(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	customFiles := []string{
-		"/assets/custom.js",
-		"/assets/custom.css",
+	filesToTest := []struct {
+		fileUrl  string
+		mimetype string
+	}{
+		{
+			fileUrl:  "/assets/custom.js",
+			mimetype: "application/javascript",
+		},
+		{
+			fileUrl:  "/assets/custom.css",
+			mimetype: "text/css",
+		},
 	}
 
-	for _, f := range customFiles {
-		t.Run(f, func(t *testing.T) {
-			request, err := http.NewRequest(http.MethodGet, f, nil)
-			request.RequestURI = f // additional required for mocking
+	for _, f := range filesToTest {
+		t.Run(f.fileUrl, func(t *testing.T) {
+			request, err := http.NewRequest(http.MethodGet, f.fileUrl, nil)
+			request.RequestURI = f.fileUrl // additional required for mocking
 			assert.NoError(t, err)
 
 			rr := httptest.NewRecorder()
@@ -45,6 +54,7 @@ func Test_custom_file_returns_OK_and_empty_content(t *testing.T) {
 
 			assert.Equal(t, 200, rr.Code)
 			assert.Equal(t, []byte(nil), rr.Body.Bytes())
+			assert.Contains(t, rr.Header().Get("Content-Type"), f.mimetype)
 		})
 	}
 }


### PR DESCRIPTION
The fix is simple, just providing a file name, so `http.ServeContent(...)` can set the correct mimeype in case the content is zero bytes.

The test was just extended.