### PR TITLE
Fix DAG cycle detection

### DIFF
--- a/pipeline/frontend/yaml/compiler/dag.go
+++ b/pipeline/frontend/yaml/compiler/dag.go
@@ -102,6 +102,8 @@ func dfsVisit(steps map[string]*dagCompilerStep, name string, visited map[string
 		}
 	}
 
+	delete(visited, name)
+
 	return nil
 }
 

--- a/pipeline/frontend/yaml/compiler/dag_test.go
+++ b/pipeline/frontend/yaml/compiler/dag_test.go
@@ -52,6 +52,26 @@ func TestConvertDAGToStages(t *testing.T) {
 	assert.NoError(t, err)
 
 	steps = map[string]*dagCompilerStep{
+		"a": {
+			step: &backend_types.Step{},
+		},
+		"b": {
+			step:      &backend_types.Step{},
+			dependsOn: []string{"a"},
+		},
+		"c": {
+			step:      &backend_types.Step{},
+			dependsOn: []string{"a"},
+		},
+		"d": {
+			step:      &backend_types.Step{},
+			dependsOn: []string{"b", "c"},
+		},
+	}
+	_, err = convertDAGToStages(steps, "")
+	assert.NoError(t, err)
+
+	steps = map[string]*dagCompilerStep{
 		"step1": {
 			step:      &backend_types.Step{},
 			dependsOn: []string{"not-existing-step"},


### PR DESCRIPTION
Previously a graph like this.

    a <- b
    ^    ^
    |    |
    c <- d

Was incorrectly recognized as having a cycle.

Fixes #3048.