### PR TITLE
Enable golangci linter stylecheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -163,6 +163,7 @@ linters:
     - whitespace
     - gocritic
     - nolintlint
+    - stylecheck
 
 run:
   timeout: 15m

--- a/cli/common/flags.go
+++ b/cli/common/flags.go
@@ -64,7 +64,6 @@ func FormatFlag(tmpl string, hidden ...bool) *cli.StringFlag {
 	}
 }
 
-// specify repository
 var RepoFlag = &cli.StringFlag{
 	Name:    "repository",
 	Aliases: []string{"repo"},

--- a/cli/deploy/deploy.go
+++ b/cli/deploy/deploy.go
@@ -97,7 +97,7 @@ func deploy(c *cli.Context) error {
 			}
 		}
 		if number == 0 {
-			return fmt.Errorf("Cannot deploy failure pipeline")
+			return fmt.Errorf("cannot deploy failure pipeline")
 		}
 	} else {
 		number, err = strconv.ParseInt(pipelineArg, 10, 64)
@@ -108,7 +108,7 @@ func deploy(c *cli.Context) error {
 
 	env := c.Args().Get(2)
 	if env == "" {
-		return fmt.Errorf("Please specify the target environment (ie production)")
+		return fmt.Errorf("please specify the target environment (i.e. production)")
 	}
 
 	params := internal.ParseKeyPair(c.StringSlice("param"))

--- a/cli/user/user_info.go
+++ b/cli/user/user_info.go
@@ -41,7 +41,7 @@ func userInfo(c *cli.Context) error {
 
 	login := c.Args().First()
 	if len(login) == 0 {
-		return fmt.Errorf("Missing or invalid user login")
+		return fmt.Errorf("missing or invalid user login")
 	}
 
 	user, err := client.User(login)

--- a/docs/versioned_docs/version-1.0/30-administration/22-backends/20-local.md
+++ b/docs/versioned_docs/version-1.0/30-administration/22-backends/20-local.md
@@ -5,7 +5,7 @@ The local backend will execute the pipelines on the local system without any iso
 :::
 
 :::note
-This backend is still pretty new and can not be treated as stable. Its
+This backend is still pretty new and cannot be treated as stable. Its
 implementation and configuration can change at any time.
 :::
 

--- a/docs/versioned_docs/version-1.0/30-administration/22-backends/30-ssh.md
+++ b/docs/versioned_docs/version-1.0/30-administration/22-backends/30-ssh.md
@@ -5,7 +5,7 @@ The SSH backend will execute the pipelines using SSH on a remote system without 
 :::
 
 :::note
-This backend is still pretty new and can not be treated as stable. Its implementation and configuration can change at any time.
+This backend is still pretty new and cannot be treated as stable. Its implementation and configuration can change at any time.
 :::
 Since the code run directly on the SSH machine, a malicious pipeline could access and edit files the SSH user has access to and execute every command the remote user is allowed to use. Always restrict the user as far as possible!
 

--- a/docs/versioned_docs/version-2.0/30-administration/22-backends/20-local.md
+++ b/docs/versioned_docs/version-2.0/30-administration/22-backends/20-local.md
@@ -5,7 +5,7 @@ The local backend will execute the pipelines on the local system without any iso
 :::
 
 :::note
-This backend is still pretty new and can not be treated as stable. Its
+This backend is still pretty new and cannot be treated as stable. Its
 implementation and configuration can change at any time.
 :::
 

--- a/docs/versioned_docs/version-2.1/30-administration/22-backends/20-local.md
+++ b/docs/versioned_docs/version-2.1/30-administration/22-backends/20-local.md
@@ -5,7 +5,7 @@ The local backend will execute the pipelines on the local system without any iso
 :::
 
 :::note
-This backend is still pretty new and can not be treated as stable. Its
+This backend is still pretty new and cannot be treated as stable. Its
 implementation and configuration can change at any time.
 :::
 

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -255,7 +255,7 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 	}
 
 	if isImagePullBackOffState(pod) {
-		return nil, fmt.Errorf("Could not pull image for pod %s", pod.Name)
+		return nil, fmt.Errorf("could not pull image for pod %s", pod.Name)
 	}
 
 	bs := &types.State{

--- a/pipeline/backend/local/const.go
+++ b/pipeline/backend/local/const.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 )
 
-// notAllowedEnvVarOverwrites are all env vars that can not be overwritten by step config
+// notAllowedEnvVarOverwrites are all env vars that cannot be overwritten by step config
 var notAllowedEnvVarOverwrites = []string{
 	"CI_NETRC_MACHINE",
 	"CI_NETRC_USERNAME",

--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -261,7 +261,7 @@ func (c *List) UnmarshalYAML(value *yaml.Node) error {
 
 	if err1 != nil && err2 != nil {
 		y, _ := yaml.Marshal(value)
-		return fmt.Errorf("Could not parse condition: %s: %w", y, multierr.Append(err1, err2))
+		return fmt.Errorf("could not parse condition: %s: %w", y, multierr.Append(err1, err2))
 	}
 
 	return nil
@@ -342,7 +342,7 @@ func (c *Path) UnmarshalYAML(value *yaml.Node) error {
 
 	if err1 != nil && err2 != nil {
 		y, _ := yaml.Marshal(value)
-		return fmt.Errorf("Could not parse condition: %s", y)
+		return fmt.Errorf("could not parse condition: %s", y)
 	}
 
 	return nil

--- a/pipeline/frontend/yaml/linter/schema/schema.go
+++ b/pipeline/frontend/yaml/linter/schema/schema.go
@@ -36,29 +36,29 @@ func Lint(r io.Reader) ([]gojsonschema.ResultError, error) {
 	// read yaml config
 	rBytes, err := io.ReadAll(r)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load yml file %w", err)
+		return nil, fmt.Errorf("failed to load yml file %w", err)
 	}
 
 	// resolve sequence merges
 	yamlDoc := new(yaml.Node)
 	if err := xyaml.Unmarshal(rBytes, yamlDoc); err != nil {
-		return nil, fmt.Errorf("Failed to parse yml file %w", err)
+		return nil, fmt.Errorf("failed to parse yml file %w", err)
 	}
 
 	// convert to json
 	jsonDoc, err := yaml2json.ConvertNode(yamlDoc)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to convert yaml %w", err)
+		return nil, fmt.Errorf("failed to convert yaml %w", err)
 	}
 
 	documentLoader := gojsonschema.NewBytesLoader(jsonDoc)
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
-		return nil, fmt.Errorf("Validation failed %w", err)
+		return nil, fmt.Errorf("validation failed %w", err)
 	}
 
 	if !result.Valid() {
-		return result.Errors(), fmt.Errorf("Config not valid")
+		return result.Errors(), fmt.Errorf("config not valid")
 	}
 
 	return nil, nil

--- a/pipeline/frontend/yaml/types/base/base_types_test.go
+++ b/pipeline/frontend/yaml/types/base/base_types_test.go
@@ -104,7 +104,7 @@ bars: []
 func TestUnmarshalSliceOrMap(t *testing.T) {
 	s := StructSliceorMap{}
 	err := yaml.Unmarshal([]byte(sampleStructSliceorMap), &s)
-	assert.Equal(t, fmt.Errorf("Cannot unmarshal 'true' of type bool into a string value"), err)
+	assert.Equal(t, fmt.Errorf("cannot unmarshal 'true' of type bool into a string value"), err)
 }
 
 func TestStr2SliceOrMapPtrMap(t *testing.T) {

--- a/pipeline/frontend/yaml/types/base/int.go
+++ b/pipeline/frontend/yaml/types/base/int.go
@@ -42,7 +42,7 @@ func (s *StringOrInt) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return errors.New("Failed to unmarshal StringOrInt")
+	return errors.New("failed to unmarshal StringOrInt")
 }
 
 // MemStringOrInt represents a string or an integer
@@ -67,5 +67,5 @@ func (s *MemStringOrInt) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return errors.New("Failed to unmarshal MemStringOrInt")
+	return errors.New("failed to unmarshal MemStringOrInt")
 }

--- a/pipeline/frontend/yaml/types/base/map.go
+++ b/pipeline/frontend/yaml/types/base/map.go
@@ -40,7 +40,7 @@ func (s *SliceOrMap) UnmarshalYAML(unmarshal func(any) error) error {
 				}
 				parts[key] = val
 			} else {
-				return fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", s, s)
+				return fmt.Errorf("cannot unmarshal '%v' of type %T into a string value", s, s)
 			}
 		}
 		*s = parts
