### PR TITLE
Use labels for platform in example form Matrix workflows

### DIFF
--- a/docs/versioned_docs/version-1.0/20-usage/30-matrix-workflows.md
+++ b/docs/versioned_docs/version-1.0/20-usage/30-matrix-workflows.md
@@ -120,7 +120,8 @@ matrix:
     - linux/amd64
     - linux/arm64
 
-platform: ${platform}
+labels:
+  platform: ${platform}
 
 steps:
   test:


### PR DESCRIPTION

I used example from https://woodpecker-ci.org/docs/usage/matrix-workflows
Then I see warning message from Woodpecker:

<img width="848" alt="image" src="https://github.com/woodpecker-ci/woodpecker/assets/21104/0dc7ea0f-9acb-4aca-afb9-14cb2ab0fbb3">
