### PR TITLE
renovate: add `golang` group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,8 +17,14 @@
       "labels": ["build"]
     },
     {
+      "groupName": "golang",
+      "matchManagers": ["golang"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "extends": ["schedule:daily"]
+    },
+    {
       "groupName": "golang deps non-major",
-      "matchManagers": ["gomod", "golang"],
+      "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch"],
       "extends": ["schedule:daily"]
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
       "labels": ["devx"]
     },
     {
-      "matchManagers": ["gomod", "npm", "dockerfile"],
+      "matchManagers": ["gomod", "npm", "dockerfile", "golang"],
       "labels": ["dependencies"]
     },
     {
@@ -18,7 +18,7 @@
     },
     {
       "groupName": "golang deps non-major",
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "golang"],
       "matchUpdateTypes": ["minor", "patch"],
       "extends": ["schedule:daily"]
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,7 @@
     {
       "groupName": "golang",
       "matchManagers": ["golang"],
+      "matchPackagePatterns": ["xgo"],
       "matchUpdateTypes": ["minor", "patch"],
       "extends": ["schedule:daily"]
     },


### PR DESCRIPTION
Until now they are coming in in single PRs (i.e. the docker tags and xgo updates) . Adding the `"golang"` group which would bundle the following single PRs:

- https://github.com/woodpecker-ci/woodpecker/pull/2564
- https://github.com/woodpecker-ci/woodpecker/pull/2565

At first I thought that it would be good to merge with "golang deps non-major" but I think keeping the golang version updates distinct from the packages is better.