### PR TITLE
Remove `vX.X` docker version

### DIFF
--- a/docs/docs/30-administration/00-deployment/10-docker-compose.md
+++ b/docs/docs/30-administration/00-deployment/10-docker-compose.md
@@ -129,7 +129,7 @@ Image variants:
 
 - The `latest` image is the latest stable release
 - The `vX.X.X` images are stable releases
-- The `next` images are based on the current `main` branch
+- The `next` images are based on the current `main` branch, might contain bugs as these are not tested as heavily as releases
 
 ```bash
 # server


### PR DESCRIPTION
Close https://github.com/woodpecker-ci/woodpecker/issues/3131

Seems that they aren't pushed anymore anyways.