### PR TITLE
Partially revert hiding archived (Gitea) repos

### DIFF
--- a/server/forge/gitea/gitea.go
+++ b/server/forge/gitea/gitea.go
@@ -270,9 +270,6 @@ func (c *Gitea) Repos(ctx context.Context, u *model.User) ([]*model.Repo, error)
 		)
 		result := make([]*model.Repo, 0, len(repos))
 		for _, repo := range repos {
-			if repo.Archived {
-				continue
-			}
 			result = append(result, toRepo(repo))
 		}
 		return result, err


### PR DESCRIPTION
The code in question will prevent the return of all Gitea repos from the API. See https://github.com/woodpecker-ci/woodpecker/discussions/2491#discussioncomment-7491101 for a more detailed explanation.

Partially reverts #2374 

Side ref: #2613

Not sure about the GH and GL parts, but the Gitea part needs fixing. This is just a quick fix to revert it.

cc @mzampetakis 