### PR TITLE
Fix agent polling

### DIFF
--- a/server/api/agent.go
+++ b/server/api/agent.go
@@ -137,6 +137,9 @@ func PatchAgent(c *gin.Context) {
 	}
 	agent.Name = in.Name
 	agent.NoSchedule = in.NoSchedule
+	if agent.NoSchedule {
+		server.Config.Services.Queue.KickAgentWorkers(agent.ID)
+	}
 
 	err = _store.AgentUpdate(agent)
 	if err != nil {
@@ -213,6 +216,9 @@ func DeleteAgent(c *gin.Context) {
 			return
 		}
 	}
+
+	// kick workers to remove the agent from the queue
+	server.Config.Services.Queue.KickAgentWorkers(agent.ID)
 
 	if err = _store.AgentDelete(agent); err != nil {
 		c.String(http.StatusInternalServerError, "Error deleting user. %s", err)

--- a/server/grpc/rpc.go
+++ b/server/grpc/rpc.go
@@ -69,13 +69,13 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 	}
 
 	for {
-		// poll blocks until a task is available
+		// poll blocks until a task is available or the context is canceled / worker is kicked
 		task, err := s.queue.Poll(c, agent.ID, filterFn)
 		if err != nil {
 			return nil, err
 		}
 
-		// poll returns nil if workers context was canceled
+		// poll returns nil task if context was canceled / worker was kicked
 		if task == nil {
 			return nil, nil
 		}

--- a/server/grpc/rpc.go
+++ b/server/grpc/rpc.go
@@ -71,13 +71,8 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 	for {
 		// poll blocks until a task is available or the context is canceled / worker is kicked
 		task, err := s.queue.Poll(c, agent.ID, filterFn)
-		if err != nil {
+		if err != nil || task == nil {
 			return nil, err
-		}
-
-		// poll returns nil task if context was canceled / worker was kicked
-		if task == nil {
-			return nil, nil
 		}
 
 		if task.ShouldRun() {

--- a/server/grpc/rpc.go
+++ b/server/grpc/rpc.go
@@ -64,7 +64,7 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 		}
 
 		if agent.NoSchedule {
-			time.Sleep(5 * time.Second)
+			time.Sleep(1 * time.Second)
 			continue
 		}
 

--- a/server/queue/fifo.go
+++ b/server/queue/fifo.go
@@ -70,7 +70,7 @@ func (q *fifo) Push(_ context.Context, task *model.Task) error {
 	return nil
 }
 
-// Push pushes an item to the tail of this queue.
+// PushAtOnce pushes items to the tail of this queue.
 func (q *fifo) PushAtOnce(_ context.Context, tasks []*model.Task) error {
 	q.Lock()
 	for _, task := range tasks {
@@ -111,12 +111,12 @@ func (q *fifo) Done(_ context.Context, id string, exitStatus model.StatusValue) 
 	return q.finished([]string{id}, exitStatus, nil)
 }
 
-// Error signals that the item is done executing with error.
+// Error signals that the item is done executing with an error.
 func (q *fifo) Error(_ context.Context, id string, err error) error {
 	return q.finished([]string{id}, model.StatusFailure, err)
 }
 
-// ErrorAtOnce signals that the item is done executing with error.
+// ErrorAtOnce signals that the items are done executing with an error.
 func (q *fifo) ErrorAtOnce(_ context.Context, id []string, err error) error {
 	return q.finished(id, model.StatusFailure, err)
 }
@@ -145,7 +145,7 @@ func (q *fifo) Evict(c context.Context, id string) error {
 	return q.EvictAtOnce(c, []string{id})
 }
 
-// Evict removes a pending task from the queue.
+// EvictAtOnce removes multiple pending tasks from the queue.
 func (q *fifo) EvictAtOnce(_ context.Context, ids []string) error {
 	q.Lock()
 	defer q.Unlock()

--- a/server/queue/fifo.go
+++ b/server/queue/fifo.go
@@ -200,7 +200,6 @@ func (q *fifo) Info(_ context.Context) InfoT {
 	stats.Stats.Pending = q.pending.Len()
 	stats.Stats.WaitingOnDeps = q.waitingOnDeps.Len()
 	stats.Stats.Running = len(q.running)
-	stats.Stats.Complete = 0 // TODO: implement this
 
 	for e := q.pending.Front(); e != nil; e = e.Next() {
 		task, _ := e.Value.(*model.Task)

--- a/server/queue/persistent.go
+++ b/server/queue/persistent.go
@@ -95,9 +95,30 @@ func (q *persistentQueue) Evict(c context.Context, id string) error {
 	return err
 }
 
-// EvictAtOnce removes a pending task from the queue.
+// EvictAtOnce removes multiple pending tasks from the queue.
 func (q *persistentQueue) EvictAtOnce(c context.Context, ids []string) error {
 	if err := q.Queue.EvictAtOnce(c, ids); err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if err := q.store.TaskDelete(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Error signals the task is done with an error.
+func (q *persistentQueue) Error(c context.Context, id string, err error) error {
+	if err := q.Queue.Error(c, id, err); err != nil {
+		return err
+	}
+	return q.store.TaskDelete(id)
+}
+
+// ErrorAtOnce signals multiple tasks are done with an error.
+func (q *persistentQueue) ErrorAtOnce(c context.Context, ids []string, err error) error {
+	if err := q.Queue.ErrorAtOnce(c, ids, err); err != nil {
 		return err
 	}
 	for _, id := range ids {

--- a/server/queue/queue.go
+++ b/server/queue/queue.go
@@ -72,7 +72,7 @@ type Queue interface {
 	// Push pushes a task to the tail of this queue.
 	Push(c context.Context, task *model.Task) error
 
-	// PushAtOnce pushes a task to the tail of this queue.
+	// PushAtOnce pushes tasks to the tail of this queue.
 	PushAtOnce(c context.Context, tasks []*model.Task) error
 
 	// Poll retrieves and removes a task head of this queue.
@@ -87,13 +87,13 @@ type Queue interface {
 	// Error signals the task is complete with errors.
 	Error(c context.Context, id string, err error) error
 
-	// ErrorAtOnce signals the task is complete with errors.
+	// ErrorAtOnce signals tasks are complete with errors.
 	ErrorAtOnce(c context.Context, id []string, err error) error
 
 	// Evict removes a pending task from the queue.
 	Evict(c context.Context, id string) error
 
-	// EvictAtOnce removes a pending task from the queue.
+	// EvictAtOnce removes pending tasks from the queue.
 	EvictAtOnce(c context.Context, id []string) error
 
 	// Wait waits until the task is complete.
@@ -107,4 +107,7 @@ type Queue interface {
 
 	// Resume starts the queue again, Poll returns new items
 	Resume()
+
+	// KickAgentWorkers kicks all workers for a given agent.
+	KickAgentWorkers(agentID int64)
 }

--- a/server/queue/queue.go
+++ b/server/queue/queue.go
@@ -40,7 +40,6 @@ type InfoT struct {
 		Pending       int `json:"pending_count"`
 		WaitingOnDeps int `json:"waiting_on_deps_count"`
 		Running       int `json:"running_count"`
-		Complete      int `json:"completed_count"`
 	} `json:"stats"`
 	Paused bool `json:"paused"`
 } //	@name InfoT

--- a/server/queue/queue.go
+++ b/server/queue/queue.go
@@ -72,7 +72,7 @@ type Queue interface {
 	// Push pushes a task to the tail of this queue.
 	Push(c context.Context, task *model.Task) error
 
-	// PushAtOnce pushes tasks to the tail of this queue.
+	// PushAtOnce pushes multiple tasks to the tail of this queue.
 	PushAtOnce(c context.Context, tasks []*model.Task) error
 
 	// Poll retrieves and removes a task head of this queue.
@@ -84,17 +84,17 @@ type Queue interface {
 	// Done signals the task is complete.
 	Done(c context.Context, id string, exitStatus model.StatusValue) error
 
-	// Error signals the task is complete with errors.
+	// Error signals the task is done with an error.
 	Error(c context.Context, id string, err error) error
 
-	// ErrorAtOnce signals tasks are complete with errors.
-	ErrorAtOnce(c context.Context, id []string, err error) error
+	// ErrorAtOnce signals multiple done are complete with an error.
+	ErrorAtOnce(c context.Context, ids []string, err error) error
 
 	// Evict removes a pending task from the queue.
 	Evict(c context.Context, id string) error
 
-	// EvictAtOnce removes pending tasks from the queue.
-	EvictAtOnce(c context.Context, id []string) error
+	// EvictAtOnce removes multiple pending tasks from the queue.
+	EvictAtOnce(c context.Context, ids []string) error
 
 	// Wait waits until the task is complete.
 	Wait(c context.Context, id string) error
@@ -105,7 +105,7 @@ type Queue interface {
 	// Pause stops the queue from handing out new work items in Poll
 	Pause()
 
-	// Resume starts the queue again, Poll returns new items
+	// Resume starts the queue again.
 	Resume()
 
 	// KickAgentWorkers kicks all workers for a given agent.


### PR DESCRIPTION
Supersedes #3206
closes #1990 
closes https://github.com/woodpecker-ci/autoscaler/issues/50

This solves a bug that `NoSchedule` wasn't considered if the agent already had workers waiting for tasks in the queue by kicking those workers from the queue when updating the agents no-schedule flag via api. We now also kick the agents workers when deleting the agent.

In addition a timeout prevents agents with `NoSchedule` from spamming the server.

Removes errored tasks from the database queue.

I also removed the queue info completed property as it is never used.