### PR TITLE
Allow to disable deployments

### DIFF
--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -4048,6 +4048,9 @@ const docTemplate = `{
                 "active": {
                     "type": "boolean"
                 },
+                "allow_deploy": {
+                    "type": "boolean"
+                },
                 "allow_pr": {
                     "type": "boolean"
                 },
@@ -4123,6 +4126,9 @@ const docTemplate = `{
         "RepoPatch": {
             "type": "object",
             "properties": {
+                "allow_deploy": {
+                    "type": "boolean"
+                },
                 "allow_pr": {
                     "type": "boolean"
                 },

--- a/docs/docs/20-usage/71-project-settings.md
+++ b/docs/docs/20-usage/71-project-settings.md
@@ -18,11 +18,11 @@ Enables handling webhook's pull request event. If disabled, then pipeline won't 
 
 ## Allow deployments
 
-Allows you to start a pipeline with `deploy` event from a succeeded pipeline.
+Enables a pipeline to be started with the `deploy` event from a successful pipeline.
 
 :::danger
-Only enable this option if you trust all users that have push access to your repository.
-Otherwise these users are able to steal secrets only available to `deploy` events.
+Only activate this option if you trust all users who have push access to your repository.
+Otherwise, these users will be able to steal secrets that are only available for `deploy` events.
 :::
 
 ## Protected

--- a/docs/docs/20-usage/71-project-settings.md
+++ b/docs/docs/20-usage/71-project-settings.md
@@ -16,6 +16,15 @@ Your Version-Control-System will notify Woodpecker about events via webhooks. If
 
 Enables handling webhook's pull request event. If disabled, then pipeline won't run for pull requests.
 
+## Allow deployments
+
+Allows you to start a pipeline with `deploy` event from a succeeded pipeline.
+
+:::danger
+Only enable this option if you trust all users that have push access to your repository.
+Otherwise these users are able to steal secrets only available to `deploy` events.
+:::
+
 ## Protected
 
 Every pipeline initiated by an webhook event needs to be approved by a project members with push permissions before being executed.

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -407,23 +407,22 @@ func PostPipeline(c *gin.Context) {
 	refreshUserToken(c, user)
 
 	// make Deploy overridable
-	pl.Deploy = c.DefaultQuery("deploy_to", pl.Deploy)
 
 	// make Event overridable to deploy
 	// TODO refactor to use own proper API for deploy
 	if event, ok := c.GetQuery("event"); ok {
-		// only allow deploy from push, tag and release
-		if pl.Event != model.EventPush && pl.Event != model.EventTag && pl.Event != model.EventRelease {
-			_ = c.AbortWithError(http.StatusBadRequest, fmt.Errorf("can only deploy push, tag and release pipelines"))
-			return
-		}
-
 		pl.Event = model.WebhookEvent(event)
-
 		if pl.Event != model.EventDeploy {
 			_ = c.AbortWithError(http.StatusBadRequest, model.ErrInvalidWebhookEvent)
 			return
 		}
+
+		if !repo.AllowDeploy {
+			_ = c.AbortWithError(http.StatusForbidden, fmt.Errorf("repo does not allow deployments"))
+			return
+		}
+
+		pl.Deploy = c.DefaultQuery("deploy_to", pl.Deploy)
 	}
 
 	// Read query string parameters into pipelineParams, exclude reserved params

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -86,6 +86,7 @@ func PostRepo(c *gin.Context) {
 	} else {
 		repo = from
 		repo.AllowPull = true
+		repo.AllowDeploy = false
 		repo.NetrcOnlyTrusted = true
 		repo.CancelPreviousPipelineEvents = server.Config.Pipeline.DefaultCancelPreviousPipelineEvents
 	}
@@ -222,6 +223,9 @@ func PatchRepo(c *gin.Context) {
 
 	if in.AllowPull != nil {
 		repo.AllowPull = *in.AllowPull
+	}
+	if in.AllowDeploy != nil {
+		repo.AllowDeploy = *in.AllowDeploy
 	}
 	if in.IsGated != nil {
 		repo.IsGated = *in.IsGated

--- a/server/model/repo.go
+++ b/server/model/repo.go
@@ -44,6 +44,7 @@ type Repo struct {
 	IsGated                      bool           `json:"gated"                           xorm:"repo_gated"`
 	IsActive                     bool           `json:"active"                          xorm:"repo_active"`
 	AllowPull                    bool           `json:"allow_pr"                        xorm:"repo_allow_pr"`
+	AllowDeploy                  bool           `json:"allow_deploy"                    xorm:"repo_allow_deploy"`
 	Config                       string         `json:"config_file"                     xorm:"varchar(500) 'repo_config_path'"`
 	Hash                         string         `json:"-"                               xorm:"varchar(500) 'repo_hash'"`
 	Perm                         *Perm          `json:"-"                               xorm:"-"`
@@ -112,6 +113,7 @@ type RepoPatch struct {
 	Timeout                      *int64          `json:"timeout,omitempty"`
 	Visibility                   *string         `json:"visibility,omitempty"`
 	AllowPull                    *bool           `json:"allow_pr,omitempty"`
+	AllowDeploy                  *bool           `json:"allow_deploy,omitempty"`
 	CancelPreviousPipelineEvents *[]WebhookEvent `json:"cancel_previous_pipeline_events"`
 	NetrcOnlyTrusted             *bool           `json:"netrc_only_trusted"`
 } //	@name RepoPatch

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -92,7 +92,7 @@
         },
         "allow_deploy": {
           "allow": "Allow deployments",
-          "desc": "Allow deployments from succeeded pipelines. Only use if you trust all users with push access."
+          "desc": "Allow deployments from successful pipelines. Only use if you trust all users with push access."
         },
         "protected": {
           "protected": "Protected",

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -90,6 +90,10 @@
           "allow": "Allow Pull Requests",
           "desc": "Pipelines can run on pull requests."
         },
+        "allow_deploy": {
+          "allow": "Allow deployments",
+          "desc": "Allow deployments from succeeded pipelines. Only use if you trust all users with push access."
+        },
         "protected": {
           "protected": "Protected",
           "desc": "Every pipeline needs to be approved before being executed."

--- a/web/src/components/repo/settings/GeneralTab.vue
+++ b/web/src/components/repo/settings/GeneralTab.vue
@@ -30,6 +30,11 @@
           :description="$t('repo.settings.general.allow_pr.desc')"
         />
         <Checkbox
+          v-model="repoSettings.allow_deploy"
+          :label="$t('repo.settings.general.allow_deploy.allow')"
+          :description="$t('repo.settings.general.allow_deploy.desc')"
+        />
+        <Checkbox
           v-model="repoSettings.gated"
           :label="$t('repo.settings.general.protected.protected')"
           :description="$t('repo.settings.general.protected.desc')"
@@ -132,8 +137,9 @@ function loadRepoSettings() {
     gated: repo.value.gated,
     trusted: repo.value.trusted,
     allow_pr: repo.value.allow_pr,
+    allow_deploy: repo.value.allow_deploy,
     cancel_previous_pipeline_events: repo.value.cancel_previous_pipeline_events || [],
-    netrc_only_trusted: repo.value.netrc_only_trusted,
+    netrc_only_trusted: repo.value.netrc_only_trusted
   };
 }
 

--- a/web/src/components/repo/settings/GeneralTab.vue
+++ b/web/src/components/repo/settings/GeneralTab.vue
@@ -139,7 +139,7 @@ function loadRepoSettings() {
     allow_pr: repo.value.allow_pr,
     allow_deploy: repo.value.allow_deploy,
     cancel_previous_pipeline_events: repo.value.cancel_previous_pipeline_events || [],
-    netrc_only_trusted: repo.value.netrc_only_trusted
+    netrc_only_trusted: repo.value.netrc_only_trusted,
   };
 }
 

--- a/web/src/lib/api/types/repo.ts
+++ b/web/src/lib/api/types/repo.ts
@@ -56,6 +56,8 @@ export type Repo = {
   // Whether pull requests should trigger a pipeline.
   allow_pr: boolean;
 
+  allow_deploy: boolean;
+
   config_file: string;
 
   visibility: RepoVisibility;
@@ -84,6 +86,7 @@ export type RepoSettings = Pick<
   | 'trusted'
   | 'gated'
   | 'allow_pr'
+  | 'allow_deploy'
   | 'cancel_previous_pipeline_events'
   | 'netrc_only_trusted'
 >;

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -45,9 +45,7 @@
               @click="restartPipeline"
             />
             <Button
-              v-if="
-                pipeline.status === 'success' && repo.allow_deploy
-              "
+              v-if="pipeline.status === 'success' && repo.allow_deploy"
               class="flex-shrink-0"
               :text="$t('repo.pipeline.actions.deploy')"
               @click="showDeployPipelinePopup = true"

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -46,8 +46,7 @@
             />
             <Button
               v-if="
-                pipeline.status === 'success' &&
-                (pipeline.event === 'push' || pipeline.event === 'tag' || pipeline.event === 'release')
+                pipeline.status === 'success' && repo.allow_deploy
               "
               class="flex-shrink-0"
               :text="$t('repo.pipeline.actions.deploy')"


### PR DESCRIPTION
…but if they're enabled, allow for all events. Also add warning that you should only enable it if you trust the users with push access.

closes #3559