### PR TITLE
Adds bitbucket tag support in docs

### DIFF
--- a/docs/docs/30-administration/11-forges/10-overview.md
+++ b/docs/docs/30-administration/11-forges/10-overview.md
@@ -5,7 +5,7 @@
 | Feature | [GitHub](github/) | [Gitea / Forgejo](gitea/) | [Gitlab](gitlab/) | [Bitbucket](bitbucket/) |
 | --- | :---: | :---: | :---: | :---: |
 | Event: Push | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Event: Tag | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
+| Event: Tag | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Event: Pull-Request | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Event: Deploy | :white_check_mark: | :x: | :x: | :x: |
 | [Multiple workflows](../../20-usage/25-workflows.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/docs/versioned_docs/version-1.0/30-administration/11-forges/10-overview.md
+++ b/docs/versioned_docs/version-1.0/30-administration/11-forges/10-overview.md
@@ -5,7 +5,7 @@
 | Feature | [GitHub](github/) | [Gitea / Forgejo](gitea/) | [Gitlab](gitlab/) | [Bitbucket](bitbucket/) |
 | --- | :---: | :---: | :---: | :---: |
 | Event: Push | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Event: Tag | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
+| Event: Tag | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Event: Pull-Request | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Event: Deploy | :white_check_mark: | :x: | :x: | :x: |
 | [Multiple workflows](../../20-usage/25-workflows.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |


### PR DESCRIPTION
Applies for v1.0.x and next

Tested for both push and tag at the current main:
<img width="1030" alt="Screenshot 2023-10-06 at 21 06 38" src="https://github.com/woodpecker-ci/woodpecker/assets/16765483/a81dfb83-9196-412f-9b42-1942007ce0cc">

but also for 1.0.x using #d9e06696bf85f260a0550d58301ac396874b32e3
<img width="1022" alt="Screenshot 2023-10-06 at 21 09 31" src="https://github.com/woodpecker-ci/woodpecker/assets/16765483/d00c0352-19dd-4c70-96f8-0a3eb5e199d4">

