### PR TITLE
Add plugin "NixOS Remote Builder" to plugin index

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -138,6 +138,11 @@
       "name": "Dockle",
       "docs": "https://raw.githubusercontent.com/euryecetelecom/woodpeckerci-dockle/master/README.md",
       "verified": false
+    },
+    {
+      "name": "NixOS Remote Builder",
+      "docs": "https://codeberg.org/JohnWalkerx/nix-remote-builder-plugin/raw/branch/main/docs.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
I created a small Woodpecker plugin to build nix flake paths on a remote NixOS system.
So this adds it to the plugin index because this plugin could be interesting for other users.