### PR TITLE
Ignore gitlab merge request events without code changes

### DIFF
--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -644,6 +644,10 @@ func (g *GitLab) Hook(ctx context.Context, req *http.Request) (*model.Repo, *mod
 
 	switch event := parsed.(type) {
 	case *gitlab.MergeEvent:
+		// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events
+		if event.ObjectAttributes.OldRev == "" && event.ObjectAttributes.Action != "open" {
+			return nil, nil, &forge_types.ErrIgnoreEvent{Event: string(eventType) + " without code changes"}
+		}
 		mergeIID, repo, pipeline, err := convertMergeRequestHook(event, req)
 		if err != nil {
 			return nil, nil, err

--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -646,7 +646,7 @@ func (g *GitLab) Hook(ctx context.Context, req *http.Request) (*model.Repo, *mod
 	case *gitlab.MergeEvent:
 		// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events
 		if event.ObjectAttributes.OldRev == "" && event.ObjectAttributes.Action != "open" {
-			return nil, nil, &forge_types.ErrIgnoreEvent{Event: string(eventType) + " without code changes"}
+			return nil, nil, &forge_types.ErrIgnoreEvent{Event: string(eventType), Reason: "no code changes"}
 		}
 		mergeIID, repo, pipeline, err := convertMergeRequestHook(event, req)
 		if err != nil {

--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -645,7 +645,7 @@ func (g *GitLab) Hook(ctx context.Context, req *http.Request) (*model.Repo, *mod
 	switch event := parsed.(type) {
 	case *gitlab.MergeEvent:
 		// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events
-		if event.ObjectAttributes.OldRev == "" && event.ObjectAttributes.Action != "open" {
+		if event.ObjectAttributes.OldRev == "" && event.ObjectAttributes.Action != "open" && event.ObjectAttributes.Action != "close" && event.ObjectAttributes.Action != "merge" {
 			return nil, nil, &forge_types.ErrIgnoreEvent{Event: string(eventType), Reason: "no code changes"}
 		}
 		mergeIID, repo, pipeline, err := convertMergeRequestHook(event, req)

--- a/server/forge/gitlab/testdata/hooks.go
+++ b/server/forge/gitlab/testdata/hooks.go
@@ -323,6 +323,296 @@ var HookPullRequest = []byte(`
 }
 `)
 
+var HookPullRequestWithoutChanges = []byte(`
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 2251488,
+    "name": "Anbraten",
+    "username": "anbraten",
+    "avatar_url": "https://secure.gravatar.com/avatar/fc9b6fe77c6b732a02925a62a81f05a0?s=80&d=identicon",
+    "email": "some@mail.info"
+  },
+  "project": {
+    "id": 32059612,
+    "name": "woodpecker",
+    "description": "",
+    "web_url": "https://gitlab.com/anbraten/woodpecker",
+    "avatar_url": "http://example.com/uploads/project/avatar/555/Outh-20-Logo.jpg",
+    "git_ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+    "git_http_url": "https://gitlab.com/anbraten/woodpecker.git",
+    "namespace": "Anbraten",
+    "visibility_level": 20,
+    "path_with_namespace": "anbraten/woodpecker",
+    "default_branch": "main",
+    "ci_config_path": "",
+    "homepage": "https://gitlab.com/anbraten/woodpecker",
+    "url": "git@gitlab.com:anbraten/woodpecker.git",
+    "ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+    "http_url": "https://gitlab.com/anbraten/woodpecker.git"
+  },
+  "object_attributes": {
+    "assignee_id": 2251488,
+    "author_id": 2251488,
+    "created_at": "2022-01-10 15:23:41 UTC",
+    "description": "",
+    "head_pipeline_id": 449733536,
+    "id": 134400602,
+    "iid": 3,
+    "last_edited_at": "2022-01-17 15:46:23 UTC",
+    "last_edited_by_id": 2251488,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "unchecked",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "anbraten-main-patch-05373",
+    "source_project_id": 32059612,
+    "state_id": 1,
+    "target_branch": "main",
+    "target_project_id": 32059612,
+    "time_estimate": 0,
+    "title": "Update client.go 🎉",
+    "updated_at": "2022-01-17 15:47:39 UTC",
+    "updated_by_id": 2251488,
+    "url": "https://gitlab.com/anbraten/woodpecker/-/merge_requests/3",
+    "source": {
+      "id": 32059612,
+      "name": "woodpecker",
+      "description": "",
+      "web_url": "https://gitlab.com/anbraten/woodpecker",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+      "git_http_url": "https://gitlab.com/anbraten/woodpecker.git",
+      "namespace": "Anbraten",
+      "visibility_level": 20,
+      "path_with_namespace": "anbraten/woodpecker",
+      "default_branch": "main",
+      "ci_config_path": "",
+      "homepage": "https://gitlab.com/anbraten/woodpecker",
+      "url": "git@gitlab.com:anbraten/woodpecker.git",
+      "ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+      "http_url": "https://gitlab.com/anbraten/woodpecker.git"
+    },
+    "target": {
+      "id": 32059612,
+      "name": "woodpecker",
+      "description": "",
+      "web_url": "https://gitlab.com/anbraten/woodpecker",
+      "avatar_url": "http://example.com/uploads/project/avatar/555/Outh-20-Logo.jpg",
+      "git_ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+      "git_http_url": "https://gitlab.com/anbraten/woodpecker.git",
+      "namespace": "Anbraten",
+      "visibility_level": 20,
+      "path_with_namespace": "anbraten/woodpecker",
+      "default_branch": "main",
+      "ci_config_path": "",
+      "homepage": "https://gitlab.com/anbraten/woodpecker",
+      "url": "git@gitlab.com:anbraten/woodpecker.git",
+      "ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+      "http_url": "https://gitlab.com/anbraten/woodpecker.git"
+    },
+    "last_commit": {
+      "id": "c136499ec574e1034b24c5d306de9acda3005367",
+      "message": "Update folder/todo.txt",
+      "title": "Update folder/todo.txt",
+      "timestamp": "2022-01-17T15:47:38+00:00",
+      "url": "https://gitlab.com/anbraten/woodpecker/-/commit/c136499ec574e1034b24c5d306de9acda3005367",
+      "author": {
+        "name": "Anbraten",
+        "email": "some@mail.info"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "time_change": 0,
+    "human_total_time_spent": null,
+    "human_time_change": null,
+    "human_time_estimate": null,
+    "assignee_ids": [
+      2251488
+    ],
+    "state": "opened",
+    "blocking_discussions_resolved": true,
+    "action": "update"
+  },
+  "labels": [
+
+  ],
+  "changes": {
+    "updated_at": {
+      "previous": "2022-01-17 15:46:23 UTC",
+      "current": "2022-01-17 15:47:39 UTC"
+    }
+  },
+  "repository": {
+    "name": "woodpecker",
+    "url": "git@gitlab.com:anbraten/woodpecker.git",
+    "description": "",
+    "homepage": "https://gitlab.com/anbraten/woodpecker"
+  },
+  "assignees": [
+    {
+      "id": 2251488,
+      "name": "Anbraten",
+      "username": "anbraten",
+      "avatar_url": "https://secure.gravatar.com/avatar/fc9b6fe77c6b732a02925a62a81f05a0?s=80&d=identicon",
+      "email": "some@mail.info"
+    }
+  ]
+}
+`)
+
+var HookPullRequestApproved = []byte(`
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 2251488,
+    "name": "Anbraten",
+    "username": "anbraten",
+    "avatar_url": "https://secure.gravatar.com/avatar/fc9b6fe77c6b732a02925a62a81f05a0?s=80&d=identicon",
+    "email": "some@mail.info"
+  },
+  "project": {
+    "id": 32059612,
+    "name": "woodpecker",
+    "description": "",
+    "web_url": "https://gitlab.com/anbraten/woodpecker",
+    "avatar_url": "http://example.com/uploads/project/avatar/555/Outh-20-Logo.jpg",
+    "git_ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+    "git_http_url": "https://gitlab.com/anbraten/woodpecker.git",
+    "namespace": "Anbraten",
+    "visibility_level": 20,
+    "path_with_namespace": "anbraten/woodpecker",
+    "default_branch": "main",
+    "ci_config_path": "",
+    "homepage": "https://gitlab.com/anbraten/woodpecker",
+    "url": "git@gitlab.com:anbraten/woodpecker.git",
+    "ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+    "http_url": "https://gitlab.com/anbraten/woodpecker.git"
+  },
+  "object_attributes": {
+    "assignee_id": 2251488,
+    "author_id": 2251488,
+    "created_at": "2022-01-10 15:23:41 UTC",
+    "description": "",
+    "head_pipeline_id": 449733536,
+    "id": 134400602,
+    "iid": 3,
+    "last_edited_at": "2022-01-17 15:46:23 UTC",
+    "last_edited_by_id": 2251488,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "unchecked",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "anbraten-main-patch-05373",
+    "source_project_id": 32059612,
+    "state_id": 1,
+    "target_branch": "main",
+    "target_project_id": 32059612,
+    "time_estimate": 0,
+    "title": "Update client.go 🎉",
+    "updated_at": "2022-01-17 15:47:39 UTC",
+    "updated_by_id": 2251488,
+    "url": "https://gitlab.com/anbraten/woodpecker/-/merge_requests/3",
+    "source": {
+      "id": 32059612,
+      "name": "woodpecker",
+      "description": "",
+      "web_url": "https://gitlab.com/anbraten/woodpecker",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+      "git_http_url": "https://gitlab.com/anbraten/woodpecker.git",
+      "namespace": "Anbraten",
+      "visibility_level": 20,
+      "path_with_namespace": "anbraten/woodpecker",
+      "default_branch": "main",
+      "ci_config_path": "",
+      "homepage": "https://gitlab.com/anbraten/woodpecker",
+      "url": "git@gitlab.com:anbraten/woodpecker.git",
+      "ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+      "http_url": "https://gitlab.com/anbraten/woodpecker.git"
+    },
+    "target": {
+      "id": 32059612,
+      "name": "woodpecker",
+      "description": "",
+      "web_url": "https://gitlab.com/anbraten/woodpecker",
+      "avatar_url": "http://example.com/uploads/project/avatar/555/Outh-20-Logo.jpg",
+      "git_ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+      "git_http_url": "https://gitlab.com/anbraten/woodpecker.git",
+      "namespace": "Anbraten",
+      "visibility_level": 20,
+      "path_with_namespace": "anbraten/woodpecker",
+      "default_branch": "main",
+      "ci_config_path": "",
+      "homepage": "https://gitlab.com/anbraten/woodpecker",
+      "url": "git@gitlab.com:anbraten/woodpecker.git",
+      "ssh_url": "git@gitlab.com:anbraten/woodpecker.git",
+      "http_url": "https://gitlab.com/anbraten/woodpecker.git"
+    },
+    "last_commit": {
+      "id": "c136499ec574e1034b24c5d306de9acda3005367",
+      "message": "Update folder/todo.txt",
+      "title": "Update folder/todo.txt",
+      "timestamp": "2022-01-17T15:47:38+00:00",
+      "url": "https://gitlab.com/anbraten/woodpecker/-/commit/c136499ec574e1034b24c5d306de9acda3005367",
+      "author": {
+        "name": "Anbraten",
+        "email": "some@mail.info"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "time_change": 0,
+    "human_total_time_spent": null,
+    "human_time_change": null,
+    "human_time_estimate": null,
+    "assignee_ids": [
+      2251488
+    ],
+    "state": "opened",
+    "blocking_discussions_resolved": true,
+    "action": "approved"
+  },
+  "labels": [
+
+  ],
+  "changes": {
+    "updated_at": {
+      "previous": "2022-01-17 15:46:23 UTC",
+      "current": "2022-01-17 15:47:39 UTC"
+    }
+  },
+  "repository": {
+    "name": "woodpecker",
+    "url": "git@gitlab.com:anbraten/woodpecker.git",
+    "description": "",
+    "homepage": "https://gitlab.com/anbraten/woodpecker"
+  },
+  "assignees": [
+    {
+      "id": 2251488,
+      "name": "Anbraten",
+      "username": "anbraten",
+      "avatar_url": "https://secure.gravatar.com/avatar/fc9b6fe77c6b732a02925a62a81f05a0?s=80&d=identicon",
+      "email": "some@mail.info"
+    }
+  ]
+}
+`)
+
 var HookPullRequestClosed = []byte(`
 {
   "object_kind": "merge_request",

--- a/server/forge/types/errors.go
+++ b/server/forge/types/errors.go
@@ -46,11 +46,12 @@ var _ error = new(AuthError)
 var ErrNotImplemented = errors.New("not implemented")
 
 type ErrIgnoreEvent struct {
-	Event string
+	Event  string
+	Reason string
 }
 
 func (err *ErrIgnoreEvent) Error() string {
-	return fmt.Sprintf("explicit ignored event '%s'", err.Event)
+	return fmt.Sprintf("explicit ignored event '%s', reason: %s", err.Event, err.Reason)
 }
 
 func (*ErrIgnoreEvent) Is(target error) bool {


### PR DESCRIPTION
Closes #3320 

From the gitlab docs at: https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events

> The field object_attributes.oldrev is only available when there are actual code changes
