### PR TITLE
Fix multiple error matching

### DIFF
--- a/server/api/helper.go
+++ b/server/api/helper.go
@@ -29,9 +29,9 @@ import (
 )
 
 func handlePipelineErr(c *gin.Context, err error) {
-	if errors.Is(err, &pipeline.ErrNotFound{}) {
+	if errors.As(err, &pipeline.ErrNotFound{}) {
 		c.String(http.StatusNotFound, "%s", err)
-	} else if errors.Is(err, &pipeline.ErrBadRequest{}) {
+	} else if errors.As(err, &pipeline.ErrBadRequest{}) {
 		c.String(http.StatusBadRequest, "%s", err)
 	} else if errors.Is(err, pipeline.ErrFiltered) {
 		c.Status(http.StatusNoContent)

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -111,7 +111,8 @@ func PostHook(c *gin.Context) {
 
 	tmpRepo, tmpPipeline, err := forge.Hook(c, c.Request)
 	if err != nil {
-		if errors.Is(err, &types.ErrIgnoreEvent{}) {
+		var ierr *types.ErrIgnoreEvent
+		if errors.As(err, &ierr) {
 			msg := fmt.Sprintf("forge driver: %s", err)
 			log.Debug().Err(err).Msg(msg)
 			c.String(http.StatusOK, msg)


### PR DESCRIPTION
Fix for multiple error matching issues: *errors.Is()* is used wrongly to compare 2 instances of an error while *error.As()* should be used instead to compare their type. 
TODO: It might also be better to change **pipeline.ErrNotFound** and **pipeline.ErrBadRequest** to pointer receivers in their *Error()* method, to prevent  having both value & pointer as valid errors.