### PR TITLE
Temp pin golangci version in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ check-xgo: ## Check if xgo is installed
 
 install-tools: ## Install development tools
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.56.2 ; \
 	fi ; \
 	hash gofumpt > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go install mvdan.cc/gofumpt@latest; \


### PR DESCRIPTION
Looks like something is broken in v1.57.x, and I don't think that's something that can be fixed on the end-user side:

https://ci.woodpecker-ci.org/repos/3780/pipeline/14131/33

```
WARN [runner] Can't process result by autogenerated_exclude processor: can't filter issue result.Issue{FromLinter:"contextcheck", Text:"Function `Start$1->runCron` should pass the context parameter", Severity:"", SourceLines:[]string(nil), Replacement:(*result.Replacement)(nil), Pkg:(*packages.Package)(0xc001871980), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"", Offset:0, Line:0, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}: no file path for issue 
WARN [runner] Can't process result by nolint processor: can't filter issue result.Issue{FromLinter:"contextcheck", Text:"Function `Start$1->runCron` should pass the context parameter", Severity:"", SourceLines:[]string(nil), Replacement:(*result.Replacement)(nil), Pkg:(*packages.Package)(0xc001871980), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"", Offset:0, Line:0, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}: no file path for issue 
WARN [runner/source_code] Failed to get line 0 for file : failed to get file  lines cache: can't get file  bytes from cache: can't read file : open : no such file or directory 
```