### PR TITLE
Temp exclude huh/spinner from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,10 @@
   "extends": ["github>woodpecker-ci/renovate-config"],
   "packageRules": [
     {
+      "matchPackageNames": ["github.com/charmbracelet/huh/spinner"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["docker-compose"],
       "matchFileNames": ["docker-compose.gitpod.yml"],
       "addLabels": ["devx"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,12 @@
   "extends": ["github>woodpecker-ci/renovate-config"],
   "packageRules": [
     {
+      "matchCurrentVersion": "<1.0.0",
+      "matchPackageNames": ["github.com/distribution/reference"],
+      "matchUpdateTypes": ["major", "minor"],
+      "dependencyDashboardApproval": true
+    },
+    {
       "matchPackageNames": ["github.com/charmbracelet/huh/spinner"],
       "enabled": false
     },


### PR DESCRIPTION
Ref: https://github.com/woodpecker-ci/woodpecker/pull/3585

There seems to be an issue in renovate when updating modules from a subdirectory of another module. I'll create an upstream issue/discussion later.