### PR TITLE
Remove `WOODPECKER_DOCS` config

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -160,12 +160,6 @@ var flags = append([]cli.Flag{
 		Usage:   "The maximum time in minutes you can set in the repo settings before a pipeline gets killed",
 		Value:   120,
 	},
-	&cli.StringFlag{
-		EnvVars: []string{"WOODPECKER_DOCS"},
-		Name:    "docs",
-		Usage:   "link to user documentation",
-		Value:   "https://woodpecker-ci.org/",
-	},
 	&cli.DurationFlag{
 		EnvVars: []string{"WOODPECKER_SESSION_EXPIRES"},
 		Name:    "session-expires",

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -332,7 +332,6 @@ func setupEvilGlobals(c *cli.Context, v store.Store, f forge.Forge) {
 	}
 	server.Config.Server.Port = c.String("server-addr")
 	server.Config.Server.PortTLS = c.String("server-addr-tls")
-	server.Config.Server.Docs = c.String("docs")
 	server.Config.Server.StatusContext = c.String("status-context")
 	server.Config.Server.StatusContextFormat = c.String("status-context-format")
 	server.Config.Server.SessionExpires = c.Duration("session-expires")

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -346,12 +346,6 @@ Example: `user1,user2`
 
 Enable to allow user registration.
 
-### `WOODPECKER_DOCS`
-
-> Default: `https://woodpecker-ci.org/`
-
-Link to documentation in the UI.
-
 ### `WOODPECKER_AUTHENTICATE_PUBLIC_REPOS`
 
 > Default: `false`

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -13,6 +13,7 @@ Some versions need some changes to the server configuration or the pipeline conf
 - Removed `build` alias for `pipeline` command in CLI
 - Removed `ssh` backend. Use an agent directly on the SSH machine using the `local` backend.
 - Removed `/hook` and `/stream` API paths in favor of `/api/(hook|stream)`. You may need to use the "Repair repository" button in the repo settings or "Repair all" in the admin settings to recreate the forge hook.
+- Removed `WOODPECKER_DOCS` config variable
 
 ## 1.0.0
 

--- a/server/config.go
+++ b/server/config.go
@@ -63,7 +63,6 @@ var Config = struct {
 		Port                string
 		PortTLS             string
 		AgentToken          string
-		Docs                string
 		StatusContext       string
 		StatusContextFormat string
 		SessionExpires      time.Duration

--- a/server/web/config.go
+++ b/server/web/config.go
@@ -42,7 +42,6 @@ func Config(c *gin.Context) {
 	configData := map[string]interface{}{
 		"user":           user,
 		"csrf":           csrf,
-		"docs":           server.Config.Server.Docs,
 		"version":        version.String(),
 		"forge":          server.Config.Services.Forge.Name(),
 		"root_path":      server.Config.Server.RootPath,
@@ -73,7 +72,6 @@ const configTemplate = `
 window.WOODPECKER_USER = {{ json .user }};
 window.WOODPECKER_CSRF = "{{ .csrf }}";
 window.WOODPECKER_VERSION = "{{ .version }}";
-window.WOODPECKER_DOCS = "{{ .docs }}";
 window.WOODPECKER_FORGE = "{{ .forge }}";
 window.WOODPECKER_ROOT_PATH = "{{ .root_path }}";
 window.WOODPECKER_ENABLE_SWAGGER = {{ .enable_swagger }};

--- a/web/src/components/atomic/DocsLink.vue
+++ b/web/src/components/atomic/DocsLink.vue
@@ -12,7 +12,6 @@
 import { computed, toRef } from 'vue';
 
 import Icon from '~/components/atomic/Icon.vue';
-import useConfig from '~/compositions/useConfig';
 
 const props = defineProps<{
   url: string;

--- a/web/src/components/atomic/DocsLink.vue
+++ b/web/src/components/atomic/DocsLink.vue
@@ -19,8 +19,7 @@ const props = defineProps<{
   topic: string;
 }>();
 
-const docsBaseUrl = useConfig().docs;
 const url = toRef(props, 'url');
 const topic = toRef(props, 'topic');
-const docsUrl = computed(() => (url.value.startsWith('http') ? url.value : `${docsBaseUrl}${url.value}`));
+const docsUrl = computed(() => (url.value.startsWith('http') ? url.value : `https://woodpecker-ci.org/${url.value}`));
 </script>

--- a/web/src/components/layout/header/Navbar.vue
+++ b/web/src/components/layout/header/Navbar.vue
@@ -16,7 +16,7 @@
         <span class="hidden md:flex">{{ $t('repositories') }}</span>
       </router-link>
       <!-- Docs Link -->
-      <a :href="docsUrl" target="_blank" class="navbar-link navbar-clickable hidden md:flex">{{ $t('docs') }}</a>
+      <a href="https://woodpecker-ci.org/" target="_blank" class="navbar-link navbar-clickable hidden md:flex">{{ $t('docs') }}</a>
       <!-- API Link -->
       <a v-if="enableSwagger" :href="apiUrl" target="_blank" class="navbar-link navbar-clickable hidden md:flex">{{
         $t('api')
@@ -69,7 +69,6 @@ const route = useRoute();
 const authentication = useAuthentication();
 const { user } = authentication;
 const { darkMode } = useDarkMode();
-const docsUrl = config.docs || undefined;
 const apiUrl = `${config.rootPath ?? ''}/swagger/index.html`;
 
 function doLogin() {

--- a/web/src/components/layout/header/Navbar.vue
+++ b/web/src/components/layout/header/Navbar.vue
@@ -16,7 +16,9 @@
         <span class="hidden md:flex">{{ $t('repositories') }}</span>
       </router-link>
       <!-- Docs Link -->
-      <a href="https://woodpecker-ci.org/" target="_blank" class="navbar-link navbar-clickable hidden md:flex">{{ $t('docs') }}</a>
+      <a href="https://woodpecker-ci.org/" target="_blank" class="navbar-link navbar-clickable hidden md:flex">{{
+        $t('docs')
+      }}</a>
       <!-- API Link -->
       <a v-if="enableSwagger" :href="apiUrl" target="_blank" class="navbar-link navbar-clickable hidden md:flex">{{
         $t('api')

--- a/web/src/compositions/useConfig.ts
+++ b/web/src/compositions/useConfig.ts
@@ -3,7 +3,6 @@ import { User } from '~/lib/api/types';
 declare global {
   interface Window {
     WOODPECKER_USER: User | undefined;
-    WOODPECKER_DOCS: string | undefined;
     WOODPECKER_VERSION: string | undefined;
     WOODPECKER_CSRF: string | undefined;
     WOODPECKER_FORGE: 'github' | 'gitlab' | 'gitea' | 'bitbucket' | undefined;
@@ -14,7 +13,6 @@ declare global {
 
 export default () => ({
   user: window.WOODPECKER_USER || null,
-  docs: window.WOODPECKER_DOCS || null,
   version: window.WOODPECKER_VERSION,
   csrf: window.WOODPECKER_CSRF || null,
   forge: window.WOODPECKER_FORGE || null,


### PR DESCRIPTION
I don't really see a reason why this should be configurable.
The docs link is mainly used to construct links to our docs so if you would change this, you'd need to have the same structure and pages as our docs have.