### PR TITLE
fix: bug pod service without label service

### DIFF
--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -80,6 +80,10 @@ func podMeta(step *types.Step, config *config, podName string) metav1.ObjectMeta
 	}
 	meta.Labels[StepLabel] = step.Name
 
+	if step.Type == types.StepTypeService {
+		meta.Labels[ServiceLabel] = step.Name
+	}
+
 	meta.Annotations = config.PodAnnotations
 	if meta.Annotations == nil {
 		meta.Annotations = make(map[string]string)


### PR DESCRIPTION
# Bug

Service has selector label `service: mydb` and pod running without this labels 


![image](https://github.com/woodpecker-ci/woodpecker/assets/22245125/fc5dce98-cd0d-452c-af14-734b8c27bc00)

![image](https://github.com/woodpecker-ci/woodpecker/assets/22245125/5c87dcc8-85bc-4a0e-9183-31fa82f16ba7)

