### PR TITLE
Format depends_on example

### DIFF
--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -449,21 +449,21 @@ Normally steps of a workflow are executed serially in the order in which they ar
 
 ```diff
  steps:
-  build: # build will be executed immediately
-    image: golang
-    commands:
-      - go build
-
-  deploy:
-    image: plugins/docker
-    settings:
-      repo: foo/bar
+   build: # build will be executed immediately
+     image: golang
+     commands:
+       - go build
+ 
+   deploy:
+     image: plugins/docker
+     settings:
+       repo: foo/bar
 +    depends_on: [build, test] # deploy will be executed after build and test finished
-
-  test: # test will be executed immediately as no dependencies are set
-    image: golang
-    commands:
-      - go test
+ 
+   test: # test will be executed immediately as no dependencies are set
+     image: golang
+     commands:
+       - go test
 ```
 
 ### `volumes`


### PR DESCRIPTION
There is incosistent spaces in the example, and base on it it is not clear where the `depends_on` should be. Update the code block to have consistent number of spaces.

Before:

<img width="1013" alt="image" src="https://github.com/woodpecker-ci/woodpecker/assets/21104/6299ebf4-4cc7-42d9-8525-cdf4491c4c99">

After:

<waiiting>