### PR TITLE
Switch back to latest version of golangci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ ci:
   autofix_prs: true
   autoupdate_branch: ''
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-  autoupdate_schedule: monthly
+  autoupdate_schedule: quarterly
   # NB: hadolint not included in pre-commit.ci
   skip: [check-hooks-apply, check-useless-excludes, hadolint, prettier]
   submodules: false

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ check-xgo: ## Check if xgo is installed
 
 install-tools: ## Install development tools
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2 ; \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest ; \
 	fi ; \
 	hash gofumpt > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go install mvdan.cc/gofumpt@latest; \


### PR DESCRIPTION
Reverts: https://github.com/woodpecker-ci/woodpecker/pull/3520

As we have enabled pre-commit updates in renovate now, I've increased the `autoupdate_schedule` of pre-commit to the max value (there is no way to disable it).