### PR TITLE
Avoid brances in group names

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,12 +8,12 @@
       "addLabels": ["devx"]
     },
     {
-      "groupName": "golang (lang)",
+      "groupName": "golang-lang",
       "matchPackagePatterns": ["^golang$", "xgo"],
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
-      "groupName": "golang (packages)",
+      "groupName": "golang-packages",
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch"]
     },


### PR DESCRIPTION
Removes brackets from group names, as these are also used for branch names and brackets lead to problems with tab completion on the cli.