### PR TITLE
Pin golang container to minor release

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
       WOODPECKER_DEV_WWW_PROXY: http://localhost:8010
       WOODPECKER_BACKEND_DOCKER_NETWORK: ci_default
     init: |
-      GO_VERSION=1.21.5
+      GO_VERSION=1.22
       rm -rf ~/go
       curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar xzs -C ~/
       go mod tidy

--- a/.woodpecker/binaries.yaml
+++ b/.woodpecker/binaries.yaml
@@ -4,8 +4,7 @@ when:
 variables:
   - &golang_image 'docker.io/golang:1.22'
   - &node_image 'docker.io/node:22-alpine'
-  - &xgo_image 'docker.io/techknowlogick/xgo:go-1.22'
-  - &xgo_version 'go-1.21.2'
+  - &xgo_image 'docker.io/techknowlogick/xgo:go-1.22.x'
 
 steps:
   build-web:
@@ -34,7 +33,6 @@ steps:
     environment:
       PLATFORMS: linux|arm64/v8;linux|amd64;windows|amd64
       TAGS: bindata sqlite sqlite_unlock_notify netgo
-      XGO_VERSION: *xgo_version
       TARGZ: '1'
 
   build-tarball:

--- a/.woodpecker/binaries.yaml
+++ b/.woodpecker/binaries.yaml
@@ -2,9 +2,9 @@ when:
   event: tag
 
 variables:
-  - &golang_image 'docker.io/golang:1.22.2'
+  - &golang_image 'docker.io/golang:1.22'
   - &node_image 'docker.io/node:22-alpine'
-  - &xgo_image 'docker.io/techknowlogick/xgo:go-1.22.2'
+  - &xgo_image 'docker.io/techknowlogick/xgo:go-1.22'
   - &xgo_version 'go-1.21.2'
 
 steps:

--- a/.woodpecker/docker.yaml
+++ b/.woodpecker/docker.yaml
@@ -1,7 +1,7 @@
 variables:
-  - &golang_image 'docker.io/golang:1.22.2'
+  - &golang_image 'docker.io/golang:1.22'
   - &node_image 'docker.io/node:22-alpine'
-  - &xgo_image 'docker.io/techknowlogick/xgo:go-1.22.2'
+  - &xgo_image 'docker.io/techknowlogick/xgo:go-1.22'
   - &xgo_version 'go-1.21.2'
   - &buildx_plugin 'docker.io/woodpeckerci/plugin-docker-buildx:3.2.1'
   - &platforms_release 'linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64,linux/ppc64le,linux/riscv64,linux/s390x,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64'

--- a/.woodpecker/docker.yaml
+++ b/.woodpecker/docker.yaml
@@ -1,8 +1,7 @@
 variables:
   - &golang_image 'docker.io/golang:1.22'
   - &node_image 'docker.io/node:22-alpine'
-  - &xgo_image 'docker.io/techknowlogick/xgo:go-1.22'
-  - &xgo_version 'go-1.21.2'
+  - &xgo_image 'docker.io/techknowlogick/xgo:go-1.22.x'
   - &buildx_plugin 'docker.io/woodpeckerci/plugin-docker-buildx:3.2.1'
   - &platforms_release 'linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64,linux/ppc64le,linux/riscv64,linux/s390x,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64'
   - &platforms_server 'linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,linux/riscv64'
@@ -98,7 +97,6 @@ steps:
     environment:
       PLATFORMS: linux|amd64
       TAGS: bindata sqlite sqlite_unlock_notify netgo
-      XGO_VERSION: *xgo_version
     when:
       - event: pull_request
         evaluate: 'CI_COMMIT_PULL_REQUEST_LABELS contains "build_pr_images"'
@@ -121,7 +119,6 @@ steps:
     environment:
       PLATFORMS: linux|arm/v7;linux|arm64/v8;linux|amd64;linux|ppc64le;linux|riscv64
       TAGS: bindata sqlite sqlite_unlock_notify netgo
-      XGO_VERSION: *xgo_version
     when:
       branch:
         - ${CI_REPO_DEFAULT_BRANCH}

--- a/.woodpecker/docs.yaml
+++ b/.woodpecker/docs.yaml
@@ -1,5 +1,5 @@
 variables:
-  - &golang_image 'docker.io/golang:1.21.5'
+  - &golang_image 'docker.io/golang:1.22'
   - &node_image 'docker.io/node:21-alpine'
   - &alpine_image 'docker.io/alpine:3.19'
   - path: &when_path

--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -1,5 +1,5 @@
 variables:
-  - &golang_image 'docker.io/golang:1.21.5'
+  - &golang_image 'docker.io/golang:1.22'
   - &when
     - path: &when_path # related config files
         - '.woodpecker/test.yaml'


### PR DESCRIPTION
Creates a lot of noise and I don't really see a benefit to pin it to patch releases.