### PR TITLE
Adjust github scopes and clarify documentation.

### DIFF
--- a/docs/versioned_docs/version-1.0/30-administration/11-forges/20-github.md
+++ b/docs/versioned_docs/version-1.0/30-administration/11-forges/20-github.md
@@ -21,7 +21,7 @@ services:
 
 ## Registration
 
-Register your application with GitHub to create your client id and secret. It is very important that the authorization callback URL matches your http(s) scheme and hostname exactly with `<scheme>://<host>/authorize` as the path.
+Register your application with GitHub to create your client id and secret. Grant "repo", "user:email" and "read:org" scopes. It is very important that the authorization callback URL matches your http(s) scheme and hostname exactly with `<scheme>://<host>/authorize` as the path.
 
 Please use this screenshot for reference:
 

--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -408,7 +408,7 @@ func (c *client) newConfig(req *http.Request) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     c.Client,
 		ClientSecret: c.Secret,
-		Scopes:       []string{"repo", "repo:status", "user:email", "read:org"},
+		Scopes:       []string{"repo", "user:email", "read:org"},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  fmt.Sprintf("%s/login/oauth/authorize", c.url),
 			TokenURL: fmt.Sprintf("%s/login/oauth/access_token", c.url),


### PR DESCRIPTION
Add scopes needed when creating Github application.
Removed "repo:status" scope, because it is included in already requested "repo" scope.