### PR TITLE
Do not sanitzie secrets with 3 or less chars

### DIFF
--- a/pipeline/shared/replace_secrets.go
+++ b/pipeline/shared/replace_secrets.go
@@ -20,7 +20,7 @@ func NewSecretsReplacer(secrets []string) *strings.Replacer {
 	var oldnew []string
 	for _, old := range secrets {
 		old = strings.TrimSpace(old)
-		if len(old) == 0 {
+		if len(old) <= 3 {
 			continue
 		}
 		// since replacer is executed on each line we have to split multi-line-secrets

--- a/pipeline/shared/replace_secrets_test.go
+++ b/pipeline/shared/replace_secrets_test.go
@@ -22,34 +22,42 @@ import (
 
 func TestNewSecretsReplacer(t *testing.T) {
 	tc := []struct {
+		name    string
 		log     string
 		secrets []string
 		expect  string
 	}{{
+		name:    "dont replace secrets with less than 3 chars",
 		log:     "start log\ndone",
-		secrets: []string{""},
+		secrets: []string{"", "d", "art"},
 		expect:  "start log\ndone",
 	}, {
+		name:    "single line passwords",
 		log:     `this IS secret: password`,
 		secrets: []string{"password", " IS "},
-		expect:  `this ******** secret: ********`,
+		expect:  `this IS secret: ********`,
 	}, {
+		name:    "secret with one newline",
 		log:     "start log\ndone\nnow\nan\nmulti line secret!! ;)",
 		secrets: []string{"an\nmulti line secret!!"},
 		expect:  "start log\ndone\nnow\n********\n******** ;)",
 	}, {
+		name:    "secret with multible lines with no match",
 		log:     "start log\ndone\nnow\nan\nmulti line secret!! ;)",
 		secrets: []string{"Test\nwith\n\ntwo new lines"},
 		expect:  "start log\ndone\nnow\nan\nmulti line secret!! ;)",
 	}, {
+		name:    "secret with multible lines with match",
 		log:     "start log\ndone\nnow\nan\nmulti line secret!! ;)\nwith\ntwo\n\nnewlines",
 		secrets: []string{"an\nmulti line secret!!", "two\n\nnewlines"},
 		expect:  "start log\ndone\nnow\n********\n******** ;)\nwith\n********\n\n********",
 	}}
 
 	for _, c := range tc {
-		rep := NewSecretsReplacer(c.secrets)
-		result := rep.Replace(c.log)
-		assert.EqualValues(t, c.expect, result)
+		t.Run(c.name, func(t *testing.T) {
+			rep := NewSecretsReplacer(c.secrets)
+			result := rep.Replace(c.log)
+			assert.EqualValues(t, c.expect, result)
+		})
 	}
 }


### PR DESCRIPTION
as this secrets have to low entropy they can not be valid secrets and e.g. make log only unredable

just add a secret with value `a` to a repo an run a pipeline ...

---
*Sponsored by Kithara Software GmbH*