### PR TITLE
Update renovate schedule & use central config repo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":maintainLockFilesWeekly",
-    "schedule:automergeDaily",
-    "schedule:weekends"
-  ],
+  "extends": ["github>woodpecker-ci/renovate-config"],
   "prConcurrentLimit": 5,
   "packageRules": [
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":maintainLockFilesWeekly"],
+  "extends": [
+    "config:recommended",
+    ":maintainLockFilesWeekly",
+    "schedule:automergeEarlyMondays",
+    "schedule:weekends"
+  ],
   "prConcurrentLimit": 5,
   "packageRules": [
     {
@@ -19,28 +24,24 @@
     {
       "groupName": "golang (lang)",
       "matchPackagePatterns": ["^golang$", "xgo"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "extends": ["schedule:daily"]
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
       "groupName": "golang (packages)",
       "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "extends": ["schedule:daily"]
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
       "groupName": "web npm deps non-major",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "matchFileNames": ["web/package.json"],
-      "extends": ["schedule:daily"]
+      "matchFileNames": ["web/package.json"]
     },
     {
       "groupName": "docs npm deps non-major",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "matchFileNames": ["docs/**/package.json"],
-      "extends": ["schedule:daily"]
+      "matchFileNames": ["docs/**/package.json"]
     },
     {
       "matchDatasources": ["docker"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     ":maintainLockFilesWeekly",
-    "schedule:automergeEarlyMondays",
+    "schedule:automergeDaily",
     "schedule:weekends"
   ],
   "prConcurrentLimit": 5,


### PR DESCRIPTION
To reduce the `renovate` noise and relax their influence on PRs a bit, I suggest the following updates:

- Run renovate only on weekends (this should create the PRs initially)
- Automerge daily (once automerge is in place -> currently testing in helm repo). This should ideally automerge the PRs from the weekend early morning on each day. Assuming there are more than one opened on the weekend, only one can be merged each day due to required branch rebasing. Ofc automerge will only happen if tests pass.
- Use a central config repo for easier maintenance of a shared config

Central config repo: https://github.com/woodpecker-ci/renovate-config/blob/main/default.json