### PR TITLE
fix: Make sure to refresh access token when reading commit information

### DIFF
--- a/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
@@ -525,6 +525,8 @@ func (c *client) getUserAndRepo(ctx context.Context, r *model.Repo) (*model.User
 	}
 	log.Trace().Any("user", user).Msg("got user")
 
+	forge.Refresh(ctx, c, _store, user)
+
 	return user, repo, nil
 }
 


### PR DESCRIPTION
When receiving notification by webhook the forge tries to read information on the latest commit when constructing the pipeline. This requires a call to the Bitbucket API which again requires the access token to be up-to-date.