### PR TITLE
Removed redundent definition of webhook form doc

### DIFF
--- a/docs/docs/20-usage/10-intro.md
+++ b/docs/docs/20-usage/10-intro.md
@@ -14,12 +14,6 @@ Webhooks are used to trigger pipeline executions. When you push code to your rep
 >
 > Note that manually creating webhooks yourself is not possible. This is because webhooks are signed using a per-repository secret key which is not exposed to end users.
 
-# Webhooks
-
-When you activate your repository Woodpecker automatically add webhooks to your forge (e.g. GitHub). There is no manual configuration required.
-
-Webhooks are used to trigger pipeline executions. When you push code to your repository, open a pull request, or create a tag, your forge will automatically send a webhook to Woodpecker which will in turn trigger pipeline execution.
-
 ## Configuration
 
 To configure your pipeline you must create a `.woodpecker.yml` file in the root of your repository. The `.woodpecker.yml` file is used to define your pipeline steps.

--- a/docs/versioned_docs/version-0.15/20-usage/10-intro.md
+++ b/docs/versioned_docs/version-0.15/20-usage/10-intro.md
@@ -14,12 +14,6 @@ Webhooks are used to trigger pipeline executions. When you push code to your rep
 >
 > Note that manually creating webhooks yourself is not possible. This is because webhooks are signed using a per-repository secret key which is not exposed to end users.
 
-# Webhooks
-
-When you activate your repository Woodpecker automatically add webhooks to your version control system (e.g. GitHub). There is no manual configuration required.
-
-Webhooks are used to trigger pipeline executions. When you push code to your repository, open a pull request, or create a tag, your version control system will automatically send a webhook to Woodpecker which will in turn trigger pipeline execution.
-
 ## Configuration
 
 To configure your pipeline you should place a `.woodpecker.yml` file in the root of your repository. The .woodpecker.yml file is used to define your pipeline steps. It is a superset of the widely used docker-compose file format.

--- a/docs/versioned_docs/version-1.0/20-usage/10-intro.md
+++ b/docs/versioned_docs/version-1.0/20-usage/10-intro.md
@@ -14,12 +14,6 @@ Webhooks are used to trigger pipeline executions. When you push code to your rep
 >
 > Note that manually creating webhooks yourself is not possible. This is because webhooks are signed using a per-repository secret key which is not exposed to end users.
 
-# Webhooks
-
-When you activate your repository Woodpecker automatically add webhooks to your forge (e.g. GitHub). There is no manual configuration required.
-
-Webhooks are used to trigger pipeline executions. When you push code to your repository, open a pull request, or create a tag, your forge will automatically send a webhook to Woodpecker which will in turn trigger pipeline execution.
-
 ## Configuration
 
 To configure your pipeline you must create a `.woodpecker.yml` file in the root of your repository. The `.woodpecker.yml` file is used to define your pipeline steps.


### PR DESCRIPTION
<img width="800" alt="Screenshot 2023-10-09 at 11 59 01 PM" src="https://github.com/woodpecker-ci/woodpecker/assets/109629956/036c267b-e7e0-440b-8fc6-607ea56aee76">

<br><br><br>
Removed this from doc as it was repeating 
<img width="815" alt="Screenshot 2023-10-09 at 11 59 10 PM" src="https://github.com/woodpecker-ci/woodpecker/assets/109629956/d8782bdd-e78f-492e-a354-36f7c6c96708">
