### PR TITLE
Draft: Agent pipeline callback api

### DIFF
--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -173,6 +173,11 @@ func (e *docker) SetupWorkflow(_ context.Context, conf *backend.Config, taskUUID
 			return err
 		}
 	}
+
+	if conf.AccessToken != "" {
+		// TODO: setup callback socket
+	}
+
 	return nil
 }
 

--- a/pipeline/backend/types/config.go
+++ b/pipeline/backend/types/config.go
@@ -14,9 +14,9 @@
 
 package types
 
-// Config defines the runtime configuration of a pipeline.
+// Config defines the runtime configuration of a workflow.
 type Config struct {
-	Stages   []*Stage   `json:"pipeline"` // pipeline stages
+	Stages   []*Stage   `json:"pipeline"` // workflow stages
 	Networks []*Network `json:"networks"` // network definitions
 	Volumes  []*Volume  `json:"volumes"`  // volume definitions
 	Secrets  []*Secret  `json:"secrets"`  // secret definitions

--- a/pipeline/backend/types/config.go
+++ b/pipeline/backend/types/config.go
@@ -16,10 +16,11 @@ package types
 
 // Config defines the runtime configuration of a workflow.
 type Config struct {
-	Stages   []*Stage   `json:"pipeline"` // workflow stages
-	Networks []*Network `json:"networks"` // network definitions
-	Volumes  []*Volume  `json:"volumes"`  // volume definitions
-	Secrets  []*Secret  `json:"secrets"`  // secret definitions
+	Stages      []*Stage   `json:"pipeline"`     // workflow stages
+	Networks    []*Network `json:"networks"`     // network definitions
+	Volumes     []*Volume  `json:"volumes"`      // volume definitions
+	Secrets     []*Secret  `json:"secrets"`      // secret definitions
+	AccessToken string     `json:"access_token"` // token to access pipeline resources (rw)
 }
 
 // CliContext is the context key to pass cli context to backends if needed

--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -71,23 +71,24 @@ type ResourceLimit struct {
 
 // Compiler compiles the yaml
 type Compiler struct {
-	local             bool
-	escalated         []string
-	prefix            string
-	volumes           []string
-	networks          []string
-	env               map[string]string
-	cloneEnv          map[string]string
-	base              string
-	path              string
-	metadata          metadata.Metadata
-	registries        []Registry
-	secrets           secretMap
-	cacher            Cacher
-	reslimit          ResourceLimit
-	defaultCloneImage string
-	trustedPipeline   bool
-	netrcOnlyTrusted  bool
+	local               bool
+	escalated           []string
+	prefix              string
+	volumes             []string
+	networks            []string
+	env                 map[string]string
+	cloneEnv            map[string]string
+	base                string
+	path                string
+	metadata            metadata.Metadata
+	registries          []Registry
+	secrets             secretMap
+	cacher              Cacher
+	reslimit            ResourceLimit
+	defaultCloneImage   string
+	trustedPipeline     bool
+	netrcOnlyTrusted    bool
+	pipelineAccessToken string
 }
 
 // New creates a new Compiler with options.
@@ -107,6 +108,8 @@ func New(opts ...Option) *Compiler {
 // representation configuration format.
 func (c *Compiler) Compile(conf *yaml_types.Workflow) (*backend_types.Config, error) {
 	config := new(backend_types.Config)
+
+	config.AccessToken = c.pipelineAccessToken
 
 	if match, err := conf.When.Match(c.metadata, true, c.env); !match && err == nil {
 		// This pipeline does not match the configured filter so return an empty config and stop further compilation.

--- a/pipeline/frontend/yaml/compiler/option.go
+++ b/pipeline/frontend/yaml/compiler/option.go
@@ -246,3 +246,9 @@ func WithProxy(opt ProxyOptions) Option {
 		},
 	)
 }
+
+func WithPipelineAccessToken(token string) Option {
+	return func(c *Compiler) {
+		c.pipelineAccessToken = token
+	}
+}

--- a/pipeline/rpc/peer.go
+++ b/pipeline/rpc/peer.go
@@ -84,4 +84,6 @@ type Peer interface {
 
 	// ReportHealth reports health status of the agent to the server
 	ReportHealth(c context.Context) error
+
+	// TODO: callback api to update pipeline etc...
 }

--- a/pipeline/stepBuilder.go
+++ b/pipeline/stepBuilder.go
@@ -295,6 +295,7 @@ func (b *StepBuilder) toInternalRepresentation(parsed *yaml_types.Workflow, envi
 		compiler.WithMetadata(metadata),
 		compiler.WithTrusted(b.Repo.IsTrusted),
 		compiler.WithNetrcOnlyTrusted(b.Repo.NetrcOnlyTrusted),
+		compiler.WithPipelineAccessToken(b.Curr.AccessToken),
 	).Compile(parsed)
 }
 

--- a/server/model/pipeline.go
+++ b/server/model/pipeline.go
@@ -53,6 +53,7 @@ type Pipeline struct {
 	ChangedFiles        []string                `json:"changed_files,omitempty" xorm:"LONGTEXT 'changed_files'"`
 	AdditionalVariables map[string]string       `json:"variables,omitempty"     xorm:"json 'additional_variables'"`
 	PullRequestLabels   []string                `json:"pr_labels,omitempty"     xorm:"json 'pr_labels'"`
+	AccessToken         string                  `json:"-"                       xorm:"access_token"`
 } //	@name Pipeline
 
 // TableName return database table name for xorm

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -126,26 +126,26 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 	return pipeline, nil
 }
 
-func updatePipelineWithErr(ctx context.Context, _store store.Store, _pipeline *model.Pipeline, repo *model.Repo, repoUser *model.User, err error) error {
-	pipeline, err := UpdateToStatusError(_store, *_pipeline, err)
+func updatePipelineWithErr(ctx context.Context, _store store.Store, pipeline *model.Pipeline, repo *model.Repo, repoUser *model.User, err error) error {
+	_pipeline, err := UpdateToStatusError(_store, *pipeline, err)
 	if err != nil {
 		return err
 	}
 	// update value in ref
-	*_pipeline = *pipeline
+	*pipeline = *_pipeline
 
 	publishPipeline(ctx, pipeline, repo, repoUser)
 
 	return nil
 }
 
-func updatePipelinePending(ctx context.Context, _store store.Store, _pipeline *model.Pipeline, repo *model.Repo, repoUser *model.User) error {
-	pipeline, err := UpdateToStatusPending(_store, *_pipeline, "")
+func updatePipelinePending(ctx context.Context, _store store.Store, pipeline *model.Pipeline, repo *model.Repo, repoUser *model.User) error {
+	_pipeline, err := UpdateToStatusPending(_store, *pipeline, "")
 	if err != nil {
 		return err
 	}
 	// update value in ref
-	*_pipeline = *pipeline
+	*pipeline = *_pipeline
 
 	publishPipeline(ctx, pipeline, repo, repoUser)
 

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/errors"
@@ -53,6 +54,7 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 	// update some pipeline fields
 	pipeline.RepoID = repo.ID
 	pipeline.Status = model.StatusCreated
+	pipeline.AccessToken = uuid.New().String()
 	setGatedState(repo, pipeline)
 	err = _store.CreatePipeline(pipeline)
 	if err != nil {

--- a/server/pipeline/pipelineStatus.go
+++ b/server/pipeline/pipelineStatus.go
@@ -41,12 +41,14 @@ func UpdateToStatusDeclined(store model.UpdatePipelineStore, pipeline model.Pipe
 	pipeline.Reviewer = reviewer
 	pipeline.Status = model.StatusDeclined
 	pipeline.Reviewed = time.Now().Unix()
+	pipeline.AccessToken = ""
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }
 
 func UpdateStatusToDone(store model.UpdatePipelineStore, pipeline model.Pipeline, status model.StatusValue, stopped int64) (*model.Pipeline, error) {
 	pipeline.Status = status
 	pipeline.Finished = stopped
+	pipeline.AccessToken = ""
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }
 
@@ -55,11 +57,13 @@ func UpdateToStatusError(store model.UpdatePipelineStore, pipeline model.Pipelin
 	pipeline.Status = model.StatusError
 	pipeline.Started = time.Now().Unix()
 	pipeline.Finished = pipeline.Started
+	pipeline.AccessToken = ""
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }
 
 func UpdateToStatusKilled(store model.UpdatePipelineStore, pipeline model.Pipeline) (*model.Pipeline, error) {
 	pipeline.Status = model.StatusKilled
 	pipeline.Finished = time.Now().Unix()
+	pipeline.AccessToken = ""
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }

--- a/server/pipeline/pipelineStatus.go
+++ b/server/pipeline/pipelineStatus.go
@@ -29,9 +29,11 @@ func UpdateToStatusRunning(store model.UpdatePipelineStore, pipeline model.Pipel
 }
 
 func UpdateToStatusPending(store model.UpdatePipelineStore, pipeline model.Pipeline, reviewer string) (*model.Pipeline, error) {
-	pipeline.Reviewer = reviewer
+	if reviewer != "" {
+		pipeline.Reviewer = reviewer
+		pipeline.Reviewed = time.Now().Unix()
+	}
 	pipeline.Status = model.StatusPending
-	pipeline.Reviewed = time.Now().Unix()
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }
 

--- a/server/pipeline/restart.go
+++ b/server/pipeline/restart.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v2/server"
@@ -70,6 +71,7 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 
 	newPipeline := createNewOutOfOld(lastPipeline)
 	newPipeline.Parent = lastPipeline.ID
+	newPipeline.AccessToken = uuid.New().String()
 
 	err = store.CreatePipeline(newPipeline)
 	if err != nil {


### PR DESCRIPTION
Current STATE: this pull is more of an idea just wrote down ... anybody can start fresh ... still till no issue exist, I'll rather have this open

## Reason

If we have an propper api that can be gated by on demand random generated tokens.
Each Step can have a back hannel to woodpecker that can be propper serilaized, gate keepted, monitored and secured.
We efen could allow plugins to show addiginal UI elements in the server this way as long as we make it sainitizable e.g. no XSS issues etc...

That way we could for example let one step change/set settings for the next plugin etc... and still let the plugin decide it it wana accept that ...

in general we need more reasoning how such api should look like, what state is stored where.

with in mind:
 - not to create side channels that can be atacked
 - be secure
 - be reproducable with same input...
 - backend transparent

## TODOs:
- [ ] create agent callback server
- [ ] allow access token as auth method for server api to change the pipeline specific resources
- [ ] ...

<!-- brainstorming: https://claude.ai/chat/69ef1841-8166-4bb9-a6c0-24fa886420bd -->