### PR TITLE
Build tarball for distribution packages

### DIFF
--- a/.woodpecker/binaries.yaml
+++ b/.woodpecker/binaries.yaml
@@ -81,6 +81,7 @@ steps:
       - build-agent
       - build-cli
       - build-deb-rpm
+      - build-tarball
     image: *golang_image
     commands:
       - make release-checksums

--- a/.woodpecker/binaries.yaml
+++ b/.woodpecker/binaries.yaml
@@ -26,6 +26,13 @@ steps:
     commands:
       - go mod vendor
 
+  code-gen:
+    image: *golang_image
+    depends_on:
+      - vendor
+    commands:
+      - make generate
+
   cross-compile-server:
     depends_on:
       - vendor
@@ -41,6 +48,14 @@ steps:
       TAGS: bindata sqlite sqlite_unlock_notify netgo
       XGO_VERSION: *xgo_version
       TARGZ: '1'
+
+  build-tarball:
+    depends_on:
+      - code-gen
+      - build-web
+    image: *golang_image
+    commands:
+      - make build-tarball
 
   build-agent:
     depends_on:

--- a/.woodpecker/binaries.yaml
+++ b/.woodpecker/binaries.yaml
@@ -1,8 +1,3 @@
-depends_on:
-  - test
-  - web
-
-# TODO: upload build artifacts for pushes to ${CI_REPO_DEFAULT_BRANCH}
 when:
   event: tag
 

--- a/.woodpecker/docker.yaml
+++ b/.woodpecker/docker.yaml
@@ -6,10 +6,6 @@ when:
       - release/*
       - renovate/*
 
-depends_on:
-  - test
-  - web
-
 variables:
   - &golang_image 'docker.io/golang:1.21.6'
   - &node_image 'docker.io/node:21-alpine'

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,18 @@ build-agent: ## Build agent
 build-cli: ## Build cli
 	CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags '${LDFLAGS}' -o dist/woodpecker-cli${BIN_SUFFIX} go.woodpecker-ci.org/woodpecker/v2/cmd/cli
 
+build-tarball: ## Build tar archive
+	mkdir -p dist && tar chzvf dist/woodpecker-src.tar.gz \
+	  --exclude="*.exe" \
+	  --exclude="./.pnpm-store" \
+	  --exclude="node_modules" \
+	  --exclude="./dist" \
+	  --exclude="./data" \
+	  --exclude="./build" \
+	  --exclude="./.git" \
+	  .
+
+
 .PHONY: build
 build: build-agent build-server build-cli ## Build all binaries
 

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,6 @@ build-tarball: ## Build tar archive
 	  --exclude="./.git" \
 	  .
 
-
 .PHONY: build
 build: build-agent build-server build-cli ## Build all binaries
 


### PR DESCRIPTION
close  #3219

and also make sure the `binaries` & `docker` workflow will run on tag events, see https://ci.woodpecker-ci.org/repos/3780/pipeline/12358