### PR TITLE
Woodpecker image pull secrets in Kubernets

### DIFF
--- a/pipeline/backend/docker/convert.go
+++ b/pipeline/backend/docker/convert.go
@@ -15,8 +15,6 @@
 package docker
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"regexp"
 	"strings"
 
@@ -166,16 +164,6 @@ func toDev(paths []string) []container.DeviceMapping {
 		})
 	}
 	return devices
-}
-
-// helper function that serializes the auth configuration as JSON
-// base64 payload.
-func encodeAuthToBase64(authConfig types.Auth) (string, error) {
-	buf, err := json.Marshal(authConfig)
-	if err != nil {
-		return "", err
-	}
-	return base64.URLEncoding.EncodeToString(buf), nil
 }
 
 // helper function that split volume path

--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -186,7 +186,7 @@ func (e *docker) StartStep(ctx context.Context, step *backend.Step, taskUUID str
 	// create pull options with encoded authorization credentials.
 	pullopts := types.ImagePullOptions{}
 	if step.AuthConfig.Username != "" && step.AuthConfig.Password != "" {
-		pullopts.RegistryAuth, _ = encodeAuthToBase64(step.AuthConfig)
+		pullopts.RegistryAuth, _ = step.AuthConfig.EncodeToBase64()
 	}
 
 	// automatically pull the latest version of the image if requested

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -185,6 +185,11 @@ func (e *kube) SetupWorkflow(ctx context.Context, conf *types.Config, taskUUID s
 		}
 	}
 
+	_, err := startRegistriesAuth(ctx, e, conf.Registries, taskUUID)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -359,6 +364,11 @@ func (e *kube) DestroyWorkflow(_ context.Context, conf *types.Config, taskUUID s
 		if err != nil {
 			return err
 		}
+	}
+
+	err := stopRegistriesAuth(e.ctx, e, taskUUID, defaultDeleteOptions)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pipeline/backend/kubernetes/registry.go
+++ b/pipeline/backend/kubernetes/registry.go
@@ -1,0 +1,111 @@
+// Copyright 2023 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/rs/zerolog/log"
+	"go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/types"
+	k8s "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+type ConfigAuths struct {
+	Auths map[string]ConfigAuth `json:"auths,omitempty"`
+}
+
+type ConfigAuth struct {
+	Auth string `json:"auth,omitempty"`
+}
+
+func startRegistriesAuth(ctx context.Context, engine *kube, registries []*types.Registry, taskUUID string) (*k8s.Secret, error) {
+	regNames := make([]string, len(registries))
+	for i, reg := range registries {
+		regNames[i] = reg.Hostname
+	}
+	log.Debug().
+		Str("registries", strings.Join(regNames, ",")).
+		Msg("creating images pull secret")
+
+	authsJsonBytes, err := dockerAuths(registries)
+	if err != nil {
+		return nil, err
+	}
+
+	pullSecret, err := mkPullSecret(engine.config.Namespace, taskUUID, authsJsonBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return engine.client.CoreV1().Secrets(engine.config.Namespace).Create(ctx, pullSecret, k8smeta.CreateOptions{})
+}
+
+func stopRegistriesAuth(ctx context.Context, engine *kube, secretName string, deleteOpts k8smeta.DeleteOptions) error {
+	log.Trace().Str("name", secretName).Msg("Deleting pull secret")
+
+	err := engine.client.CoreV1().Secrets(engine.config.Namespace).Delete(ctx, secretName, deleteOpts)
+	if errors.IsNotFound(err) {
+		// Don't abort on 404 errors from k8s, they most likely mean that the pod hasn't been created yet, usually because pipeline was canceled before running all steps.
+		log.Trace().Err(err).Msgf("Unable to delete pull secret %s", secretName)
+		return nil
+	}
+	return err
+}
+
+func dockerAuths(registries []*types.Registry) ([]byte, error) {
+	auths, err := configAuths(registries)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(auths)
+}
+
+func configAuths(registries []*types.Registry) (*ConfigAuths, error) {
+	auths := make(map[string]ConfigAuth, len(registries))
+	for _, reg := range registries {
+		auth, err := configAuth(reg)
+		if err != nil {
+			return nil, err
+		}
+		auths[reg.Hostname] = auth
+	}
+	return &ConfigAuths{Auths: auths}, nil
+}
+
+func configAuth(registry *types.Registry) (ConfigAuth, error) {
+	authB64, err := types.Auth{
+		Username: registry.Username,
+		Password: registry.Password,
+		Email:    registry.Email,
+	}.EncodeToBase64()
+	return ConfigAuth{Auth: authB64}, err
+}
+
+func mkPullSecret(namespace, name string, authsJsonBytes []byte) (*k8s.Secret, error) {
+	meta := k8smeta.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	data := map[string][]byte{k8s.DockerConfigJsonKey: authsJsonBytes}
+	return &k8s.Secret{
+		ObjectMeta: meta,
+		Data:       data,
+		Type:       k8s.SecretTypeDockerConfigJson,
+	}, nil
+}

--- a/pipeline/backend/kubernetes/registry_test.go
+++ b/pipeline/backend/kubernetes/registry_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"encoding/json"
+	"go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPullSecret(t *testing.T) {
+	expected := `
+	{
+		"metadata": {
+			"name": "5b4df028-55bd-4187-8291-4725e02fcea6",
+			"namespace": "ns",
+			"creationTimestamp": null
+		},
+		"data": {
+			".dockerconfigjson": "eyJhdXRocyI6eyJnY3IuaW8iOnsiYXV0aCI6ImV5SjFjMlZ5Ym1GdFpTSTZJblZ6WlhJaUxDSndZWE56ZDI5eVpDSTZJbkJoYzNNaWZRPT0ifSwiaHViLmRvY2tlci5jb20iOnsiYXV0aCI6ImUzMD0ifX19"
+		},
+		"type": "kubernetes.io/dockerconfigjson"
+	}`
+
+	emptyRegistry := types.Registry{
+		Hostname: "hub.docker.com",
+	}
+	normalRegistry := types.Registry{
+		Hostname: "gcr.io",
+		Username: "user",
+		Password: "pass",
+	}
+
+	authsB64, err := dockerAuths([]*types.Registry{&emptyRegistry, &normalRegistry})
+	assert.NoError(t, err)
+
+	pullSecret, err := mkPullSecret("ns", "5b4df028-55bd-4187-8291-4725e02fcea6", authsB64)
+	assert.NoError(t, err)
+
+	pullSecretJson, err := json.Marshal(pullSecret)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expected, string(pullSecretJson))
+}

