### PR TITLE
Remove go versions from .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ linters-settings:
   misspell:
     locale: US
   gofumpt:
-    lang-version: '1.21'
     extra-rules: true
   forbidigo:
     forbid:
@@ -37,7 +36,6 @@ linters:
 
 run:
   timeout: 5m
-  go: '1.21'
 
 issues:
   exclude-rules:


### PR DESCRIPTION
1. `linter.lang-version` is deprecated in favor of `run.go`
2. `run.go` defaults to the version in `go.mod` as per [docs](https://golangci-lint.run/usage/configuration/#run-configuration):

```yaml
  # Define the Go version limit.
  # Mainly related to generics support since go1.18.
  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
  go: '1.19'
```

So in summary, we don't need these versions in the file as long as we keep the version in go.mod bumped.