### PR TITLE
Add X/Twitter account

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -114,6 +114,10 @@ const config: Config = {
               label: 'Mastodon',
               href: 'https://floss.social/@WoodpeckerCI',
             },
+            {
+              label: 'X',
+              href: 'https://twitter.com/woodpeckerci',
+            },
           ],
         },
         {


### PR DESCRIPTION
To have a completely list.

@anbraten It looks like the account hasn't been updated with the 2.1.0/2.1.1 release. If the account will always be inactive, we should delete it.

@woodpecker-ci/owner Can you also add the Mastodon and X accounts to the github org? Would improve finding social media accounts and verification. Also, on Mastodon, the `Latest release` field is outdated.