### PR TITLE
Remove empty strings from slice before parsing agent config

### DIFF
--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -275,7 +275,7 @@ func stringSliceAddToMap(sl []string, m map[string]string) error {
 	if m == nil {
 		m = make(map[string]string)
 	}
-	for _, v := range sl {
+	for _, v := range utils.StringSliceDeleteEmpty(sl) {
 		parts := strings.SplitN(v, "=", 2)
 		switch len(parts) {
 		case 2:

--- a/shared/utils/slices.go
+++ b/shared/utils/slices.go
@@ -69,3 +69,14 @@ func SliceToBoolMap(s []string) map[string]bool {
 	}
 	return v
 }
+
+// StringSliceDeleteEmpty removes empty strings from a string slice.
+func StringSliceDeleteEmpty(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}

--- a/shared/utils/slices.go
+++ b/shared/utils/slices.go
@@ -72,7 +72,7 @@ func SliceToBoolMap(s []string) map[string]bool {
 
 // StringSliceDeleteEmpty removes empty strings from a string slice.
 func StringSliceDeleteEmpty(s []string) []string {
-	var r []string
+	r := make([]string, 0)
 	for _, str := range s {
 		if str != "" {
 			r = append(r, str)

--- a/shared/utils/slices_test.go
+++ b/shared/utils/slices_test.go
@@ -68,3 +68,24 @@ func TestSliceToBoolMap(t *testing.T) {
 	assert.Equal(t, map[string]bool{}, SliceToBoolMap([]string{}))
 	assert.Equal(t, map[string]bool{}, SliceToBoolMap([]string{""}))
 }
+
+func TestStringSliceDeleteEmpty(t *testing.T) {
+	tests := []struct {
+		in  []string
+		out []string
+	}{{
+		in:  []string{"", "ab", "ab"},
+		out: []string{"ab", "ab"},
+	}, {
+		in:  []string{"", "ab", ""},
+		out: []string{"ab"},
+	}, {
+		in:  []string{""},
+		out: []string{},
+	}}
+
+	for _, tc := range tests {
+		exp := StringSliceDeleteEmpty(tc.in)
+		assert.EqualValues(t, tc.out, exp, "got '%#v', expects %#v", exp, tc.out)
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/3385