### PR TITLE
Clarify info on failing workflows/Steps

### DIFF
--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -1,6 +1,10 @@
 # Workflow syntax
 
-The workflow section defines a list of steps to build, test and deploy your code. Steps are executed serially, in the order in which they are defined. If a step returns a non-zero exit code, the workflow and therefore all other workflows and the pipeline immediately aborts and returns a failure status.
+The workflow section defines a list of steps to build, test and deploy your code. Steps are executed serially, in the order in which they are defined.
+
+:::note
+Should a step exit with a non-zero code, the workflow and all remaining steps will abort and return a failure status. An exception to this rule are steps with a [`status: [failure]`](#status) condition, which will execute them on a failed run.
+:::
 
 Example steps:
 

--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -1,11 +1,9 @@
 # Workflow syntax
 
-The workflow section defines a list of steps to build, test and deploy your code. Steps are executed serially, in the order in which they are defined.
-
-If a step returns a non-zero exit code, the workflow and therefore the whole pipeline immediately aborts and returns a failure status.
+The Workflow section defines a list of steps to build, test and deploy your code. The steps are executed serially in the order in which they are defined. If a step returns a non-zero exit code, the workflow and therefore the entire pipeline terminates immediately and returns an error status.
 
 :::note
-An exception to this rule are steps with a [`status: [failure]`](#status) condition, which will execute them on a failed run.
+An exception to this rule are steps with a [`status: [failure]`](#status) condition, which ensures that they are executed in the case of a failed run.
 :::
 
 Example steps:

--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -2,8 +2,10 @@
 
 The workflow section defines a list of steps to build, test and deploy your code. Steps are executed serially, in the order in which they are defined.
 
+If a step returns a non-zero exit code, the workflow and therefore the whole pipeline immediately aborts and returns a failure status.
+
 :::note
-Should a step exit with a non-zero code, the workflow and all remaining steps will abort and return a failure status. An exception to this rule are steps with a [`status: [failure]`](#status) condition, which will execute them on a failed run.
+An exception to this rule are steps with a [`status: [failure]`](#status) condition, which will execute them on a failed run.
 :::
 
 Example steps:


### PR DESCRIPTION
I felt like the info at the start of the workflow syntax page was a bit misleading.
It mentioned that a failed step cancels the full workflow, not mentioning that steps with a `status: [failed]` will actually execute under such circumstances.

I've replaced that part with a `:::note` block, informing about this special case, while also linking to the option itself.
Hope this is a good change.