### PR TITLE
Update documentation WRT to recent `$platform` changes

### DIFF
--- a/docs/docs/20-usage/30-matrix-workflows.md
+++ b/docs/docs/20-usage/30-matrix-workflows.md
@@ -120,7 +120,8 @@ matrix:
     - linux/amd64
     - linux/arm64
 
-platform: ${platform}
+labels:
+  platform: ${platform}
 
 steps:
   test:
@@ -136,3 +137,7 @@ steps:
     when:
       platform: linux/arm*
 ```
+
+:::note
+If you want to control the architecture of a runner on Kubernetes, see [the nodeSelector documentation of the Kubernetes backend](./40-kubernetes.md#nodeSelector).
+:::

--- a/docs/docs/30-administration/22-backends/40-kubernetes.md
+++ b/docs/docs/30-administration/22-backends/40-kubernetes.md
@@ -80,9 +80,31 @@ See the [kubernetes documentation](https://kubernetes.io/docs/concepts/security/
 
 ### nodeSelector
 
-Specify the label which is used to select the node where the job should be executed. Labels defined here will be appended to a list already containing "kubernetes.io/arch".
-By default the pod will use "kubernetes.io/arch" inferred from top-level "platform" setting which is deducted from the agents' environment variable CI_SYSTEM_PLATFORM. To overwrite this, you need to specify this label in the nodeSelector section.
-See the [kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more information on using nodeSelector.
+Specify the label which is used to select the node where the job should be executed.
+Labels defined here will be appended to a list already containing "kubernetes.io/arch".
+By default the pod will use "kubernetes.io/arch" inferred from top-level "platform" setting which is deducted from the agents' environment variable CI_SYSTEM_PLATFORM.
+To overwrite this, you need to specify this label in the `nodeSelector` section of the `backend_options`.
+See the [kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more information on about the `nodeSelector` setting.
+
+A practical example is when you are running a matrix-build and you want to delegate specific elements of the matrix to run on a certain architecture.
+In this case, define an arbitrary key in the matrix section of the respective matrix element:
+
+```yml
+matrix:
+  include:
+    - NAME: runner1
+      ARCH: arm64
+```
+
+And then overwrit the `nodeSelector` in the `backend_options` section of the step(s):
+
+```yml
+[...]
+    backend_options:
+      kubernetes:
+        nodeSelector:
+          kubernetes.io/arch: "${ARCH}"
+```
 
 ### tolerations
 


### PR DESCRIPTION
I am unsure if the following `when:` syntax is also deprecated and should be updated:

```yml
when:
  - platform: linux/amd64
```

@qwerty287 Do you know more here?