@@ -55,15 +55,15 @@ func (s *SliceOrMap) UnmarshalYAML(unmarshal func(any) error) error {
 				if sv, ok := v.(string); ok {
 					parts[sk] = sv
 				} else {
-					return fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", v, v)
+					return fmt.Errorf("cannot unmarshal '%v' of type %T into a string value", v, v)
 				}
 			} else {
-				return fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", k, k)
+				return fmt.Errorf("cannot unmarshal '%v' of type %T into a string value", k, k)
 			}
 		}
 		*s = parts
 		return nil
 	}
 
-	return errors.New("Failed to unmarshal SliceOrMap")
+	return errors.New("failed to unmarshal SliceOrMap")
 }

--- a/pipeline/frontend/yaml/types/base/slice.go
+++ b/pipeline/frontend/yaml/types/base/slice.go
@@ -41,7 +41,7 @@ func (s *StringOrSlice) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return errors.New("Failed to unmarshal StringOrSlice")
+	return errors.New("failed to unmarshal StringOrSlice")
 }
 
 func toStrings(s []any) ([]string, error) {
@@ -53,7 +53,7 @@ func toStrings(s []any) ([]string, error) {
 		if sv, ok := v.(string); ok {
 			r[k] = sv
 		} else {
-			return nil, fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", v, v)
+			return nil, fmt.Errorf("cannot unmarshal '%v' of type %T into a string value", v, v)
 		}
 	}
 	return r, nil

--- a/pipeline/frontend/yaml/types/network.go
+++ b/pipeline/frontend/yaml/types/network.go
@@ -50,7 +50,7 @@ func (n *Networks) UnmarshalYAML(unmarshal func(any) error) error {
 		for _, network := range sliceType {
 			name, ok := network.(string)
 			if !ok {
-				return fmt.Errorf("Cannot unmarshal '%v' to type %T into a string value", name, name)
+				return fmt.Errorf("cannot unmarshal '%v' to type %T into a string value", name, name)
 			}
 			n.Networks = append(n.Networks, &Network{
 				Name: name,
@@ -65,7 +65,7 @@ func (n *Networks) UnmarshalYAML(unmarshal func(any) error) error {
 		for mapKey, mapValue := range mapType {
 			name, ok := mapKey.(string)
 			if !ok {
-				return fmt.Errorf("Cannot unmarshal '%v' to type %T into a string value", name, name)
+				return fmt.Errorf("cannot unmarshal '%v' to type %T into a string value", name, name)
 			}
 			network, err := handleNetwork(name, mapValue)
 			if err != nil {
@@ -76,7 +76,7 @@ func (n *Networks) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return errors.New("Failed to unmarshal Networks")
+	return errors.New("failed to unmarshal Networks")
 }
 
 func handleNetwork(name string, value any) (*Network, error) {
@@ -95,7 +95,7 @@ func handleNetwork(name string, value any) (*Network, error) {
 			case "aliases":
 				aliases, ok := mapValue.([]any)
 				if !ok {
-					return &Network{}, fmt.Errorf("Cannot unmarshal '%v' to type %T into a string value", aliases, aliases)
+					return &Network{}, fmt.Errorf("cannot unmarshal '%v' to type %T into a string value", aliases, aliases)
 				}
 				network.Aliases = []string{}
 				for _, alias := range aliases {
@@ -112,6 +112,6 @@ func handleNetwork(name string, value any) (*Network, error) {
 		}
 		return network, nil
 	default:
-		return &Network{}, fmt.Errorf("Failed to unmarshal Network: %#v", value)
+		return &Network{}, fmt.Errorf("failed to unmarshal Network: %#v", value)
 	}
 }

--- a/pipeline/frontend/yaml/types/volume.go
+++ b/pipeline/frontend/yaml/types/volume.go
@@ -64,7 +64,7 @@ func (v *Volumes) UnmarshalYAML(unmarshal func(any) error) error {
 		for _, volume := range sliceType {
 			name, ok := volume.(string)
 			if !ok {
-				return fmt.Errorf("Cannot unmarshal '%v' to type %T into a string value", name, name)
+				return fmt.Errorf("cannot unmarshal '%v' to type %T into a string value", name, name)
 			}
 			elts := strings.SplitN(name, ":", 3)
 			var vol *Volume
@@ -93,5 +93,5 @@ func (v *Volumes) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return errors.New("Failed to unmarshal Volumes")
+	return errors.New("failed to unmarshal Volumes")
 }

--- a/server/api/agent.go
+++ b/server/api/agent.go
@@ -65,7 +65,7 @@ func GetAgent(c *gin.Context) {
 
 	agent, err := store.FromContext(c).AgentFind(agentID)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, agent)
@@ -89,7 +89,7 @@ func GetAgentTasks(c *gin.Context) {
 
 	agent, err := store.FromContext(c).AgentFind(agentID)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -132,7 +132,7 @@ func PatchAgent(c *gin.Context) {
 
 	agent, err := _store.AgentFind(agentID)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	agent.Name = in.Name
@@ -201,7 +201,7 @@ func DeleteAgent(c *gin.Context) {
 
 	agent, err := _store.AgentFind(agentID)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if err = _store.AgentDelete(agent); err != nil {

--- a/server/api/badge.go
+++ b/server/api/badge.go
@@ -62,7 +62,7 @@ func GetBadge(c *gin.Context) {
 	}
 
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -116,7 +116,7 @@ func GetCC(c *gin.Context) {
 	}
 
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 

--- a/server/api/cron.go
+++ b/server/api/cron.go
@@ -49,7 +49,7 @@ func GetCron(c *gin.Context) {
 
 	cron, err := store.FromContext(c).CronFind(repo, id)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, cron)
@@ -76,7 +76,7 @@ func RunCron(c *gin.Context) {
 
 	cron, err := _store.CronFind(repo, id)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -183,7 +183,7 @@ func PatchCron(c *gin.Context) {
 
 	cron, err := _store.CronFind(repo, id)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if in.Branch != "" {
@@ -259,7 +259,7 @@ func DeleteCron(c *gin.Context) {
 		return
 	}
 	if err := store.FromContext(c).CronDelete(repo, id); err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/server/api/global_secret.go
+++ b/server/api/global_secret.go
@@ -62,7 +62,7 @@ func GetGlobalSecret(c *gin.Context) {
 	name := c.Param("secret")
 	secret, err := server.Config.Services.Secrets.GlobalSecretFind(name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, secret.Copy())
@@ -122,7 +122,7 @@ func PatchGlobalSecret(c *gin.Context) {
 
 	secret, err := server.Config.Services.Secrets.GlobalSecretFind(name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if in.Value != "" {
@@ -158,7 +158,7 @@ func PatchGlobalSecret(c *gin.Context) {
 func DeleteGlobalSecret(c *gin.Context) {
 	name := c.Param("secret")
 	if err := server.Config.Services.Secrets.GlobalSecretDelete(name); err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/server/api/helper.go
+++ b/server/api/helper.go
@@ -43,7 +43,7 @@ func handlePipelineErr(c *gin.Context, err error) {
 	}
 }
 
-func handleDbError(c *gin.Context, err error) {
+func handleDBError(c *gin.Context, err error) {
 	if errors.Is(err, types.RecordNotExist) {
 		c.AbortWithStatus(http.StatusNotFound)
 		return

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -144,7 +144,7 @@ func PostHook(c *gin.Context) {
 	repo, err := _store.GetRepoNameFallback(tmpRepo.ForgeRemoteID, tmpRepo.FullName)
 	if err != nil {
 		log.Error().Err(err).Msgf("failure to get repo %s from store", tmpRepo.FullName)
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if !repo.IsActive {

--- a/server/api/login.go
+++ b/server/api/login.go
@@ -208,7 +208,7 @@ func GetLoginToken(c *gin.Context) {
 
 	user, err := _store.GetUserLogin(login)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 

--- a/server/api/metrics/prometheus.go
+++ b/server/api/metrics/prometheus.go
@@ -26,7 +26,7 @@ import (
 )
 
 // errInvalidToken is returned when the api request token is invalid.
-var errInvalidToken = errors.New("Invalid or missing token")
+var errInvalidToken = errors.New("invalid or missing token")
 
 // PromHandler will pass the call from /api/metrics/prometheus to prometheus
 func PromHandler() gin.HandlerFunc {

--- a/server/api/org.go
+++ b/server/api/org.go
@@ -49,7 +49,7 @@ func GetOrg(c *gin.Context) {
 
 	org, err := _store.OrgGet(orgID)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -122,7 +122,7 @@ func LookupOrg(c *gin.Context) {
 
 	org, err := _store.OrgFindByName(orgFullName)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 

--- a/server/api/org_secret.go
+++ b/server/api/org_secret.go
@@ -47,7 +47,7 @@ func GetOrgSecret(c *gin.Context) {
 
 	secret, err := server.Config.Services.Secrets.OrgSecretFind(orgID, name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, secret.Copy())
@@ -152,7 +152,7 @@ func PatchOrgSecret(c *gin.Context) {
 
 	secret, err := server.Config.Services.Secrets.OrgSecretFind(orgID, name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if in.Value != "" {
@@ -195,7 +195,7 @@ func DeleteOrgSecret(c *gin.Context) {
 	}
 
 	if err := server.Config.Services.Secrets.OrgSecretDelete(orgID, name); err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/server/api/orgs.go
+++ b/server/api/orgs.go
@@ -65,7 +65,7 @@ func DeleteOrg(c *gin.Context) {
 
 	err = _store.OrgDelete(orgID)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -140,7 +140,7 @@ func GetPipeline(c *gin.Context) {
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if pl.Workflows, err = _store.WorkflowGetTree(pl); err != nil {
@@ -158,7 +158,7 @@ func GetPipelineLast(c *gin.Context) {
 
 	pl, err := _store.GetPipelineLast(repo, branch)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -194,7 +194,7 @@ func GetStepLogs(c *gin.Context) {
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -206,19 +206,19 @@ func GetStepLogs(c *gin.Context) {
 
 	step, err := _store.StepLoad(stepID)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
 	if step.PipelineID != pl.ID {
-		// make sure we can not read arbitrary logs by id
+		// make sure we cannot read arbitrary logs by id
 		_ = c.AbortWithError(http.StatusBadRequest, fmt.Errorf("step with id %d is not part of repo %s", stepID, repo.FullName))
 		return
 	}
 
 	logs, err := _store.LogFind(step)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -246,7 +246,7 @@ func GetPipelineConfig(c *gin.Context) {
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -277,7 +277,7 @@ func CancelPipeline(c *gin.Context) {
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -308,7 +308,7 @@ func PostApproval(c *gin.Context) {
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -340,7 +340,7 @@ func PostDecline(c *gin.Context) {
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -394,13 +394,13 @@ func PostPipeline(c *gin.Context) {
 
 	user, err := _store.GetUser(repo.UserID)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -467,7 +467,7 @@ func DeletePipelineLogs(c *gin.Context) {
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 

--- a/server/api/registry.go
+++ b/server/api/registry.go
@@ -41,7 +41,7 @@ func GetRegistry(c *gin.Context) {
 	)
 	registry, err := server.Config.Services.Registries.RegistryFind(repo, name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.JSON(200, registry.Copy())
@@ -110,7 +110,7 @@ func PatchRegistry(c *gin.Context) {
 
 	registry, err := server.Config.Services.Registries.RegistryFind(repo, name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if in.Username != "" {
@@ -180,7 +180,7 @@ func DeleteRegistry(c *gin.Context) {
 	)
 	err := server.Config.Services.Registries.RegistryDelete(repo, name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -400,7 +400,7 @@ func DeleteRepo(c *gin.Context) {
 
 	if remove {
 		if err := _store.DeleteRepo(repo); err != nil {
-			handleDbError(c, err)
+			handleDBError(c, err)
 			return
 		}
 	}

--- a/server/api/repo_secret.go
+++ b/server/api/repo_secret.go
@@ -42,7 +42,7 @@ func GetSecret(c *gin.Context) {
 	)
 	secret, err := server.Config.Services.Secrets.SecretFind(repo, name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, secret.Copy())
@@ -110,7 +110,7 @@ func PatchSecret(c *gin.Context) {
 
 	secret, err := server.Config.Services.Secrets.SecretFind(repo, name)
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if in.Value != "" {
@@ -176,7 +176,7 @@ func DeleteSecret(c *gin.Context) {
 		name = c.Param("secret")
 	)
 	if err := server.Config.Services.Secrets.SecretDelete(repo, name); err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/server/api/stream.go
+++ b/server/api/stream.go
@@ -179,7 +179,7 @@ func LogStreamSSE(c *gin.Context) {
 	}
 
 	if step.PipelineID != pl.ID {
-		// make sure we can not read arbitrary logs by id
+		// make sure we cannot read arbitrary logs by id
 		err = fmt.Errorf("step with id %d is not part of repo %s", stepID, repo.FullName)
 		log.Debug().Err(err).Msg("event error")
 		logWriteStringErr(io.WriteString(rw, "event: error\ndata: "+err.Error()+"\n\n"))

--- a/server/api/users.go
+++ b/server/api/users.go
@@ -59,7 +59,7 @@ func GetUsers(c *gin.Context) {
 func GetUser(c *gin.Context) {
 	user, err := store.FromContext(c).GetUserLogin(c.Param("login"))
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, user)
@@ -89,7 +89,7 @@ func PatchUser(c *gin.Context) {
 
 	user, err := _store.GetUserLogin(c.Param("login"))
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 
@@ -159,11 +159,11 @@ func DeleteUser(c *gin.Context) {
 
 	user, err := _store.GetUserLogin(c.Param("login"))
 	if err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	if err = _store.DeleteUser(user); err != nil {
-		handleDbError(c, err)
+		handleDBError(c, err)
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/server/forge/bitbucket/bitbucket.go
+++ b/server/forge/bitbucket/bitbucket.go
@@ -401,7 +401,7 @@ func (c *config) Org(ctx context.Context, u *model.User, owner string) (*model.O
 
 	return &model.Org{
 		Name:   workspace.Slug,
-		IsUser: false, // bitbucket uses workspaces (similar to orgs) for teams and single users so we can not distinguish between them
+		IsUser: false, // bitbucket uses workspaces (similar to orgs) for teams and single users so we cannot distinguish between them
 	}, nil
 }
 

--- a/server/forge/common/utils.go
+++ b/server/forge/common/utils.go
@@ -55,7 +55,7 @@ func UserToken(ctx context.Context, r *model.Repo, u *model.User) string {
 		return ""
 	}
 	if r == nil {
-		log.Error().Msg("can not get user token by empty repo")
+		log.Error().Msg("cannot get user token by empty repo")
 		return ""
 	}
 	user, err := _store.GetUser(r.UserID)

--- a/server/forge/configFetcher.go
+++ b/server/forge/configFetcher.go
@@ -125,7 +125,7 @@ func (cf *configFetcher) fetch(c context.Context, timeout time.Duration, config 
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
-		return []*types.FileMeta{}, fmt.Errorf("ConfigFetcher: Fallback did not find config: %w", err)
+		return []*types.FileMeta{}, fmt.Errorf("configFetcher: fallback did not find config: %w", err)
 	}
 }
 

--- a/server/forge/configFetcher_test.go
+++ b/server/forge/configFetcher_test.go
@@ -310,8 +310,8 @@ func TestFetch(t *testing.T) {
 			}
 
 			// if the previous mocks do not match return not found errors
-			f.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("File not found"))
-			f.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("Directory not found"))
+			f.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("file not found"))
+			f.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("directory not found"))
 
 			configFetcher := forge.NewConfigFetcher(
 				f,
@@ -516,8 +516,8 @@ func TestFetchFromConfigService(t *testing.T) {
 			}
 
 			// if the previous mocks do not match return not found errors
-			f.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("File not found"))
-			f.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("Directory not found"))
+			f.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("file not found"))
+			f.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("directory not found"))
 
 			f.On("Netrc", mock.Anything, mock.Anything).Return(&model.Netrc{Machine: "mock", Login: "mock", Password: "mock"}, nil)
 

--- a/server/forge/gitea/gitea.go
+++ b/server/forge/gitea/gitea.go
@@ -39,7 +39,6 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/server"
 	"go.woodpecker-ci.org/woodpecker/v2/server/forge"
 	"go.woodpecker-ci.org/woodpecker/v2/server/forge/common"
-	"go.woodpecker-ci.org/woodpecker/v2/server/forge/types"
 	forge_types "go.woodpecker-ci.org/woodpecker/v2/server/forge/types"
 	"go.woodpecker-ci.org/woodpecker/v2/server/model"
 	"go.woodpecker-ci.org/woodpecker/v2/server/store"
@@ -292,7 +291,7 @@ func (c *Gitea) File(ctx context.Context, u *model.User, r *model.Repo, b *model
 
 	cfg, resp, err := client.GetFile(r.Owner, r.Name, b.Commit, f)
 	if err != nil && resp != nil && resp.StatusCode == http.StatusNotFound {
-		return nil, errors.Join(err, &types.ErrConfigNotFound{Configs: []string{f}})
+		return nil, errors.Join(err, &forge_types.ErrConfigNotFound{Configs: []string{f}})
 	}
 	return cfg, err
 }
@@ -318,7 +317,7 @@ func (c *Gitea) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model.
 		if m, _ := filepath.Match(f, e.Path); m && e.Type == "blob" {
 			data, err := c.File(ctx, u, r, b, e.Path)
 			if err != nil {
-				if errors.Is(err, &types.ErrConfigNotFound{}) {
+				if errors.Is(err, &forge_types.ErrConfigNotFound{}) {
 					return nil, fmt.Errorf("git tree reported existence of file but we got: %s", err.Error())
 				}
 				return nil, fmt.Errorf("multi-pipeline cannot get %s: %w", e.Path, err)
@@ -402,10 +401,10 @@ func (c *Gitea) Activate(ctx context.Context, u *model.User, r *model.Repo, link
 	if err != nil {
 		if response != nil {
 			if response.StatusCode == 404 {
-				return fmt.Errorf("Could not find repository")
+				return fmt.Errorf("could not find repository")
 			}
 			if response.StatusCode == 200 {
-				return fmt.Errorf("Could not find repository, repository was probably renamed")
+				return fmt.Errorf("could not find repository, repository was probably renamed")
 			}
 		}
 		return err

--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -33,7 +33,6 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/server"
 	"go.woodpecker-ci.org/woodpecker/v2/server/forge"
 	"go.woodpecker-ci.org/woodpecker/v2/server/forge/common"
-	"go.woodpecker-ci.org/woodpecker/v2/server/forge/types"
 	forge_types "go.woodpecker-ci.org/woodpecker/v2/server/forge/types"
 	"go.woodpecker-ci.org/woodpecker/v2/server/model"
 	"go.woodpecker-ci.org/woodpecker/v2/server/store"
@@ -132,7 +131,7 @@ func (c *client) Login(ctx context.Context, res http.ResponseWriter, req *http.R
 	}
 	email := matchingEmail(emails, c.API)
 	if email == nil {
-		return nil, fmt.Errorf("No verified Email address for GitHub account")
+		return nil, fmt.Errorf("no verified Email address for GitHub account")
 	}
 
 	return &model.User{
@@ -230,7 +229,7 @@ func (c *client) File(ctx context.Context, u *model.User, r *model.Repo, b *mode
 	opts.Ref = b.Commit
 	content, _, resp, err := client.Repositories.GetContents(ctx, r.Owner, r.Name, f, opts)
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		return nil, errors.Join(err, &types.ErrConfigNotFound{Configs: []string{f}})
+		return nil, errors.Join(err, &forge_types.ErrConfigNotFound{Configs: []string{f}})
 	}
 	if err != nil {
 		return nil, err
@@ -249,7 +248,7 @@ func (c *client) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model
 	opts.Ref = b.Commit
 	_, data, resp, err := client.Repositories.GetContents(ctx, r.Owner, r.Name, f, opts)
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		return nil, errors.Join(err, &types.ErrConfigNotFound{Configs: []string{f}})
+		return nil, errors.Join(err, &forge_types.ErrConfigNotFound{Configs: []string{f}})
 	}
 	if err != nil {
 		return nil, err
@@ -262,7 +261,7 @@ func (c *client) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model
 		go func(path string) {
 			content, err := c.File(ctx, u, r, b, path)
 			if err != nil {
-				if errors.Is(err, &types.ErrConfigNotFound{}) {
+				if errors.Is(err, &forge_types.ErrConfigNotFound{}) {
 					err = fmt.Errorf("git tree reported existence of file but we got: %s", err.Error())
 				}
 				errc <- err

--- a/server/forge/gitlab/convert.go
+++ b/server/forge/gitlab/convert.go
@@ -256,7 +256,7 @@ func getUserAvatar(email string) string {
 func extractFromPath(str string) (string, string, error) {
 	s := strings.Split(str, "/")
 	if len(s) < 2 {
-		return "", "", fmt.Errorf("Minimum match not found")
+		return "", "", fmt.Errorf("minimum match not found")
 	}
 	return s[0], s[1], nil
 }

--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -34,7 +34,6 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/server"
 	"go.woodpecker-ci.org/woodpecker/v2/server/forge"
 	"go.woodpecker-ci.org/woodpecker/v2/server/forge/common"
-	"go.woodpecker-ci.org/woodpecker/v2/server/forge/types"
 	forge_types "go.woodpecker-ci.org/woodpecker/v2/server/forge/types"
 	"go.woodpecker-ci.org/woodpecker/v2/server/model"
 	"go.woodpecker-ci.org/woodpecker/v2/server/store"
@@ -127,7 +126,7 @@ func (g *GitLab) Login(ctx context.Context, res http.ResponseWriter, req *http.R
 
 	token, err := config.Exchange(oauth2Ctx, code)
 	if err != nil {
-		return nil, fmt.Errorf("Error exchanging token. %w", err)
+		return nil, fmt.Errorf("error exchanging token: %w", err)
 	}
 
 	client, err := newClient(g.url, token.AccessToken, g.SkipVerify)
@@ -345,7 +344,7 @@ func (g *GitLab) File(ctx context.Context, user *model.User, repo *model.Repo, p
 	}
 	file, resp, err := client.RepositoryFiles.GetRawFile(_repo.ID, fileName, &gitlab.GetRawFileOptions{Ref: &pipeline.Commit}, gitlab.WithContext(ctx))
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		return nil, errors.Join(err, &types.ErrConfigNotFound{Configs: []string{fileName}})
+		return nil, errors.Join(err, &forge_types.ErrConfigNotFound{Configs: []string{fileName}})
 	}
 	return file, err
 }
@@ -383,7 +382,7 @@ func (g *GitLab) Dir(ctx context.Context, user *model.User, repo *model.Repo, pi
 			}
 			data, err := g.File(ctx, user, repo, pipeline, batch[i].Path)
 			if err != nil {
-				if errors.Is(err, &types.ErrConfigNotFound{}) {
+				if errors.Is(err, &forge_types.ErrConfigNotFound{}) {
 					return nil, fmt.Errorf("git tree reported existence of file but we got: %s", err.Error())
 				}
 				return nil, err

--- a/server/grpc/auth_server.go
+++ b/server/grpc/auth_server.go
@@ -41,7 +41,7 @@ func NewWoodpeckerAuthServer(jwtManager *JWTManager, agentMasterToken string, st
 func (s *WoodpeckerAuthServer) Auth(_ context.Context, req *proto.AuthRequest) (*proto.AuthResponse, error) {
 	agent, err := s.getAgent(req.AgentId, req.AgentToken)
 	if err != nil {
-		return nil, fmt.Errorf("Agent could not auth: %w", err)
+		return nil, fmt.Errorf("agent could not auth: %w", err)
 	}
 
 	accessToken, err := s.jwtManager.Generate(agent.ID)

--- a/server/grpc/rpc.go
+++ b/server/grpc/rpc.go
@@ -139,7 +139,7 @@ func (s *RPC) Update(_ context.Context, id string, state rpc.State) error {
 	}
 
 	if currentPipeline.Workflows, err = s.store.WorkflowGetTree(currentPipeline); err != nil {
-		log.Error().Err(err).Msg("can not build tree from step list")
+		log.Error().Err(err).Msg("cannot build tree from step list")
 		return err
 	}
 	message := pubsub.Message{
@@ -269,7 +269,7 @@ func (s *RPC) Done(c context.Context, id string, state rpc.State) error {
 
 	var queueErr error
 	if workflow.Failing() {
-		queueErr = s.queue.Error(c, id, fmt.Errorf("Step finished with exit code %d, %s", state.ExitCode, state.Error))
+		queueErr = s.queue.Error(c, id, fmt.Errorf("step finished with exit code %d, %s", state.ExitCode, state.Error))
 	} else {
 		queueErr = s.queue.Done(c, id, workflow.State)
 	}
@@ -388,6 +388,7 @@ func (s *RPC) ReportHealth(ctx context.Context, status string) error {
 	}
 
 	if status != "I am alive!" {
+		//nolint:stylecheck
 		return errors.New("Are you alive?")
 	}
 
@@ -409,7 +410,7 @@ func (s *RPC) completeChildrenIfParentCompleted(completedWorkflow *model.Workflo
 func (s *RPC) updateForgeStatus(ctx context.Context, repo *model.Repo, pipeline *model.Pipeline, workflow *model.Workflow) {
 	user, err := s.store.GetUser(repo.UserID)
 	if err != nil {
-		log.Error().Err(err).Msgf("can not get user with id '%d'", repo.UserID)
+		log.Error().Err(err).Msgf("cannot get user with id '%d'", repo.UserID)
 		return
 	}
 

--- a/server/model/registry.go
+++ b/server/model/registry.go
@@ -21,9 +21,9 @@ import (
 )
 
 var (
-	errRegistryAddressInvalid  = errors.New("Invalid Registry Address")
-	errRegistryUsernameInvalid = errors.New("Invalid Registry Username")
-	errRegistryPasswordInvalid = errors.New("Invalid Registry Password")
+	errRegistryAddressInvalid  = errors.New("invalid registry address")
+	errRegistryUsernameInvalid = errors.New("invalid registry username")
+	errRegistryPasswordInvalid = errors.New("invalid registry password")
 )
 
 // RegistryService defines a service for managing registries.

--- a/server/model/secret.go
+++ b/server/model/secret.go
@@ -23,10 +23,10 @@ import (
 )
 
 var (
-	ErrSecretNameInvalid  = errors.New("Invalid Secret Name")
-	ErrSecretImageInvalid = errors.New("Invalid Secret Image")
-	ErrSecretValueInvalid = errors.New("Invalid Secret Value")
-	ErrSecretEventInvalid = errors.New("Invalid Secret Event")
+	ErrSecretNameInvalid  = errors.New("invalid secret name")
+	ErrSecretImageInvalid = errors.New("invalid secret image")
+	ErrSecretValueInvalid = errors.New("invalid secret value")
+	ErrSecretEventInvalid = errors.New("invalid secret event")
 )
 
 // SecretService defines a service for managing secrets.

--- a/server/pipeline/decline.go
+++ b/server/pipeline/decline.go
@@ -36,7 +36,7 @@ func Decline(ctx context.Context, store store.Store, pipeline *model.Pipeline, u
 	}
 
 	if pipeline.Workflows, err = store.WorkflowGetTree(pipeline); err != nil {
-		log.Error().Err(err).Msg("can not build tree from step list")
+		log.Error().Err(err).Msg("cannot build tree from step list")
 	}
 
 	updatePipelineStatus(ctx, pipeline, repo, user)

--- a/server/pipeline/stepbuilder/stepBuilder.go
+++ b/server/pipeline/stepbuilder/stepBuilder.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/multierr"
 
 	backend_types "go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/types"
-	"go.woodpecker-ci.org/woodpecker/v2/pipeline/errors"
 	pipeline_errors "go.woodpecker-ci.org/woodpecker/v2/pipeline/errors"
 	yaml_types "go.woodpecker-ci.org/woodpecker/v2/pipeline/frontend/yaml/types"
 	forge_types "go.woodpecker-ci.org/woodpecker/v2/server/forge/types"
@@ -137,7 +136,7 @@ func (b *StepBuilder) genItemForWorkflow(workflow *model.Workflow, axis matrix.A
 	// parse yaml pipeline
 	parsed, err := yaml.ParseString(substituted)
 	if err != nil {
-		return nil, &errors.PipelineError{Message: err.Error(), Type: errors.PipelineErrorTypeCompiler}
+		return nil, &pipeline_errors.PipelineError{Message: err.Error(), Type: pipeline_errors.PipelineErrorTypeCompiler}
 	}
 
 	// lint pipeline

--- a/server/plugins/config/http.go
+++ b/server/plugins/config/http.go
@@ -66,7 +66,7 @@ func (cp *http) FetchConfig(ctx context.Context, repo *model.Repo, pipeline *mod
 
 	status, err := utils.Send(ctx, "POST", cp.endpoint, cp.privateKey, body, response)
 	if err != nil && status != 204 {
-		return nil, false, fmt.Errorf("Failed to fetch config via http (%d) %w", status, err)
+		return nil, false, fmt.Errorf("failed to fetch config via http (%d) %w", status, err)
 	}
 
 	var newFileMeta []*forge_types.FileMeta

--- a/server/plugins/encryption/constants.go
+++ b/server/plugins/encryption/constants.go
@@ -55,7 +55,7 @@ const (
 
 	// error messages
 	errMessageTemplateUnsupportedKeyType = "unsupported encryption key type: %s"
-	errMessageCantUseBothServices        = "can not use raw encryption key and tink keyset at the same time"
+	errMessageCantUseBothServices        = "cannot use raw encryption key and tink keyset at the same time"
 	errMessageNoKeysProvided             = "encryption enabled but no keys provided"
 	errMessageFailedRotatingEncryption   = "failed rotating encryption"
 

--- a/server/plugins/registry/filesystem.go
+++ b/server/plugins/registry/filesystem.go
@@ -111,11 +111,11 @@ func decodeAuth(authStr string) (string, string, error) {
 		return "", "", err
 	}
 	if n > decLen {
-		return "", "", fmt.Errorf("Something went wrong decoding auth config")
+		return "", "", fmt.Errorf("something went wrong decoding auth config")
 	}
 	arr := strings.SplitN(string(decoded), ":", 2)
 	if len(arr) != 2 {
-		return "", "", fmt.Errorf("Invalid auth configuration file")
+		return "", "", fmt.Errorf("invalid auth configuration file")
 	}
 	password := strings.Trim(arr[1], "\x00")
 	return arr[0], password, nil

--- a/server/plugins/utils/http.go
+++ b/server/plugins/utils/http.go
@@ -71,7 +71,7 @@ func Send(ctx context.Context, method, path string, privateKey crypto.PrivateKey
 			return resp.StatusCode, err
 		}
 
-		return resp.StatusCode, fmt.Errorf("Response: %s", string(body))
+		return resp.StatusCode, fmt.Errorf("response: %s", string(body))
 	}
 
 	// if no other errors parse and return the json response.

--- a/server/store/datastore/agent.go
+++ b/server/store/datastore/agent.go
@@ -20,7 +20,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/server/model"
 )
 
-var ErrNoTokenProvided = errors.New("Please provide a token")
+var ErrNoTokenProvided = errors.New("please provide a token")
 
 func (s storage) AgentList(p *model.ListOptions) ([]*model.Agent, error) {
 	var agents []*model.Agent

--- a/server/store/datastore/cron_test.go
+++ b/server/store/datastore/cron_test.go
@@ -32,7 +32,7 @@ func TestCronCreate(t *testing.T) {
 	assert.NoError(t, store.CronCreate(cron1))
 	assert.NotEqualValues(t, 0, cron1.ID)
 
-	// can not insert cron job with same repoID and title
+	// cannot insert cron job with same repoID and title
 	assert.Error(t, store.CronCreate(cron1))
 
 	oldID := cron1.ID

--- a/server/store/datastore/migration/migration.go
+++ b/server/store/datastore/migration/migration.go
@@ -113,7 +113,7 @@ func Migrate(e *xorm.Engine, allowLong bool) error {
 func syncAll(sess *xorm.Engine) error {
 	for _, bean := range allBeans {
 		if err := sess.Sync(bean); err != nil {
-			return fmt.Errorf("Sync error '%s': %w", reflect.TypeOf(bean), err)
+			return fmt.Errorf("sync error '%s': %w", reflect.TypeOf(bean), err)
 		}
 	}
 	return nil

--- a/server/web/web.go
+++ b/server/web/web.go
@@ -122,7 +122,7 @@ func serveFile(f *prefixFS) func(ctx *gin.Context) {
 		ctx.Writer.Header().Del("Expires")
 		ctx.Writer.Header().Set("Content-Type", mime)
 		if _, err := ctx.Writer.Write(replaceBytes(data)); err != nil {
-			log.Error().Err(err).Msgf("can not write %s", ctx.Request.URL.Path)
+			log.Error().Err(err).Msgf("cannot write %s", ctx.Request.URL.Path)
 		}
 	}
 }
@@ -145,7 +145,7 @@ func handleIndex(c *gin.Context) {
 	rw.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	rw.WriteHeader(http.StatusOK)
 	if _, err := rw.Write(indexHTML); err != nil {
-		log.Error().Err(err).Msg("can not write index.html")
+		log.Error().Err(err).Msg("cannot write index.html")
 	}
 }
 
@@ -164,7 +164,7 @@ func replaceBytes(data []byte) []byte {
 func parseIndex() ([]byte, error) {
 	data, err := loadFile("index.html")
 	if err != nil {
-		return nil, fmt.Errorf("can not find index.html: %w", err)
+		return nil, fmt.Errorf("cannot find index.html: %w", err)
 	}
 	data = bytes.ReplaceAll(data, []byte("/web-config.js"), []byte(server.Config.Server.RootPath+"/web-config.js"))
 	data = bytes.ReplaceAll(data, []byte("/assets/custom.css"), []byte(server.Config.Server.RootPath+"/assets/custom.css"))

--- a/web/src/views/repo/pipeline/Pipeline.vue
+++ b/web/src/views/repo/pipeline/Pipeline.vue
@@ -135,7 +135,7 @@ const selectedStepId = computed({
         return step.pid;
       }
 
-      // return fallback if step-id is provided, but step can not be found
+      // return fallback if step-id is provided, but step cannot be found
       return defaultStepId.value;
     }
 


### PR DESCRIPTION
This PR only fixes error string formatting, log message strings are still mixed upper/lowercase (see https://github.com/woodpecker-ci/woodpecker/pull/3161#issuecomment-1885140649) and I'm not aware of a linter to enforce it. 