### PR TITLE
Add "Gradle Wrapper Validation" plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -179,6 +179,11 @@
       "name": "Kaniko",
       "docs": "https://raw.githubusercontent.com/woodpecker-ci/plugin-kaniko/main/docs.md",
       "verified": true
+    },
+    {
+      "name": "Gradle Wrapper Validation",
+      "docs": "https://codeberg.org/beaks/gradle-wrapper-validation/raw/branch/main/docs.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
This Woodpecker CI plugin validates the checksums of all Gradle Wrapper JAR files present in the repository and fails if any unknown Gradle Wrapper JAR files are found. It is a port of [gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action).