### PR TITLE
fix: plugin doc page not found

### DIFF
--- a/docs/src/components/HomepageFeatures.js
+++ b/docs/src/components/HomepageFeatures.js
@@ -23,7 +23,7 @@ const FeatureList = [
       <>
         Woodpecker uses docker containers to execute pipeline steps. If you need more than a normal docker image, you
         can create plugins to extend the pipeline features.{' '}
-        <a href="/docs/usage/plugins/plugins">How do plugins work?</a>
+        <a href="/docs/usage/plugins/overview">How do plugins work?</a>
       </>
     ),
   },


### PR DESCRIPTION
closes [The link on the main page does not work](https://github.com/woodpecker-ci/woodpecker/issues/3479)