### PR TITLE
Add discord announcements

### DIFF
--- a/.woodpecker/social.yaml
+++ b/.woodpecker/social.yaml
@@ -26,7 +26,7 @@ steps:
   - name: discord
     image: docker.io/appleboy/drone-discord:1.3.1
     settings:
-      webhook_id: TODO
+      webhook_id: 1236558396820295711
       webhook_token:
         from_secret: discord_token
       message: '**{{ build.tag }}** was released: <https://github.com/woodpecker-ci/woodpecker/releases/tag/{{ build.tag }}>'

--- a/.woodpecker/social.yaml
+++ b/.woodpecker/social.yaml
@@ -6,7 +6,7 @@ when:
   - event: tag
 
 steps:
-  mastodon-toot:
+  - name: mastodon-toot
     image: docker.io/woodpeckerci/plugin-mastodon-post
     settings:
       server: https://floss.social
@@ -16,10 +16,17 @@ steps:
       ai_token:
         from_secret: openai_token
       ai_prompt: |
-        We want to present the next version of our app on Twitter.
+        We want to present the next version of our app on Mastodon.
         Therefore we want to post a catching text, so users will know why they should
         update to the newest version. If there is no special feature included
         just summarize the changes in a few sentences. Use #WoodpeckerCI, #release and
         additional fitting hashtags and emojis to make the post more appealing.
 
         The changelog entry: {{ changelog }}
+  - name: discord
+    image: docker.io/appleboy/drone-discord:1.3.1
+    settings:
+      webhook_id: TODO
+      webhook_token:
+        from_secret: discord_token
+      message: "**{{ build.tag }}** was released: <https://github.com/woodpecker-ci/woodpecker/releases/tag/{{ build.tag }}>"

--- a/.woodpecker/social.yaml
+++ b/.woodpecker/social.yaml
@@ -18,9 +18,10 @@ steps:
       ai_prompt: |
         We want to present the next version of our app on Mastodon.
         Therefore we want to post a catching text, so users will know why they should
-        update to the newest version. If there is no special feature included
-        just summarize the changes in a few sentences. Use #WoodpeckerCI, #release and
-        additional fitting hashtags and emojis to make the post more appealing.
+        update to the newest version. Highlight the most special features. If there is no special feature 
+        included just summarize the changes in a few sentences. The whole text should not be longer than 240
+        characters. Avoid naming contributors from. Use #WoodpeckerCI, #release and 
+        additional fitting hashtags and emojis to make the post more appealing
 
         The changelog entry: {{ changelog }}
   - name: discord

--- a/.woodpecker/social.yaml
+++ b/.woodpecker/social.yaml
@@ -18,9 +18,9 @@ steps:
       ai_prompt: |
         We want to present the next version of our app on Mastodon.
         Therefore we want to post a catching text, so users will know why they should
-        update to the newest version. Highlight the most special features. If there is no special feature 
+        update to the newest version. Highlight the most special features. If there is no special feature
         included just summarize the changes in a few sentences. The whole text should not be longer than 240
-        characters. Avoid naming contributors from. Use #WoodpeckerCI, #release and 
+        characters. Avoid naming contributors from. Use #WoodpeckerCI, #release and
         additional fitting hashtags and emojis to make the post more appealing
 
         The changelog entry: {{ changelog }}

--- a/.woodpecker/social.yaml
+++ b/.woodpecker/social.yaml
@@ -29,4 +29,4 @@ steps:
       webhook_id: TODO
       webhook_token:
         from_secret: discord_token
-      message: "**{{ build.tag }}** was released: <https://github.com/woodpecker-ci/woodpecker/releases/tag/{{ build.tag }}>"
+      message: '**{{ build.tag }}** was released: <https://github.com/woodpecker-ci/woodpecker/releases/tag/{{ build.tag }}>'


### PR DESCRIPTION
see https://github.com/woodpecker-ci/woodpecker/issues/1689

@woodpecker-ci/owner We need a webhook and the ID/token for the `announcements` channel.