### PR TITLE
Blocked: Fix alterTableSecretsAddUserCol to handle NULL cases of secret_repo_id

### DIFF
--- a/server/store/datastore/migration/008_secrets_add_user.go
+++ b/server/store/datastore/migration/008_secrets_add_user.go
@@ -36,6 +36,9 @@ var alterTableSecretsAddUserCol = xormigrate.Migration{
 		if err := sess.Sync(new(SecretV008)); err != nil {
 			return err
 		}
+		if _, err := sess.SQL(`UPDATE secrets SET secret_repo_id=0 WHERE secret_repo_id=NULL;`).Exec(); err != nil {
+			return err
+		}
 		if err := alterColumnDefault(sess, "secrets", "secret_repo_id", "0"); err != nil {
 			return err
 		}


### PR DESCRIPTION
see https://discord.com/channels/838698813463724034/838698813463724037/1190775891282907238

"... SInce migrating to v2 I get this error "fatal could not migrate datastore | error=migration alter-table-add-secrets-user-id failed: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'COLUMN secret_repo_id SET NOT NULL' at line 1 " ..."