### PR TITLE
Ignore gitlab push events without commits

### DIFF
--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -655,6 +655,9 @@ func (g *GitLab) Hook(ctx context.Context, req *http.Request) (*model.Repo, *mod
 
 		return repo, pipeline, nil
 	case *gitlab.PushEvent:
+		if event.TotalCommitsCount == 0 {
+			return nil, nil, &forge_types.ErrIgnoreEvent{Event: string(eventType), Reason: "no commits"}
+		}
 		return convertPushHook(event)
 	case *gitlab.TagEvent:
 		return convertTagHook(event)

--- a/server/forge/types/errors.go
+++ b/server/forge/types/errors.go
@@ -46,11 +46,12 @@ var _ error = new(AuthError)
 var ErrNotImplemented = errors.New("not implemented")
 
 type ErrIgnoreEvent struct {
-	Event string
+	Event  string
+	Reason string
 }
 
 func (err *ErrIgnoreEvent) Error() string {
-	return fmt.Sprintf("explicit ignored event '%s'", err.Event)
+	return fmt.Sprintf("explicit ignored event '%s', reason: %s", err.Event, err.Reason)
 }
 
 func (*ErrIgnoreEvent) Is(target error) bool {


### PR DESCRIPTION
Example of the resulting buggy pipeline:

![image](https://github.com/woodpecker-ci/woodpecker/assets/32853499/1e4bedc6-465b-466e-8d89-a7348e374c7f)
