### PR TITLE
Add plugin "Gitea Create Pull Request" to plugin index

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -95,6 +95,11 @@
       "verified": true
     },
     {
+      "name": "Gitea Create Pull Request",
+      "docs": "https://codeberg.org/JohnWalkerx/gitea-pull-request-create-plugin/raw/branch/main/docs.md",
+      "verified": false
+    },
+    {
       "name": "Woodpecker Email",
       "docs": "https://gitnet.fr/deblan/woodpecker-email/raw/branch/develop/DOCS.md",
       "verified": false

--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -41,6 +41,11 @@
       "verified": false
     },
     {
+      "name": "Gitea Create Pull Request",
+      "docs": "https://codeberg.org/JohnWalkerx/gitea-pull-request-create-plugin/raw/branch/main/docs.md",
+      "verified": false
+    },
+    {
       "name": "Gitea Pull comment",
       "docs": "https://raw.githubusercontent.com/markopolo123/gitea-comment-plugin/main/docs.md",
       "verified": false
@@ -93,11 +98,6 @@
       "name": "Gitea Release",
       "docs": "https://codeberg.org/woodpecker-plugins/gitea-release/raw/branch/main/docs.md",
       "verified": true
-    },
-    {
-      "name": "Gitea Create Pull Request",
-      "docs": "https://codeberg.org/JohnWalkerx/gitea-pull-request-create-plugin/raw/branch/main/docs.md",
-      "verified": false
     },
     {
       "name": "Woodpecker Email",


### PR DESCRIPTION
I wrote a plugin to create a new pull request on a Gitea/Forgejo instance.
So I wanna add it to the plugin index because I think this is very useful for automated workflows.