### PR TITLE
Bump default clone image version to 2.4.0

### DIFF
--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -33,7 +33,7 @@ var DefaultConfigOrder = [...]string{
 
 const (
 	// DefaultCloneImage can be changed by 'WOODPECKER_DEFAULT_CLONE_IMAGE' at runtime
-	DefaultCloneImage = "docker.io/woodpeckerci/plugin-git:2.1.1"
+	DefaultCloneImage = "docker.io/woodpeckerci/plugin-git:2.4.0"
 )
 
 var TrustedCloneImages = []string{


### PR DESCRIPTION
as with https://github.com/woodpecker-ci/plugin-git/pull/106 we have a potential to speed up clone step a lot