### PR TITLE
Deprecate HTTP config service

### DIFF
--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -330,6 +330,7 @@ func setupConfigService(c *cli.Context) (config.Extension, error) {
 	}
 
 	if endpoint := c.String("config-service-endpoint"); endpoint != "" {
+		log.Warn().Msg("the HTTP config service is deprecated, use addons instead")
 		return config.NewHTTP(endpoint, server.Config.Services.SignaturePrivateKey), nil
 	}
 

--- a/docs/docs/30-administration/100-external-configuration-api.md
+++ b/docs/docs/30-administration/100-external-configuration-api.md
@@ -1,7 +1,7 @@
 # External Configuration API
 
 :::warning
-The HTTP config service is deprecated. Migrate to [addons](../75-addons/00-overview.md) instead.
+The HTTP config service is deprecated. Migrate to [addons](./75-addons/00-overview.md) instead.
 :::
 
 To provide additional management and preprocessing capabilities for pipeline configurations Woodpecker supports an HTTP API which can be enabled to call an external config service.

--- a/docs/docs/30-administration/100-external-configuration-api.md
+++ b/docs/docs/30-administration/100-external-configuration-api.md
@@ -1,5 +1,9 @@
 # External Configuration API
 
+:::warning
+The HTTP config service is deprecated. Migrate to [addons](../75-addons/00-overview.md) instead.
+:::
+
 To provide additional management and preprocessing capabilities for pipeline configurations Woodpecker supports an HTTP API which can be enabled to call an external config service.
 Before the run or restart of any pipeline Woodpecker will make a POST request to an external HTTP API sending the current repository, build information and all current config files retrieved from the repository. The external API can then send back new pipeline configurations that will be used immediately or respond with `HTTP 204` to tell the system to use the existing configuration.
 


### PR DESCRIPTION
As we have an addon system now, we can migrate http config services to them and remove support for http config services in the next major (so deprecate for now).

If you're currently using the http config service, you need to write the server yourself, there's only an example provided by us.
Then you can also write the addon I think. This is much faster than a HTTP request, simplifies typings and thus reduces errors etc. and does not require you to run an additional server.

Of course, we would need to update https://github.com/woodpecker-ci/example-config-service repository for this, I'm happy to open a PR for this.