### PR TITLE
feat(k8s): Add a port name to service definition

### DIFF
--- a/pipeline/backend/kubernetes/service.go
+++ b/pipeline/backend/kubernetes/service.go
@@ -16,6 +16,7 @@ package kubernetes
 
 import (
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pipeline/backend/kubernetes/service.go
+++ b/pipeline/backend/kubernetes/service.go
@@ -15,6 +15,8 @@
 package kubernetes
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -24,6 +26,7 @@ func Service(namespace, name string, ports []uint16) (*v1.Service, error) {
 	var svcPorts []v1.ServicePort
 	for _, port := range ports {
 		svcPorts = append(svcPorts, v1.ServicePort{
+			Name:       fmt.Sprintf("port-%d", port),
 			Port:       int32(port),
 			TargetPort: intstr.IntOrString{IntVal: int32(port)},
 		})

--- a/pipeline/backend/kubernetes/service.go
+++ b/pipeline/backend/kubernetes/service.go
@@ -16,7 +16,6 @@ package kubernetes
 
 import (
 	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pipeline/backend/kubernetes/service_test.go
+++ b/pipeline/backend/kubernetes/service_test.go
@@ -32,17 +32,17 @@ func TestService(t *testing.T) {
 	  "spec": {
 	    "ports": [
 	      {
-				  "name": "port-1",
+	        "name": "port-1",
 	        "port": 1,
 	        "targetPort": 1
 	      },
 	      {
-				  "name": "port-2",
+	        "name": "port-2",
 	        "port": 2,
 	        "targetPort": 2
 	      },
 	      {
-				  "name": "port-3",
+	        "name": "port-3",
 	        "port": 3,
 	        "targetPort": 3
 	      }

--- a/pipeline/backend/kubernetes/service_test.go
+++ b/pipeline/backend/kubernetes/service_test.go
@@ -32,14 +32,17 @@ func TestService(t *testing.T) {
 	  "spec": {
 	    "ports": [
 	      {
+				  "name": "port-1",
 	        "port": 1,
 	        "targetPort": 1
 	      },
 	      {
+				  "name": "port-2",
 	        "port": 2,
 	        "targetPort": 2
 	      },
 	      {
+				  "name": "port-3",
 	        "port": 3,
 	        "targetPort": 3
 	      }


### PR DESCRIPTION
It should cover this issue: https://github.com/woodpecker-ci/woodpecker/issues/2931

To sum up, when several ports need to be specified, they must be named