### PR TITLE
fix: Add `backend_options` to service linter entry

### DIFF
--- a/pipeline/frontend/yaml/linter/schema/schema.json
+++ b/pipeline/frontend/yaml/linter/schema/schema.json
@@ -764,6 +764,9 @@
         "volumes": {
           "$ref": "#/definitions/step_volumes"
         },
+        "backend_options": {
+          "$ref": "#/definitions/step_backend_options"
+        },
         "ports": {
           "description": "expose ports to which other steps can connect to",
           "type": "array",


### PR DESCRIPTION
I've tried setting resources for a service and have seen the linter warning that is not supported, though the the pipeline was successful and resources were actually set on the pod. So I assume it shouldn't be a linter issue.

I"m also not sure if my change is correct, I only hope it is

## Some Context

A pipeline example (I've removed steps that are not related directly:
```yaml
---
steps:
  test:
    name: Test charts
    image: quay.io/helmpack/chart-testing
    environment:
      - DOCKER_HOST=tcp://docker:2375
    commands:
      - export PATH=$PWD/.bin:$PATH
      - apk update && apk add docker
      - kind create cluster --config kind.yaml
      - sed -i -E -e 's/localhost|0\.0\.0\.0/docker/g' ~/.kube/config
      - git fetch origin
      - |
        if [ -e .changed ]; then
          ct install --target-branch main --chart-dirs .
          ct install --target-branch main --chart-dirs . --upgrade
        fi

services:
  docker:
    image: docker:dind
    commands: dockerd -H tcp://0.0.0.0:2375 --tls=false
    privileged: true
    ports:
      - 2375
    backend_options:
      kubernetes:
        resources:
          requests:
            memory: 400Mi
            cpu: 100m
          limits:
            memory: 400Mi
            cpu: 100m
```

Pod description:
```
Containers:
  wp-01hhczdknafj81jv80gzjbgt93-0-services-0:
    Limits:
      cpu:     100m
      memory:  400Mi
    Requests:
      cpu:     100m
      memory:  400Mi
```

Warning in the Woodpecker UI:

```
[linter]woodpecker: services.dockerAdditional property backend_options is not allowed
```