### PR TITLE
Move skip-ci back into central place

### DIFF
--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -19,19 +19,15 @@ import (
 	"fmt"
 	"maps"
 	"path"
-	"regexp"
 	"strings"
 
 	"github.com/antonmedv/expr"
 	"github.com/bmatcuk/doublestar/v4"
-	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 
 	"github.com/woodpecker-ci/woodpecker/pipeline/frontend/metadata"
 	yamlBaseTypes "github.com/woodpecker-ci/woodpecker/pipeline/frontend/yaml/types/base"
 )
-
-var skipRe = regexp.MustCompile(`\[(?i:ci *skip|skip *ci)\]`)
 
 type (
 	// When defines a set of runtime constraints.
@@ -82,16 +78,6 @@ func (when *When) IsEmpty() bool {
 
 // Returns true if at least one of the internal constraints is true.
 func (when *When) Match(metadata metadata.Metadata, global bool, env map[string]string) (bool, error) {
-	if global {
-		// skip the whole workflow if any case-insensitive combination of the words "skip" and "ci"
-		// wrapped in square brackets appear in the commit message
-		skipMatch := skipRe.FindString(metadata.Curr.Commit.Message)
-		if len(skipMatch) > 0 {
-			log.Debug().Msgf("skip workflow as keyword to do so was detected in commit message '%s'", metadata.Curr.Commit.Message)
-			return false, nil
-		}
-	}
-
 	for _, c := range when.Constraints {
 		match, err := c.Match(metadata, global, env)
 		if err != nil {

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -17,6 +17,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -27,6 +28,8 @@ import (
 	"github.com/woodpecker-ci/woodpecker/server/store"
 )
 
+var skipPipelineRegex = regexp.MustCompile(`\[(?i:ci *skip|skip *ci)\]`)
+
 // Create a new pipeline and start it
 func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline *model.Pipeline) (*model.Pipeline, error) {
 	repoUser, err := _store.GetUser(repo.UserID)
@@ -34,6 +37,12 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		msg := fmt.Sprintf("failure to find repo owner via id '%d'", repo.UserID)
 		log.Error().Err(err).Str("repo", repo.FullName).Msg(msg)
 		return nil, fmt.Errorf(msg)
+	}
+
+	skipMatch := skipPipelineRegex.FindString(pipeline.Message)
+	if len(skipMatch) > 0 {
+		log.Debug().Str("repo", repo.FullName).Msgf("ignoring pipeline as skip-ci was found in the commit (%s) message '%s'", pipeline.Commit, pipeline.Message)
+		return nil, ErrFiltered
 	}
 
 	// If the forge has a refresh token, the current access token


### PR DESCRIPTION
The skip logic should be in a central place and not in the compiler as it also needs to work independent of the compiler.

reverts #2216

solves #2313