### PR TITLE
Pipeline errors must be an array

### DIFF
--- a/woodpecker-go/woodpecker/types.go
+++ b/woodpecker-go/woodpecker/types.go
@@ -69,12 +69,12 @@ type (
 
 	// Pipeline defines a pipeline object.
 	Pipeline struct {
-		ID     int64         `json:"id"`
-		Number int64         `json:"number"`
-		Parent int64         `json:"parent"`
-		Event  string        `json:"event"`
-		Status string        `json:"status"`
-		Errors PipelineError `json:"errors"`
+		ID     int64            `json:"id"`
+		Number int64            `json:"number"`
+		Parent int64            `json:"parent"`
+		Event  string           `json:"event"`
+		Status string           `json:"status"`
+		Errors []*PipelineError `json:"errors"`
 		// Deprecated TODO remove in 3.x
 		Enqueued  int64       `json:"enqueued_at"`
 		Created   int64       `json:"created_at"`


### PR DESCRIPTION
This PR addresses 
``json: cannot unmarshal array into Go struct field Pipeline.errors of type woodpecker.PipelineError``
when executing 
``woodpecker-cli pipeline ls X``

According to API schema, pipeline.errors should contain an array

Fixes #3119