### PR TITLE
Reduce default privileged plugins

### DIFF
--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -16,9 +16,6 @@ package constant
 
 // PrivilegedPlugins can be changed by 'WOODPECKER_ESCALATE' at runtime
 var PrivilegedPlugins = []string{
-	"plugins/docker",
-	"plugins/gcr",
-	"plugins/ecr",
 	"woodpeckerci/plugin-docker-buildx",
 	"codeberg.org/woodpecker-plugins/docker-buildx",
 }


### PR DESCRIPTION
We should not allow privileged to plugins we don't control ourselves.

Also, `plugins/docker` and `plugins/ecr` should be replaced by `docker-buildx`.

Does somebody know whether our buildx plugin has support for GCR?