--- a/pipeline/backend/types/config.go
+++ b/pipeline/backend/types/config.go
@@ -16,10 +16,11 @@ package types
 
 // Config defines the runtime configuration of a workflow.
 type Config struct {
-	Stages   []*Stage   `json:"pipeline"` // workflow stages
-	Networks []*Network `json:"networks"` // network definitions
-	Volumes  []*Volume  `json:"volumes"`  // volume definitions
-	Secrets  []*Secret  `json:"secrets"`  // secret definitions
+	Stages     []*Stage    `json:"pipeline"` // workflow stages
+	Networks   []*Network  `json:"networks"` // network definitions
+	Volumes    []*Volume   `json:"volumes"`  // volume definitions
+	Secrets    []*Secret   `json:"secrets"`  // secret definitions
+	Registries []*Registry `json:"secrets"`  // registry definitions
 }
 
 // CliContext is the context key to pass cli context to backends if needed

--- a/pipeline/backend/types/registry.go
+++ b/pipeline/backend/types/registry.go
@@ -14,24 +14,11 @@
 
 package types
 
-import (
-	"encoding/base64"
-	"encoding/json"
-)
-
-// Auth defines registry authentication credentials.
-type Auth struct {
+// Registry defines a registry authorization
+type Registry struct {
+	Hostname string `json:"hostname,omitempty"`
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
 	Email    string `json:"email,omitempty"`
-}
-
-// helper function that serializes the auth configuration as JSON
-// base64 payload.
-func (a Auth) EncodeToBase64() (string, error) {
-	buf, err := json.Marshal(a)
-	if err != nil {
-		return "", err
-	}
-	return base64.URLEncoding.EncodeToString(buf), nil
+	Token    string `json:"token,omitempty"`
 }

--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -135,6 +135,17 @@ func (c *Compiler) Compile(conf *yaml_types.Workflow) (*backend_types.Config, er
 		})
 	}
 
+	// create registries
+	for _, reg := range c.registries {
+		config.Registries = append(config.Registries, &backend_types.Registry{
+			Hostname: reg.Hostname,
+			Username: reg.Username,
+			Password: reg.Password,
+			Email:    reg.Email,
+			Token:    reg.Token,
+		})
+	}
+
 	// overrides the default workspace paths when specified
 	// in the YAML file.
 	if len(conf.Workspace.Base) != 0 {


### PR DESCRIPTION
Fully cover #2987

Doesn't work right now and it is not my priority. Hope, some can polish it.

Made the secrets pipeline-wide instead of step-wide as in Docker backend.