### PR TITLE
Compare to pipeline created timestamp while using before/after filter

### DIFF
--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -59,11 +59,11 @@ func (s storage) GetPipelineList(repo *model.Repo, p *model.ListOptions, f *mode
 
 	if f != nil {
 		if f.After != 0 {
-			cond = cond.And(builder.Gt{"pipeline_started": f.After})
+			cond = cond.And(builder.Gt{"pipeline_created": f.After})
 		}
 
 		if f.Before != 0 {
-			cond = cond.And(builder.Lt{"pipeline_started": f.Before})
+			cond = cond.And(builder.Lt{"pipeline_created": f.Before})
 		}
 	}
 


### PR DESCRIPTION
`pipeline_started` and `pipeline_finished` can be `0` for various reasons and therefor is unreliable for timestamp filters. Using `pipeline_created` might be the better option anyway.