### PR TITLE
Display runners errors in UI

### DIFF
--- a/server/grpc/rpc.go
+++ b/server/grpc/rpc.go
@@ -274,10 +274,13 @@ func (s *RPC) Done(c context.Context, id string, state rpc.State) error {
 	}
 	s.completeChildrenIfParentCompleted(workflow)
 
+			if currentPipeline, err = pipeline.UpdateToStatusKilled(s.store, *currentPipeline, errors.New(state.Error)); err != nil {
+				logger.Error().Err(err).Msgf("pipeline.UpdateStatusToDone: cannot update workflow final state")
+			}
 	if !model.IsThereRunningStage(currentPipeline.Workflows) {
-		if currentPipeline, err = pipeline.UpdateStatusToDone(s.store, *currentPipeline, model.PipelineStatus(currentPipeline.Workflows), workflow.Stopped); err != nil {
-			logger.Error().Err(err).Msgf("pipeline.UpdateStatusToDone: cannot update workflow final state")
-		}
+			if currentPipeline, err = pipeline.UpdateStatusToDone(s.store, *currentPipeline, model.PipelineStatus(currentPipeline.Workflows), workflow.Stopped); err != nil {
+				logger.Error().Err(err).Msgf("pipeline.UpdateStatusToDone: cannot update workflow final state")
+			}
 	}
 
 	s.updateForgeStatus(c, repo, currentPipeline, workflow)

--- a/server/pipeline/cancel.go
+++ b/server/pipeline/cancel.go
@@ -82,7 +82,7 @@ func Cancel(ctx context.Context, store store.Store, repo *model.Repo, user *mode
 		}
 	}
 
-	killedPipeline, err := UpdateToStatusKilled(store, *pipeline)
+	killedPipeline, err := UpdateToStatusKilled(store, *pipeline, err)
 	if err != nil {
 		log.Error().Err(err).Msgf("UpdateToStatusKilled: %v", pipeline)
 		return err

--- a/server/pipeline/pipelineStatus.go
+++ b/server/pipeline/pipelineStatus.go
@@ -56,7 +56,8 @@ func UpdateToStatusError(store model.UpdatePipelineStore, pipeline model.Pipelin
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }
 
-func UpdateToStatusKilled(store model.UpdatePipelineStore, pipeline model.Pipeline) (*model.Pipeline, error) {
+func UpdateToStatusKilled(store model.UpdatePipelineStore, pipeline model.Pipeline, err error) (*model.Pipeline, error) {
+	pipeline.Errors = errors.GetPipelineErrors(err)
 	pipeline.Status = model.StatusKilled
 	pipeline.Finished = time.Now().Unix()
 	return &pipeline, store.UpdatePipeline(&pipeline)


### PR DESCRIPTION
It should resolve this issue: #2937 

I've only tested on k8s backend, and here you can see what it looks like in UI: https://ci.badhouseplants.net/repos/2/pipeline/55 

I'm not sure about change here: `server/pipeline/cancel.go`. So I still want to figure out what I've actually done, but I guess maybe @qwerty287, could you please look at the result and say what you think already?