### PR TITLE
Add option to set the local repository path to the cli command exec.

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -57,7 +57,12 @@ func run(c *cli.Context) error {
 
 func execDir(c *cli.Context, dir string) error {
 	// TODO: respect pipeline dependency
-	repoPath, _ := filepath.Abs(filepath.Dir(dir))
+	repoPath := c.String("repo-path")
+	if repoPath != "" {
+		repoPath, _ = filepath.Abs(repoPath)
+	} else {
+		repoPath, _ = filepath.Abs(filepath.Dir(dir))
+	}
 	if runtime.GOOS == "windows" {
 		repoPath = convertPathForWindows(repoPath)
 	}
@@ -79,7 +84,12 @@ func execDir(c *cli.Context, dir string) error {
 }
 
 func execFile(c *cli.Context, file string) error {
-	repoPath, _ := filepath.Abs(filepath.Dir(file))
+	repoPath := c.String("repo-path")
+	if repoPath != "" {
+		repoPath, _ = filepath.Abs(repoPath)
+	} else {
+		repoPath, _ = filepath.Abs(filepath.Dir(file))
+	}
 	if runtime.GOOS == "windows" {
 		repoPath = convertPathForWindows(repoPath)
 	}

--- a/cli/exec/flags.go
+++ b/cli/exec/flags.go
@@ -29,6 +29,11 @@ var flags = []cli.Flag{
 		Usage:   "run from local directory",
 		Value:   true,
 	},
+	&cli.StringFlag{
+		EnvVars: []string{"WOODPECKER_REPO_PATH"},
+		Name:    "repo-path",
+		Usage:   "path to local repository",
+	},
 	&cli.DurationFlag{
 		EnvVars: []string{"WOODPECKER_TIMEOUT"},
 		Name:    "timeout",

--- a/docs/versioned_docs/version-2.4/40-cli.md
+++ b/docs/versioned_docs/version-2.4/40-cli.md
@@ -280,6 +280,8 @@ execute a local pipeline
 
 **--repo-clone-url**="":
 
+**--repo-path**="": path to local repository
+
 **--repo-private**="":
 
 **--repo-remote-id**="":


### PR DESCRIPTION
 The cli command exec not handle in a coherent way the repository path when a directory or filename is given for the pipeline.

` woodpecker-cli exec [command options] [path/to/.woodpecker.yaml]`

If the path to the pipeline is a file in the `.woodpecker` directory, for example: `.woodpecker/pipeline.yaml`, 
the repository path will be: `.woodpecker`

If the path to the pipeline yaml is a directory with more than one level, for example `ci/woodpecker/`,
the repository path will be:  `ci`

In order not to break the old behavior we added a new option to put the root directory of the repository:
~~~
woodpecker-cli exec --local --repo-path . --pipeline-event manual .woodpecker/build.yml 
~~~
