### PR TITLE
chore: make services ephemeral on k8s

### DIFF
--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -107,6 +107,10 @@ func podSpec(step *types.Step, config *config) (v1.PodSpec, error) {
 		Tolerations:        tolerations(step.BackendOptions.Kubernetes.Tolerations),
 		SecurityContext:    podSecurityContext(step.BackendOptions.Kubernetes.SecurityContext, config.SecurityContext),
 	}
+
+	if step.Type == types.StepTypeService {
+		return spec, nil
+	}
 	spec.Volumes, err = volumes(step.Volumes)
 	if err != nil {
 		return spec, err
@@ -146,6 +150,9 @@ func podContainer(step *types.Step, podName, goos string) (v1.Container, error) 
 		return container, err
 	}
 
+	if step.Type == types.StepTypeService {
+		return container, nil
+	}
 	container.VolumeMounts, err = volumeMounts(step.Volumes)
 	if err != nil {
 		return container, err

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -108,7 +108,7 @@ func podSpec(step *types.Step, config *config) (v1.PodSpec, error) {
 		SecurityContext:    podSecurityContext(step.BackendOptions.Kubernetes.SecurityContext, config.SecurityContext),
 	}
 
-	if (step.Type == types.StepTypeService) && (config.StorageRwx == false) {
+	if (step.Type == types.StepTypeService) && (!config.StorageRwx) {
 		return spec, nil
 	}
 	spec.Volumes, err = volumes(step.Volumes)
@@ -150,7 +150,7 @@ func podContainer(step *types.Step, podName, goos string, storageRwx bool) (v1.C
 		return container, err
 	}
 
-	if (step.Type == types.StepTypeService) && (storageRwx == false) {
+	if (step.Type == types.StepTypeService) && (!storageRwx) {
 		return container, nil
 	}
 	container.VolumeMounts, err = volumeMounts(step.Volumes)

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -43,7 +43,7 @@ func mkPod(step *types.Step, config *config, podName, goos string) (*v1.Pod, err
 		return nil, err
 	}
 
-	container, err := podContainer(step, podName, goos)
+	container, err := podContainer(step, podName, goos, config.StorageRwx)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func podSpec(step *types.Step, config *config) (v1.PodSpec, error) {
 		SecurityContext:    podSecurityContext(step.BackendOptions.Kubernetes.SecurityContext, config.SecurityContext),
 	}
 
-	if step.Type == types.StepTypeService {
+	if (step.Type == types.StepTypeService) && (config.StorageRwx == false) {
 		return spec, nil
 	}
 	spec.Volumes, err = volumes(step.Volumes)
@@ -119,7 +119,7 @@ func podSpec(step *types.Step, config *config) (v1.PodSpec, error) {
 	return spec, nil
 }
 
-func podContainer(step *types.Step, podName, goos string) (v1.Container, error) {
+func podContainer(step *types.Step, podName, goos string, storageRwx bool) (v1.Container, error) {
 	var err error
 	container := v1.Container{
 		Name:       podName,
@@ -150,7 +150,7 @@ func podContainer(step *types.Step, podName, goos string) (v1.Container, error) 
 		return container, err
 	}
 
-	if step.Type == types.StepTypeService {
+	if (step.Type == types.StepTypeService) && (storageRwx == false) {
 		return container, nil
 	}
 	container.VolumeMounts, err = volumeMounts(step.Volumes)


### PR DESCRIPTION
# Context

When we run `services` and a storage `rwx` is set to `false`, sometimes pipelines get stuck when the steps run in another host. 

```
  Warning  FailedMount     	19s	kubelet              	Unable to attach or mount volumes: unmounted volumes=[wp-01hmhhfewr9cwqsj2q4v440rwa-0-default], unattached volumes=[aws-iam-token wp-01hmhhfewr9cwqsj2q4v440rwa-0-default 
```

# How 
I propose to treat them as ephemeral pods without PVC and just serve the service as is. 
Removing the volume when the pod is a `services` and when `rwx` is `false`. To prevent unnecessary mount volumes. 

