### PR TITLE
Remove duplicate golangci linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -136,7 +136,6 @@ linters:
     - staticcheck
     - typecheck
     - unused
-    - whitespace
     - gofumpt
     - errorlint
     - forbidigo


### PR DESCRIPTION
`whitespace` is listed twice