### PR TITLE
Add flag to only access public repositories on GitHub

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -322,6 +322,12 @@ var flags = append([]cli.Flag{
 		Usage:   "github server address",
 		Value:   "https://github.com",
 	},
+	&cli.BoolFlag{
+		EnvVars: []string{"WOODPECKER_GITHUB_ONLY_PUBLIC"},
+		Name:    "github-only-public",
+		Usage:   "github tokens should only get access to public repos",
+		Value:   false,
+	},
 	&cli.StringFlag{
 		EnvVars:  []string{"WOODPECKER_GITHUB_CLIENT"},
 		Name:     "github-client",

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -200,6 +200,7 @@ func setupGitHub(c *cli.Context) (forge.Forge, error) {
 		Secret:     c.String("github-secret"),
 		SkipVerify: c.Bool("github-skip-verify"),
 		MergeRef:   c.Bool("github-merge-ref"),
+		OnlyPublic: c.Bool("github-only-public"),
 	}
 	log.Trace().Msgf("forge (github) opts: %#v", opts)
 	return github.New(opts)

--- a/docs/docs/30-administration/11-forges/20-github.md
+++ b/docs/docs/30-administration/11-forges/20-github.md
@@ -81,3 +81,9 @@ Read the value for `WOODPECKER_GITHUB_SECRET` from the specified filepath.
 > Default: `false`
 
 Configure if SSL verification should be skipped.
+
+### `WOODPECKER_GITHUB_ONLY_PUBLIC`
+
+> Default: `false`
+
+Configures the GitHub OAuth client to only obtain a token that can manage public repositories.


### PR DESCRIPTION
This PR adds the `WOODPECKER_GITHUB_ONLY_PUBLIC` which instructs the GitHub client to only obtain clients which have permissions to operate on public repositories.

We have tested these changes on our own instance and can report that at least the basic functionality works.  
Someone please feel free to chime in if this breaks any other functionality of Woodpecker we weren't aware of.

Rationale: This follows the principle of least privilege. We run a public Woodpecker instance for an open-source project. We never intend to run it on anything but public repositories.  
The standard permissions are rather scary though.

Read and write access to all public and private data including settings, deploy keys, code, collaboration invites, etc.

By restricting access to the following scopes:

- `admin:repo_hook`
- `repo:status`
- `user:email`
- `read:org`

we can still have all the functionality Woodpecker needs (manage webhooks, update repository statuses, etc.) without the scary settings such as invites, writing to all aspects, etc.