### PR TITLE
Move `cmd/common` to `shared`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,6 +141,6 @@ issues:
       linters:
         - forbidigo
     # allow some setup functions to use log.Fatal()
-    - path: 'server/web/web.go|server/plugins/encryption/tink_keyset_watcher.go'
+    - path: 'server/web/web.go|server/plugins/encryption/tink_keyset_watcher.go|shared/logger/logger.go'
       linters:
         - forbidigo

--- a/cli/common/flags.go
+++ b/cli/common/flags.go
@@ -17,7 +17,7 @@ package common
 import (
 	"github.com/urfave/cli/v2"
 
-	"go.woodpecker-ci.org/woodpecker/v2/cmd/common"
+	"go.woodpecker-ci.org/woodpecker/v2/shared/logger"
 )
 
 var GlobalFlags = append([]cli.Flag{
@@ -51,7 +51,7 @@ var GlobalFlags = append([]cli.Flag{
 		Usage:   "socks proxy ignored",
 		Hidden:  true,
 	},
-}, common.GlobalLoggerFlags...)
+}, logger.GlobalLoggerFlags...)
 
 // FormatFlag return format flag with value set based on template
 // if hidden value is set, flag will be hidden

--- a/cli/common/zerologger.go
+++ b/cli/common/zerologger.go
@@ -17,10 +17,10 @@ package common
 import (
 	"github.com/urfave/cli/v2"
 
-	"go.woodpecker-ci.org/woodpecker/v2/cmd/common"
+	"go.woodpecker-ci.org/woodpecker/v2/shared/logger"
 )
 
 func SetupGlobalLogger(c *cli.Context) error {
-	common.SetupGlobalLogger(c, false)
+	logger.SetupGlobalLogger(c, false)
 	return nil
 }

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -39,18 +39,18 @@ import (
 
 	"go.woodpecker-ci.org/woodpecker/v2/agent"
 	agentRpc "go.woodpecker-ci.org/woodpecker/v2/agent/rpc"
-	"go.woodpecker-ci.org/woodpecker/v2/cmd/common"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/backend"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/types"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/rpc"
 	"go.woodpecker-ci.org/woodpecker/v2/shared/addon"
 	addonTypes "go.woodpecker-ci.org/woodpecker/v2/shared/addon/types"
+	"go.woodpecker-ci.org/woodpecker/v2/shared/logger"
 	"go.woodpecker-ci.org/woodpecker/v2/shared/utils"
 	"go.woodpecker-ci.org/woodpecker/v2/version"
 )
 
 func run(c *cli.Context) error {
-	common.SetupGlobalLogger(c, true)
+	logger.SetupGlobalLogger(c, true)
 
 	agentConfigPath := c.String("agent-config")
 	hostname := c.String("hostname")

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -21,10 +21,10 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/urfave/cli/v2"
 
-	"go.woodpecker-ci.org/woodpecker/v2/cmd/common"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/docker"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/kubernetes"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/local"
+	"go.woodpecker-ci.org/woodpecker/v2/shared/logger"
 	"go.woodpecker-ci.org/woodpecker/v2/shared/utils"
 	"go.woodpecker-ci.org/woodpecker/v2/version"
 )
@@ -42,7 +42,7 @@ func main() {
 			Action: pinger,
 		},
 	}
-	app.Flags = utils.MergeSlices(flags, common.GlobalLoggerFlags, docker.Flags, kubernetes.Flags, local.Flags)
+	app.Flags = utils.MergeSlices(flags, logger.GlobalLoggerFlags, docker.Flags, kubernetes.Flags, local.Flags)
 
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"go.woodpecker-ci.org/woodpecker/v2/cmd/common"
 	"go.woodpecker-ci.org/woodpecker/v2/shared/constant"
+	"go.woodpecker-ci.org/woodpecker/v2/shared/logger"
 )
 
 var flags = append([]cli.Flag{
@@ -472,4 +472,4 @@ var flags = append([]cli.Flag{
 		Name:    "encryption-disable-flag",
 		Usage:   "Flag to decrypt all encrypted data and disable encryption on server",
 	},
-}, common.GlobalLoggerFlags...)
+}, logger.GlobalLoggerFlags...)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 
-	"go.woodpecker-ci.org/woodpecker/v2/cmd/common"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/rpc/proto"
 	"go.woodpecker-ci.org/woodpecker/v2/server"
 	"go.woodpecker-ci.org/woodpecker/v2/server/cron"
@@ -49,13 +48,14 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/server/store"
 	"go.woodpecker-ci.org/woodpecker/v2/server/web"
 	"go.woodpecker-ci.org/woodpecker/v2/shared/constant"
+	"go.woodpecker-ci.org/woodpecker/v2/shared/logger"
 	"go.woodpecker-ci.org/woodpecker/v2/version"
 	// "go.woodpecker-ci.org/woodpecker/v2/server/plugins/encryption"
 	// encryptedStore "go.woodpecker-ci.org/woodpecker/v2/server/plugins/encryption/wrapper/store"
 )
 
 func run(c *cli.Context) error {
-	common.SetupGlobalLogger(c, true)
+	logger.SetupGlobalLogger(c, true)
 
 	// set gin mode based on log level
 	if zerolog.GlobalLevel() > zerolog.DebugLevel {

--- a/shared/logger/logger.go
+++ b/shared/logger/logger.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package logger
 
 import (
 	"io"
@@ -41,13 +41,13 @@ var GlobalLoggerFlags = []cli.Flag{
 		EnvVars: []string{"WOODPECKER_DEBUG_PRETTY"},
 		Name:    "pretty",
 		Usage:   "enable pretty-printed debug output",
-		Value:   IsInteractive(), // make pretty on interactive terminal by default
+		Value:   isInteractiveTerminal(), // make pretty on interactive terminal by default
 	},
 	&cli.BoolFlag{
 		EnvVars: []string{"WOODPECKER_DEBUG_NOCOLOR"},
 		Name:    "nocolor",
 		Usage:   "disable colored debug output, only has effect if pretty output is set too",
-		Value:   !IsInteractive(), // do color on interactive terminal by default
+		Value:   !isInteractiveTerminal(), // do color on interactive terminal by default
 	},
 }
 

--- a/shared/logger/terminal.go
+++ b/shared/logger/terminal.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package logger
 
 import (
 	"os"
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/term"
 )
 
-// IsInteractive checks if the output is piped, but NOT if the session is run interactively.
-func IsInteractive() bool {
+// isInteractiveTerminal checks if the output is piped, but NOT if the session is run interactively.
+func isInteractiveTerminal() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }


### PR DESCRIPTION
`cmd` should only contain the entrypoints of the binaries.