### PR TITLE
Remove broken link to gobook.io

### DIFF
--- a/docs/docs/92-development/06-guides.md
+++ b/docs/docs/92-development/06-guides.md
@@ -3,7 +3,6 @@
 ## ORM
 
 Woodpecker uses [Xorm](https://xorm.io/) as ORM for the database connection.
-You can find its documentation at [gobook.io/read/gitea.com/xorm](https://gobook.io/read/gitea.com/xorm/manual-en-US/).
 
 ## Add a new migration
 


### PR DESCRIPTION
We link to https://xorm.io already, and the official docs can be found at https://xorm.io/docs/.