### PR TITLE
Correctly prefer datasource env var over file content

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -224,7 +224,7 @@ var flags = append([]cli.Flag{
 	&cli.StringFlag{
 		EnvVars: []string{"WOODPECKER_DATABASE_DATASOURCE_FILE"},
 		Name:    "datasource-file",
-		Usage:   "database driver configuration stored in a file, if set will always be prefered",
+		Usage:   "database driver configuration stored in a file, if set will always be preferred over simple configuration string",
 	},
 	&cli.StringFlag{
 		EnvVars:  []string{"WOODPECKER_PROMETHEUS_AUTH_TOKEN"},

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -216,11 +216,15 @@ var flags = append([]cli.Flag{
 		Value:   "sqlite3",
 	},
 	&cli.StringFlag{
-		EnvVars:  []string{"WOODPECKER_DATABASE_DATASOURCE"},
-		Name:     "datasource",
-		Usage:    "database driver configuration string",
-		Value:    "woodpecker.sqlite",
-		FilePath: os.Getenv("WOODPECKER_DATABASE_DATASOURCE_FILE"),
+		EnvVars: []string{"WOODPECKER_DATABASE_DATASOURCE"},
+		Name:    "datasource",
+		Usage:   "database driver configuration string",
+		Value:   "woodpecker.sqlite",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_DATABASE_DATASOURCE_FILE"},
+		Name:    "datasource-file",
+		Usage:   "database driver configuration stored in a file, if set will always be prefered",
 	},
 	&cli.StringFlag{
 		EnvVars:  []string{"WOODPECKER_PROMETHEUS_AUTH_TOKEN"},

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -46,6 +46,14 @@ import (
 
 func setupStore(c *cli.Context) (store.Store, error) {
 	datasource := c.String("datasource")
+	if datasourceFile := c.String("datasource-file"); datasourceFile != "" {
+		value, err := os.ReadFile(datasourceFile)
+		if err != nil {
+			return nil, fmt.Errorf("cant read datasource file '%s': %w", datasourceFile, err)
+		}
+		datasource = strings.TrimSpace(string(value))
+	}
+
 	driver := c.String("driver")
 	xorm := store.XORM{
 		Log:     c.Bool("log-xorm"),


### PR DESCRIPTION
close  #3404

fixes https://github.com/woodpecker-ci/woodpecker/issues/3389