### PR TITLE
init CI_COMMIT_TAG if commit ref is a tag

### DIFF
--- a/pipeline/frontend/metadata/environment.go
+++ b/pipeline/frontend/metadata/environment.go
@@ -119,7 +119,7 @@ func (m *Metadata) Environ() map[string]string {
 		// TODO Deprecated, remove in 3.x
 		"CI_COMMIT_URL": m.Curr.ForgeURL,
 	}
-	if m.Curr.Event == EventTag {
+	if strings.HasPrefix(m.Curr.Commit.Ref, "refs/tags/") {
 		params["CI_COMMIT_TAG"] = strings.TrimPrefix(m.Curr.Commit.Ref, "refs/tags/")
 	}
 	if m.Curr.Event == EventPull {

--- a/pipeline/frontend/metadata/environment.go
+++ b/pipeline/frontend/metadata/environment.go
@@ -119,7 +119,7 @@ func (m *Metadata) Environ() map[string]string {
 		// TODO Deprecated, remove in 3.x
 		"CI_COMMIT_URL": m.Curr.ForgeURL,
 	}
-	if strings.HasPrefix(m.Curr.Commit.Ref, "refs/tags/") {
+	if m.Curr.Event == EventTag || strings.HasPrefix(m.Curr.Commit.Ref, "refs/tags/") {
 		params["CI_COMMIT_TAG"] = strings.TrimPrefix(m.Curr.Commit.Ref, "refs/tags/")
 	}
 	if m.Curr.Event == EventPull {


### PR DESCRIPTION
When triggering a deployment event on an existing pipeline, there is no way to get the tag used to trigger the parent pipeline, even if this parent was a tag event. 

In our company CI/CD current setup with drone, we use the tag event to trigger a kaniko image build step, using the git tag as an image tag, and the deployment/promotion step to effectively deploy this image using the tag reference in our cluster. This is the only point blocking us to completely switch to woodpecker and get rid of drone...

What's done:
- changed the metadata environ() method to populate CI_COMMIT_TAG env var if commit ref starts with /refs/tags (like it's done in drone), independently of event type EventTag.

Please let me know if I'm wrong, I will happily contribute in this nice project.