### PR TITLE
Load more pipeline log lines (500 => 5000)

### DIFF
--- a/web/src/components/repo/pipeline/PipelineLog.vue
+++ b/web/src/components/repo/pipeline/PipelineLog.vue
@@ -159,7 +159,7 @@ const ansiUp = ref(new AnsiUp());
 ansiUp.value.use_classes = true;
 const logBuffer = ref<LogLine[]>([]);
 
-const maxLineCount = 500; // TODO: think about way to support lazy-loading more than last 300 logs (#776)
+const maxLineCount = 5000; // TODO: think about way to support lazy-loading more than last 5000 logs (#776)
 
 function isSelected(line: LogLine): boolean {
   return route.hash === `#L${line.number}`;


### PR DESCRIPTION
I was able to load 3500 lines without problems (it seems the browser goes from 5 MB memory usage to 10 MB).

This way, we will hit the boundary less often, lowering the need to get lazy loading #2653 fixed