### PR TITLE
fix bitbucket SSO using UUID from bitbucket api response as ForgeRemoteID

### DIFF
--- a/server/forge/bitbucket/convert.go
+++ b/server/forge/bitbucket/convert.go
@@ -137,7 +137,7 @@ func convertUser(from *internal.Account, token *oauth2.Token) *model.User {
 		Secret:        token.RefreshToken,
 		Expiry:        token.Expiry.UTC().Unix(),
 		Avatar:        from.Links.Avatar.Href,
-		ForgeRemoteID: model.ForgeRemoteID(fmt.Sprint(from.ID)),
+		ForgeRemoteID: model.ForgeRemoteID(fmt.Sprint(from.UUID)),
 	}
 }
 

--- a/server/forge/bitbucket/fixtures/handler.go
+++ b/server/forge/bitbucket/fixtures/handler.go
@@ -300,6 +300,7 @@ const pullRequestsPayload = `
 
 const userPayload = `
 {
+	"uuid": "{4d8c0f46-cd62-4b77-b0cf-faa3e4d932c6}",
   "username": "superman",
   "links": {
     "avatar": {

--- a/server/forge/bitbucket/internal/types.go
+++ b/server/forge/bitbucket/internal/types.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Account struct {
-	ID    int64  `json:"id"`
+	UUID  string `json:"uuid"`
 	Login string `json:"username"`
 	Name  string `json:"display_name"`
 	Type  string `json:"type"`


### PR DESCRIPTION
This pull request addresses the issue https://github.com/woodpecker-ci/woodpecker/issues/3264.

The recent changes made to the Bitbucket API have eliminated the provision of user IDs and renamed it to UUID.

It was causing that every time a new user logged in, the system identified them as an existing user (response.ID is null or 0), overriding the same user all the time and, therefore, disconnecting previous user.