### PR TITLE
Remove env argument of addons

### DIFF
--- a/docs/docs/30-administration/75-addons/20-creating-addons.md
+++ b/docs/docs/30-administration/75-addons/20-creating-addons.md
@@ -8,10 +8,7 @@ An addon consists of two variables/functions in Go.
 
 1. The `Type` variable. Specifies the type of the addon and must be directly accessed from `shared/addons/types/types.go`.
 2. The `Addon` function which is the main point of your addon.
-   This function takes two arguments:
-
-   1. The zerolog logger you should use to log errors, warnings etc.
-   2. A slice of strings with the environment variables used as configuration.
+   This function takes the zerolog logger you should use to log errors, warnings etc. as argument.
 
    It returns two values:
 

--- a/docs/docs/30-administration/75-addons/20-creating-addons.md
+++ b/docs/docs/30-administration/75-addons/20-creating-addons.md
@@ -76,7 +76,7 @@ import (
 
 var Type = addon_types.TypeForge
 
-func Addon(logger zerolog.Logger, env []string) (forge.Forge, error) {
+func Addon(logger zerolog.Logger) (forge.Forge, error) {
   logger.Info().Msg("hello world from addon")
   return &config{l: logger}, nil
 }

--- a/shared/addon/addon.go
+++ b/shared/addon/addon.go
@@ -2,7 +2,6 @@ package addon
 
 import (
 	"errors"
-	"os"
 	"plugin"
 
 	"github.com/rs/zerolog"
@@ -42,14 +41,14 @@ func Load[T any](files []string, t types.Type) (*Addon[T], error) {
 		if err != nil {
 			return nil, err
 		}
-		main, is := mainLookup.(func(zerolog.Logger, []string) (T, error))
+		main, is := mainLookup.(func(zerolog.Logger) (T, error))
 		if !is {
 			return nil, errors.New("addon main function has incorrect type")
 		}
 
 		logger := log.Logger.With().Str("addon", file).Logger()
 
-		mainOut, err := main(logger, os.Environ())
+		mainOut, err := main(logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This argument is pretty useless, so let's remove it and let addons get their config on their own.

Note that this is a breaking change, but as [per docs](https://woodpecker-ci.org/docs/next/administration/addons/overview) the addon implementation can change at any time.