### PR TITLE
Fix incorrect yaml syntax for `ref` in docs

### DIFF
--- a/docs/docs/20-usage/20-pipeline-syntax.md
+++ b/docs/docs/20-usage/20-pipeline-syntax.md
@@ -348,8 +348,8 @@ This allows you to filter, for example, tags that must start with **v**:
 
 ```yaml
 when:
-  event: tag
-  ref: refs/tags/v*
+  - event: tag
+    ref: refs/tags/v*
 ```
 
 #### `status`


### PR DESCRIPTION
`when` contents for the `ref` option were written as a mapping, but it must be a list.