### PR TITLE
Add changelog 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [1.0.3](https://github.com/woodpecker-ci/woodpecker/releases/tag/1.0.3) - 2023-10-14
+## [1.0.4](https://github.com/woodpecker-ci/woodpecker/releases/tag/v1.0.4) - 2023-11-04
+
+* BUGFIXES
+  *  Fix secret image filter regex (#2674) (#2686)
+  *  Fix error when closing logs (#2637) (#2640)
+
+## [1.0.3](https://github.com/woodpecker-ci/woodpecker/releases/tag/v1.0.3) - 2023-10-14
 
 * SECURITY
   * Update dependencies (#2587)
@@ -20,7 +26,7 @@
 * MISC
   * Rebuild swagger with latest version (#2455)
 
-## [1.0.2](https://github.com/woodpecker-ci/woodpecker/releases/tag/1.0.2) - 2023-08-16
+## [1.0.2](https://github.com/woodpecker-ci/woodpecker/releases/tag/v1.0.2) - 2023-08-16
 
 * SECURITY
   * Validate webhook before change any data (#2221) (#2222)


### PR DESCRIPTION
So we release the latest bugfixes before we release 2.0 and probably won't do backports anymore.