### PR TITLE
Use unique label selector for pod label for kubernetes services

### DIFF
--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -164,7 +164,7 @@ func (e *kube) SetupWorkflow(ctx context.Context, conf *types.Config, taskUUID s
 					return err
 				}
 				log.Trace().Str("pod-name", stepName).Msgf("Creating service: %s", step.Name)
-				svc, err := Service(e.config.Namespace, step.Name, step.Alias, step.Ports)
+				svc, err := Service(e.config.Namespace, step.Name, step.Ports)
 				if err != nil {
 					return err
 				}
@@ -391,7 +391,7 @@ func (e *kube) DestroyWorkflow(_ context.Context, conf *types.Config, taskUUID s
 		if stage.Alias == "services" {
 			for _, step := range stage.Steps {
 				log.Trace().Msgf("Deleting service: %s", step.Name)
-				svc, err := Service(e.config.Namespace, step.Name, step.Alias, step.Ports)
+				svc, err := Service(e.config.Namespace, step.Name, step.Ports)
 				if err != nil {
 					return err
 				}

--- a/pipeline/backend/kubernetes/service.go
+++ b/pipeline/backend/kubernetes/service.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func Service(namespace, name, podName string, ports []uint16) (*v1.Service, error) {
+func Service(namespace, name string, ports []uint16) (*v1.Service, error) {
 	var svcPorts []v1.ServicePort
 	for _, port := range ports {
 		svcPorts = append(svcPorts, v1.ServicePort{
@@ -42,7 +42,7 @@ func Service(namespace, name, podName string, ports []uint16) (*v1.Service, erro
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeClusterIP,
 			Selector: map[string]string{
-				"step": podName,
+				"step": dnsName,
 			},
 			Ports: svcPorts,
 		},

--- a/pipeline/backend/kubernetes/service_test.go
+++ b/pipeline/backend/kubernetes/service_test.go
@@ -45,7 +45,7 @@ func TestService(t *testing.T) {
 	      }
 	    ],
 	    "selector": {
-	      "step": "baz"
+	      "step": "bar"
 	    },
 	    "type": "ClusterIP"
 	  },
@@ -54,7 +54,7 @@ func TestService(t *testing.T) {
 	  }
 	}`
 
-	s, _ := Service("foo", "bar", "baz", []uint16{1, 2, 3})
+	s, _ := Service("foo", "bar", []uint16{1, 2, 3})
 	j, err := json.Marshal(s)
 	assert.NoError(t, err)
 	assert.JSONEq(t, expected, string(j))


### PR DESCRIPTION
Closes #2709 

as discussed in #2721 

relates to: #2656

[Pipeline](https://woodpecker-ci.org/docs/next/usage/services#complete-pipeline-example):

```yaml
services:
  database:
    image: mysql
    environment:
      - MYSQL_DATABASE=test
      - MYSQL_ROOT_PASSWORD=example
    ports:
      - 3306

steps:
  get-version:
    image: ubuntu
    commands:
      - ( apt update && apt dist-upgrade -y && apt install -y mysql-client 2>&1 )> /dev/null
      - sleep 60s # need to wait for mysql-server init
      - echo 'SHOW VARIABLES LIKE "version"' | mysql -uroot -hdatabase test -pexample
```