### PR TITLE
Add PipelineListsOptions to woodpecker-go

### DIFF
--- a/cli/deploy/deploy.go
+++ b/cli/deploy/deploy.go
@@ -78,7 +78,7 @@ func deploy(c *cli.Context) error {
 	var number int64
 	if pipelineArg == "last" {
 		// Fetch the pipeline number from the last pipeline
-		pipelines, berr := client.PipelineList(repoID)
+		pipelines, berr := client.PipelineList(repoID, woodpecker.PipelineListsOptions{})
 		if berr != nil {
 			return berr
 		}

--- a/cli/pipeline/list.go
+++ b/cli/pipeline/list.go
@@ -22,6 +22,7 @@ import (
 
 	"go.woodpecker-ci.org/woodpecker/v2/cli/common"
 	"go.woodpecker-ci.org/woodpecker/v2/cli/internal"
+	"go.woodpecker-ci.org/woodpecker/v2/woodpecker-go/woodpecker"
 )
 
 //nolint:gomnd
@@ -63,7 +64,7 @@ func pipelineList(c *cli.Context) error {
 		return err
 	}
 
-	pipelines, err := client.PipelineList(repoID)
+	pipelines, err := client.PipelineList(repoID, woodpecker.PipelineListsOptions{})
 	if err != nil {
 		return err
 	}

--- a/woodpecker-go/woodpecker/interface.go
+++ b/woodpecker-go/woodpecker/interface.go
@@ -85,7 +85,7 @@ type Client interface {
 
 	// PipelineList returns a list of recent pipelines for the
 	// the specified repository.
-	PipelineList(repoID int64) ([]*Pipeline, error)
+	PipelineList(repoID int64, opt PipelineListsOptions) ([]*Pipeline, error)
 
 	// PipelineQueue returns a list of enqueued pipelines.
 	PipelineQueue() ([]*Feed, error)

--- a/woodpecker-go/woodpecker/list_options.go
+++ b/woodpecker-go/woodpecker/list_options.go
@@ -1,0 +1,25 @@
+package woodpecker
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ListOptions represents the options for the Woodpecker API pagination.
+type ListOptions struct {
+	Page    int
+	PerPage int
+}
+
+// getURLQuery returns the query string for the ListOptions.
+func (o ListOptions) getURLQuery() url.Values {
+	query := make(url.Values)
+	if o.Page > 0 {
+		query.Add("page", fmt.Sprintf("%d", o.Page))
+	}
+	if o.PerPage > 0 {
+		query.Add("perPage", fmt.Sprintf("%d", o.PerPage))
+	}
+
+	return query
+}

--- a/woodpecker-go/woodpecker/list_options_test.go
+++ b/woodpecker-go/woodpecker/list_options_test.go
@@ -1,0 +1,44 @@
+package woodpecker
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListOptions_getURLQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     ListOptions
+		expected url.Values
+	}{
+		{
+			name:     "no options",
+			opts:     ListOptions{},
+			expected: url.Values{},
+		},
+		{
+			name:     "with page",
+			opts:     ListOptions{Page: 2},
+			expected: url.Values{"page": {"2"}},
+		},
+		{
+			name:     "with per page",
+			opts:     ListOptions{PerPage: 10},
+			expected: url.Values{"perPage": {"10"}},
+		},
+		{
+			name:     "with page and per page",
+			opts:     ListOptions{Page: 3, PerPage: 20},
+			expected: url.Values{"page": {"3"}, "perPage": {"20"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.opts.getURLQuery()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/woodpecker-go/woodpecker/repo_test.go
+++ b/woodpecker-go/woodpecker/repo_test.go
@@ -1,0 +1,88 @@
+package woodpecker
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipelineList(t *testing.T) {
+	tests := []struct {
+		name           string
+		fixtureHandler http.HandlerFunc
+		opts           PipelineListsOptions
+		wantErr        bool
+		expectedLength int
+		expectedIDs    []int64
+	}{
+		{
+			name: "success",
+			fixtureHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/repos/123/pipelines?after=2023-01-15T00%3A00%3A00Z&before=2023-01-16T00%3A00%3A00Z&page=2&perPage=10", r.URL.RequestURI())
+
+				w.WriteHeader(http.StatusOK)
+				_, err := fmt.Fprint(w, `[{"id":1},{"id":2}]`)
+				assert.NoError(t, err)
+			},
+			opts: PipelineListsOptions{
+				ListOptions: ListOptions{
+					Page:    2,
+					PerPage: 10,
+				},
+				Before: time.Date(2023, 1, 16, 0, 0, 0, 0, time.UTC),
+				After:  time.Date(2023, 1, 15, 0, 0, 0, 0, time.UTC),
+			},
+			expectedLength: 2,
+			expectedIDs:    []int64{1, 2},
+		},
+		{
+			name: "empty ListOptions",
+			fixtureHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/repos/123/pipelines", r.URL.RequestURI())
+
+				w.WriteHeader(http.StatusOK)
+				_, err := fmt.Fprint(w, `[{"id":1},{"id":2}]`)
+				assert.NoError(t, err)
+			},
+			opts:           PipelineListsOptions{},
+			expectedLength: 2,
+			expectedIDs:    []int64{1, 2},
+		},
+		{
+			name: "error",
+			fixtureHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			opts:    PipelineListsOptions{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(tt.fixtureHandler)
+			defer ts.Close()
+
+			client := NewClient(ts.URL, http.DefaultClient)
+
+			pipelines, err := client.PipelineList(123, tt.opts)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, pipelines)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Len(t, pipelines, tt.expectedLength)
+			for i, id := range tt.expectedIDs {
+				assert.Equal(t, id, pipelines[i].ID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I fear that's a breaking change... It's a bit pain IMO that we can not version the go lib independent of the server.