### PR TITLE
Server: Do not cache index.html

### DIFF
--- a/server/web/web.go
+++ b/server/web/web.go
@@ -143,6 +143,7 @@ func redirect(location string, status ...int) func(ctx *gin.Context) {
 func handleIndex(c *gin.Context) {
 	rw := c.Writer
 	rw.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	rw.Header().Set("Cache-Control", "public, max-age=60")
 	rw.WriteHeader(http.StatusOK)
 	if _, err := rw.Write(indexHTML); err != nil {
 		log.Error().Err(err).Msg("can not write index.html")


### PR DESCRIPTION
Or at least only cache it a short while. Set caching to 1 minute. Should not increase server load much, since most page changes are with the javascript spa app and does not ask for index.html.

This will ensure that the right version of the javascript file is loaded.

Fixes https://github.com/woodpecker-ci/woodpecker/issues/2483