### PR TITLE
Add notes about CRI-O specific config

### DIFF
--- a/docs/docs/30-administration/22-backends/40-kubernetes.md
+++ b/docs/docs/30-administration/22-backends/40-kubernetes.md
@@ -47,6 +47,19 @@ agent:
 
   Additional annotations to apply to worker pods. Must be a YAML object, e.g. `{"example.com/test-annotation":"test-value"}`.
 
+## Pipeline level configuration
+
+CRI-O users currently need to configure the workspace for all workflows in order for them to run correctly. Add the
+following at the beginning of your configuration:
+
+```yml
+workspace:
+  base: "/woodpecker"
+  path: "/"
+```
+
+See [this issue](https://github.com/woodpecker-ci/woodpecker/issues/2510) for more details.
+
 ## Job specific configuration
 
 ### Resources


### PR DESCRIPTION
CRI-O currently requires some additional config for pipelines to run. This adds some basic documentation to the kubernetes section explaining the issue.

See #2510