### PR TITLE
Make retry count of config fetching form forge configure

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -276,7 +276,7 @@ var flags = append([]cli.Flag{
 	&cli.UintFlag{
 		EnvVars: []string{"WOODPECKER_FORGE_RETRY"},
 		Name:    "forge-retry",
-		Usage:   "How many retries of fetching the Woodpecker configuration from a Forge are done before we fail",
+		Usage:   "How many retries of fetching the Woodpecker configuration from a forge are done before we fail",
 		Value:   3,
 	},
 	&cli.Int64Flag{

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -276,7 +276,7 @@ var flags = append([]cli.Flag{
 	&cli.UintFlag{
 		EnvVars: []string{"WOODPECKER_FORGE_RETRY"},
 		Name:    "forge-retry",
-		Usage:   "How many trys of fetching the the Woodpecker configuration from a Forge are done before we fail",
+		Usage:   "How many retries of fetching the Woodpecker configuration from a Forge are done before we fail",
 		Value:   3,
 	},
 	&cli.Int64Flag{

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -273,6 +273,12 @@ var flags = append([]cli.Flag{
 		Usage:   "how many seconds before timeout when fetching the Woodpecker configuration from a Forge",
 		Value:   time.Second * 3,
 	},
+	&cli.UintFlag{
+		EnvVars: []string{"WOODPECKER_FORGE_RETRY"},
+		Name:    "forge-retry",
+		Usage:   "How many trys of fetching the the Woodpecker configuration from a Forge are done before we fail",
+		Value:   3,
+	},
 	&cli.Int64Flag{
 		EnvVars: []string{"WOODPECKER_LIMIT_MEM_SWAP"},
 		Name:    "limit-mem-swap",

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -525,6 +525,12 @@ Specify a configuration service endpoint, see [Configuration Extension](./100-ex
 
 Specify timeout when fetching the Woodpecker configuration from forge. See <https://pkg.go.dev/time#ParseDuration> for syntax reference.
 
+### `WOODPECKER_FORGE_RETRY`
+
+> Default: 3
+
+Specify how many retries of fetching the Woodpecker configuration from a Forge are done before we fail.
+
 ### `WOODPECKER_ENABLE_SWAGGER`
 
 > Default: true

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -529,7 +529,7 @@ Specify timeout when fetching the Woodpecker configuration from forge. See <http
 
 > Default: 3
 
-Specify how many retries of fetching the Woodpecker configuration from a Forge are done before we fail.
+Specify how many retries of fetching the Woodpecker configuration from a forge are done before we fail.
 
 ### `WOODPECKER_ENABLE_SWAGGER`
 

--- a/server/services/config/combined_test.go
+++ b/server/services/config/combined_test.go
@@ -221,7 +221,7 @@ func TestFetchFromConfigService(t *testing.T) {
 
 			f.On("Netrc", mock.Anything, mock.Anything).Return(&model.Netrc{Machine: "mock", Login: "mock", Password: "mock"}, nil)
 
-			forgeFetcher := config.NewForge(time.Second * 3)
+			forgeFetcher := config.NewForge(time.Second*3, 3)
 			configFetcher := config.NewCombined(forgeFetcher, httpFetcher)
 			files, err := configFetcher.Fetch(
 				context.Background(),

--- a/server/services/config/forge.go
+++ b/server/services/config/forge.go
@@ -38,13 +38,13 @@ type forgeFetcher struct {
 	retryCount uint
 }
 
-func NewForge(timeout time.Duration, retrys uint) Service {
-	if retrys == 0 {
-		retrys = defaultRetryCount
+func NewForge(timeout time.Duration, retries uint) Service {
+	if retries == 0 {
+		retries = defaultRetryCount
 	}
 	return &forgeFetcher{
 		timeout:    timeout,
-		retryCount: retrys,
+		retryCount: retries,
 	}
 }
 

--- a/server/services/config/forge.go
+++ b/server/services/config/forge.go
@@ -29,19 +29,12 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/shared/constant"
 )
 
-const (
-	defaultRetryCount uint = 3
-)
-
 type forgeFetcher struct {
 	timeout    time.Duration
 	retryCount uint
 }
 
 func NewForge(timeout time.Duration, retries uint) Service {
-	if retries == 0 {
-		retries = defaultRetryCount
-	}
 	return &forgeFetcher{
 		timeout:    timeout,
 		retryCount: retries,

--- a/server/services/config/forge.go
+++ b/server/services/config/forge.go
@@ -30,16 +30,21 @@ import (
 )
 
 const (
-	forgeFetchingRetryCount = 3
+	defaultRetryCount uint = 3
 )
 
 type forgeFetcher struct {
-	timeout time.Duration
+	timeout    time.Duration
+	retryCount uint
 }
 
-func NewForge(timeout time.Duration) Service {
+func NewForge(timeout time.Duration, retrys uint) Service {
+	if retrys == 0 {
+		retrys = defaultRetryCount
+	}
 	return &forgeFetcher{
-		timeout: timeout,
+		timeout:    timeout,
+		retryCount: retrys,
 	}
 }
 
@@ -58,7 +63,7 @@ func (f *forgeFetcher) Fetch(ctx context.Context, forge forge.Forge, user *model
 	}
 
 	// try to fetch multiple times
-	for i := 0; i < forgeFetchingRetryCount; i++ {
+	for i := 0; i < int(f.retryCount); i++ {
 		files, err = ffc.fetch(ctx, strings.TrimSpace(repo.Config))
 		if err != nil {
 			log.Trace().Err(err).Msgf("%d. try failed", i+1)

--- a/server/services/config/forge_test.go
+++ b/server/services/config/forge_test.go
@@ -306,7 +306,8 @@ func TestFetch(t *testing.T) {
 			f.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("directory not found"))
 
 			configFetcher := config.NewForge(
-				time.Second * 3,
+				time.Second*3,
+				3,
 			)
 			files, err := configFetcher.Fetch(
 				context.Background(),

--- a/server/services/manager.go
+++ b/server/services/manager.go
@@ -72,13 +72,18 @@ func NewManager(c *cli.Context, store store.Store, setupForge SetupForge) (Manag
 		return nil, err
 	}
 
+	configService, err := setupConfigService(c, signaturePrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
 	return &manager{
 		signaturePrivateKey: signaturePrivateKey,
 		signaturePublicKey:  signaturePublicKey,
 		store:               store,
 		secret:              setupSecretService(store),
 		registry:            setupRegistryService(store, c.String("docker-config")),
-		config:              setupConfigService(c, signaturePrivateKey),
+		config:              configService,
 		environment:         environment.Parse(c.StringSlice("environment")),
 		forgeCache:          ttlcache.New(ttlcache.WithDisableTouchOnHit[int64, forge.Forge]()),
 		setupForge:          setupForge,

--- a/server/services/setup.go
+++ b/server/services/setup.go
@@ -58,8 +58,8 @@ func setupSecretService(store store.Store) secret.Service {
 
 func setupConfigService(c *cli.Context, privateSignatureKey crypto.PrivateKey) config.Service {
 	timeout := c.Duration("forge-timeout")
-	retrys := c.Uint("forge-retry")
-	configFetcher := config.NewForge(timeout, retrys)
+	retries := c.Uint("forge-retry")
+	configFetcher := config.NewForge(timeout, retries)
 
 	if endpoint := c.String("config-service-endpoint"); endpoint != "" {
 		httpFetcher := config.NewHTTP(endpoint, privateSignatureKey)

--- a/server/services/setup.go
+++ b/server/services/setup.go
@@ -58,7 +58,8 @@ func setupSecretService(store store.Store) secret.Service {
 
 func setupConfigService(c *cli.Context, privateSignatureKey crypto.PrivateKey) config.Service {
 	timeout := c.Duration("forge-timeout")
-	configFetcher := config.NewForge(timeout)
+	retrys := c.Uint("forge-retry")
+	configFetcher := config.NewForge(timeout, retrys)
 
 	if endpoint := c.String("config-service-endpoint"); endpoint != "" {
 		httpFetcher := config.NewHTTP(endpoint, privateSignatureKey)


### PR DESCRIPTION
add `WOODPECKER_FORGE_RETRY` to change retry count of config fetching from forge