### PR TITLE
Temp rename CI services to avoid duplicate name issues

### DIFF
--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -105,7 +105,7 @@ steps:
     image: *golang_image
     environment:
       - WOODPECKER_DATABASE_DRIVER=postgres
-      - WOODPECKER_DATABASE_DATASOURCE=host=postgres user=postgres dbname=postgres sslmode=disable
+      - WOODPECKER_DATABASE_DATASOURCE=host=sv-postgres user=postgres dbname=postgres sslmode=disable
     commands:
       - make test-server-datastore
     when: *when
@@ -116,7 +116,7 @@ steps:
     image: *golang_image
     environment:
       - WOODPECKER_DATABASE_DRIVER=mysql
-      - WOODPECKER_DATABASE_DATASOURCE=root@tcp(mysql:3306)/test?parseTime=true
+      - WOODPECKER_DATABASE_DATASOURCE=root@tcp(sv-mysql:3306)/test?parseTime=true
     commands:
       - make test-server-datastore
     when: *when

--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -141,7 +141,7 @@ steps:
     failure: ignore
 
 services:
-  postgres:
+  sv-postgres:
     image: docker.io/postgres:16
     ports: ['5432']
     environment:
@@ -149,7 +149,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     when: *when
 
-  mysql:
+  sv-mysql:
     image: docker.io/mysql:8.2.0
     ports: ['3306']
     environment:


### PR DESCRIPTION
Workaround for: https://github.com/woodpecker-ci/woodpecker/issues/3494