### PR TITLE
TestToConfigSmall ignore sort order of env vars

### DIFF
--- a/pipeline/backend/docker/convert_test.go
+++ b/pipeline/backend/docker/convert_test.go
@@ -16,6 +16,7 @@ package docker
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -102,6 +103,7 @@ func TestToConfigSmall(t *testing.T) {
 	})
 
 	assert.NotNil(t, conf)
+	sort.Strings(conf.Env)
 	assert.EqualValues(t, &container.Config{
 		AttachStdout: true,
 		AttachStderr: true,


### PR DESCRIPTION
so this https://ci.woodpecker-ci.org/repos/3780/pipeline/11803/30 can not randomly happen