### PR TITLE
Document `WOODPECKER_LOG_FILE`

### DIFF
--- a/cmd/common/logger.go
+++ b/cmd/common/logger.go
@@ -34,7 +34,7 @@ var GlobalLoggerFlags = []cli.Flag{
 	&cli.StringFlag{
 		EnvVars: []string{"WOODPECKER_LOG_FILE"},
 		Name:    "log-file",
-		Usage:   "where logs are written to. 'stdout' and 'stderr' can be used as special keywords",
+		Usage:   "Output destination for logs. 'stdout' and 'stderr' can be used as special keywords.",
 		Value:   "stderr",
 	},
 	&cli.BoolFlag{

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -189,6 +189,13 @@ The following list describes all available server configuration options.
 
 Configures the logging level. Possible values are `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`, `disabled` and empty.
 
+### `WOODPECKER_LOG_FILE`
+
+> Default: stderr
+
+Output destination for logs.
+'stdout' and 'stderr' can be used as special keywords.
+
 ### `WOODPECKER_LOG_XORM`
 
 > Default: `false`

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -191,7 +191,7 @@ Configures the logging level. Possible values are `trace`, `debug`, `info`, `war
 
 ### `WOODPECKER_LOG_FILE`
 
-> Default: stderr
+> Default: `stderr`
 
 Output destination for logs.
 'stdout' and 'stderr' can be used as special keywords.

--- a/docs/versioned_docs/version-2.0/30-administration/10-server-config.md
+++ b/docs/versioned_docs/version-2.0/30-administration/10-server-config.md
@@ -198,7 +198,7 @@ Configures the logging level. Possible values are `trace`, `debug`, `info`, `war
 
 ### `WOODPECKER_LOG_FILE`
 
-> Default: stderr
+> Default: `stderr`
 
 Output destination for logs.
 'stdout' and 'stderr' can be used as special keywords.

--- a/docs/versioned_docs/version-2.0/30-administration/10-server-config.md
+++ b/docs/versioned_docs/version-2.0/30-administration/10-server-config.md
@@ -196,6 +196,13 @@ The following list describes all available server configuration options.
 
 Configures the logging level. Possible values are `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`, `disabled` and empty.
 
+### `WOODPECKER_LOG_FILE`
+
+> Default: stderr
+
+Output destination for logs.
+'stdout' and 'stderr' can be used as special keywords.
+
 ### `WOODPECKER_LOG_XORM`
 
 > Default: `false`


### PR DESCRIPTION
Missed from #2115 

Also rephrased the description a bit.