### PR TITLE
Reload site on theme change

### DIFF
--- a/web/src/compositions/useTheme.ts
+++ b/web/src/compositions/useTheme.ts
@@ -1,6 +1,5 @@
-import { onMounted, onUnmounted } from 'vue';
 import { useColorMode } from '@vueuse/core';
-import { watch } from 'vue';
+import { onMounted, onUnmounted, watch } from 'vue';
 
 const { store: storeTheme, state: resolvedTheme } = useColorMode({
   storageKey: 'woodpecker:theme',

--- a/web/src/compositions/useTheme.ts
+++ b/web/src/compositions/useTheme.ts
@@ -1,3 +1,4 @@
+import { onMounted, onUnmounted } from 'vue';
 import { useColorMode } from '@vueuse/core';
 import { watch } from 'vue';
 
@@ -21,11 +22,22 @@ function updateTheme() {
 
 watch(storeTheme, updateTheme);
 
-updateTheme();
-
 export function useTheme() {
+  let mql: MediaQueryList;
+
+  onMounted(() => {
+    mql = window.matchMedia('(prefers-color-scheme: dark)');
+    mql.addEventListener('change', updateTheme);
+  });
+
+  onUnmounted(() => {
+    mql.removeEventListener('change', updateTheme);
+  });
+
   return {
     theme: resolvedTheme,
     storeTheme,
   };
 }
+
+updateTheme();

--- a/web/src/compositions/useTheme.ts
+++ b/web/src/compositions/useTheme.ts
@@ -1,7 +1,7 @@
 import { useColorMode } from '@vueuse/core';
 import { onMounted, onUnmounted, watch } from 'vue';
 
-const { store: storeTheme, state: resolvedTheme } = useColorMode({
+const { store: storeTheme, state: resolvedTheme, system: systemTheme } = useColorMode({
   storageKey: 'woodpecker:theme',
 });
 

--- a/web/src/compositions/useTheme.ts
+++ b/web/src/compositions/useTheme.ts
@@ -19,7 +19,7 @@ function updateTheme() {
   }
 }
 
-watch(storeTheme, updateTheme);
+watch([storeTheme, systemTheme], updateTheme);
 
 export function useTheme() {
   let mql: MediaQueryList;

--- a/web/src/compositions/useTheme.ts
+++ b/web/src/compositions/useTheme.ts
@@ -22,17 +22,6 @@ function updateTheme() {
 watch([storeTheme, systemTheme], updateTheme);
 
 export function useTheme() {
-  let mql: MediaQueryList;
-
-  onMounted(() => {
-    mql = window.matchMedia('(prefers-color-scheme: dark)');
-    mql.addEventListener('change', updateTheme);
-  });
-
-  onUnmounted(() => {
-    mql.removeEventListener('change', updateTheme);
-  });
-
   return {
     theme: resolvedTheme,
     storeTheme,

--- a/web/src/compositions/useTheme.ts
+++ b/web/src/compositions/useTheme.ts
@@ -19,7 +19,7 @@ function updateTheme() {
   }
 }
 
-watch([storeTheme, systemTheme], updateTheme);
+watch([storeTheme, systemTheme], updateTheme, { immediate: true });
 
 export function useTheme() {
   return {

--- a/web/src/compositions/useTheme.ts
+++ b/web/src/compositions/useTheme.ts
@@ -1,7 +1,11 @@
 import { useColorMode } from '@vueuse/core';
-import { onMounted, onUnmounted, watch } from 'vue';
+import { watch } from 'vue';
 
-const { store: storeTheme, state: resolvedTheme, system: systemTheme } = useColorMode({
+const {
+  store: storeTheme,
+  state: resolvedTheme,
+  system: systemTheme,
+} = useColorMode({
   storageKey: 'woodpecker:theme',
 });
 

--- a/web/src/compositions/useTheme.ts
+++ b/web/src/compositions/useTheme.ts
@@ -27,5 +27,3 @@ export function useTheme() {
     storeTheme,
   };
 }
-
-updateTheme();


### PR DESCRIPTION
Currently, when theme `auto` is set and the system theme changes, users need to reload the site themselves.

This PR adds an even listener which listens for such changes and reloads the theme automatically in the background.