### PR TITLE
Apply `documentation`/`ui` label to corresponding renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,7 +37,7 @@
       "groupName": "docs npm deps non-major",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "matchFileNames": ["docs/**/package.json"],
+      "matchFileNames": ["docs/**/package.json"]
     },
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
@woodpecker-ci/maintainers Does somebody know whether this works?
I.e.: Will
https://github.com/woodpecker-ci/woodpecker/blob/053197c9261a589901f24cf89fe6cbcbf6cbec8c/.github/renovate.json#L30-L35
overwrite
https://github.com/woodpecker-ci/woodpecker/blob/053197c9261a589901f24cf89fe6cbcbf6cbec8c/.github/renovate.json#L20-L24
? Or are they extended?