### PR TITLE
Add Twine plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -194,6 +194,11 @@
       "name": "Forge deployments",
       "docs": "https://raw.githubusercontent.com/woodpecker-ci/plugin-deployments/main/docs.md",
       "verified": true
+    },
+    {
+      "name": "Twine",
+      "docs": "https://gitea.elara.ws/music-kraken/plugin-twine/raw/branch/master/docs.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
This PR adds my plugin for the [Twine](https://github.com/pypa/twine/) tool. It lets users upload python projects to PyPi.