### PR TITLE
Correct http cache headers for firefox

### DIFF
--- a/server/api/stream.go
+++ b/server/api/stream.go
@@ -44,7 +44,7 @@ import (
 //	@Tags			Events
 func EventStreamSSE(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
-	c.Header("Cache-Control", "no-cache")
+	c.Header("Cache-Control", "no-store")
 	c.Header("Connection", "keep-alive")
 	c.Header("X-Accel-Buffering", "no")
 

--- a/server/web/web.go
+++ b/server/web/web.go
@@ -109,7 +109,7 @@ func serveFile(f *prefixFS) func(ctx *gin.Context) {
 		case strings.HasSuffix(ctx.Request.URL.Path, ".png"):
 			mime = "image/png"
 		case strings.HasSuffix(ctx.Request.URL.Path, ".svg"):
-			mime = "image/svg"
+			mime = "image/svg+xml"
 		}
 		ctx.Status(http.StatusOK)
 		ctx.Writer.Header().Set("Cache-Control", "public, max-age=31536000")


### PR DESCRIPTION
fixes #2210 (favicon display and event-stream endpoint)