### PR TITLE
Setting for empty commits on path condition

### DIFF
--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -402,7 +402,7 @@ when:
 
 You can use [glob patterns](https://github.com/bmatcuk/doublestar#patterns) to match the changed files and specify if the step should run if a file matching that pattern has been changed `include` or if some files have **not** been changed `exclude`.
 
-The behavior on an empty commit can be set using `fail_on_empty`. A value of `false`(default) will evaluate this condition to true.
+The behavior on an empty commit can be set using `on_empty`.
 
 ```yaml
 when:
@@ -410,11 +410,11 @@ when:
       include: ['.woodpecker/*.yaml', '*.ini']
       exclude: ['*.md', 'docs/**']
       ignore_message: '[ALL]'
-      fail_on_empty: false
+      on_empty: true
 ```
 
 :::info
-Passing a defined ignore-message like `[ALL]` inside the commit message will ignore all path conditions and the `fail_on_empty` setting.
+Passing a defined ignore-message like `[ALL]` inside the commit message will ignore all path conditions and the `on_empty` setting.
 :::
 
 #### `evaluate`

--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -402,16 +402,19 @@ when:
 
 You can use [glob patterns](https://github.com/bmatcuk/doublestar#patterns) to match the changed files and specify if the step should run if a file matching that pattern has been changed `include` or if some files have **not** been changed `exclude`.
 
+The behavior on an empty commit can be set using `fail_on_empty`. A value of `false`(default) will evaluate this condition to true.
+
 ```yaml
 when:
   - path:
       include: ['.woodpecker/*.yaml', '*.ini']
       exclude: ['*.md', 'docs/**']
       ignore_message: '[ALL]'
+      fail_on_empty: false
 ```
 
 :::info
-Passing a defined ignore-message like `[ALL]` inside the commit message will ignore all path conditions.
+Passing a defined ignore-message like `[ALL]` inside the commit message will ignore all path conditions and the `fail_on_empty` setting.
 :::
 
 #### `evaluate`

--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -69,8 +69,8 @@ type (
 	Path struct {
 		Include       []string
 		Exclude       []string
-		IgnoreMessage string `yaml:"ignore_message,omitempty"`
-		FailOnEmpty   bool   `yaml:"fail_on_empty,omitempty"`
+		IgnoreMessage string                 `yaml:"ignore_message,omitempty"`
+		OnEmpty       yamlBaseTypes.BoolTrue `yaml:"on_empty,omitempty"`
 	}
 )
 
@@ -332,7 +332,7 @@ func (c *Path) UnmarshalYAML(value *yaml.Node) error {
 		Include       yamlBaseTypes.StringOrSlice `yaml:"include,omitempty"`
 		Exclude       yamlBaseTypes.StringOrSlice `yaml:"exclude,omitempty"`
 		IgnoreMessage string                      `yaml:"ignore_message,omitempty"`
-		FailOnEmpty   bool                        `yaml:"fail_on_empty,omitempty"`
+		OnEmpty       yamlBaseTypes.BoolTrue      `yaml:"on_empty,omitempty"`
 	}{}
 
 	var out2 yamlBaseTypes.StringOrSlice
@@ -340,11 +340,9 @@ func (c *Path) UnmarshalYAML(value *yaml.Node) error {
 	err1 := value.Decode(&out1)
 	err2 := value.Decode(&out2)
 
-	fmt.Println(out1.FailOnEmpty)
-
 	c.Exclude = out1.Exclude
 	c.IgnoreMessage = out1.IgnoreMessage
-	c.FailOnEmpty = out1.FailOnEmpty
+	c.OnEmpty = out1.OnEmpty
 	c.Include = append( //nolint:gocritic
 		out1.Include,
 		out2...,
@@ -366,9 +364,9 @@ func (c *Path) Match(v []string, message string) bool {
 		return true
 	}
 
-	// return value based on 'fail_on_empty', if there are no commit files (empty commit)
+	// return value based on 'on_empty', if there are no commit files (empty commit)
 	if len(v) == 0 {
-		return !c.FailOnEmpty
+		return c.OnEmpty.Bool()
 	}
 
 	if len(c.Exclude) > 0 && c.Excludes(v) {

--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -70,6 +70,7 @@ type (
 		Include       []string
 		Exclude       []string
 		IgnoreMessage string `yaml:"ignore_message,omitempty"`
+		FailOnEmpty   bool   `yaml:"fail_on_empty,omitempty"`
 	}
 )
 
@@ -331,6 +332,7 @@ func (c *Path) UnmarshalYAML(value *yaml.Node) error {
 		Include       yamlBaseTypes.StringOrSlice `yaml:"include,omitempty"`
 		Exclude       yamlBaseTypes.StringOrSlice `yaml:"exclude,omitempty"`
 		IgnoreMessage string                      `yaml:"ignore_message,omitempty"`
+		FailOnEmpty   bool                        `yaml:"fail_on_empty,omitempty"`
 	}{}
 
 	var out2 yamlBaseTypes.StringOrSlice
@@ -338,8 +340,11 @@ func (c *Path) UnmarshalYAML(value *yaml.Node) error {
 	err1 := value.Decode(&out1)
 	err2 := value.Decode(&out2)
 
+	fmt.Println(out1.FailOnEmpty)
+
 	c.Exclude = out1.Exclude
 	c.IgnoreMessage = out1.IgnoreMessage
+	c.FailOnEmpty = out1.FailOnEmpty
 	c.Include = append( //nolint:gocritic
 		out1.Include,
 		out2...,
@@ -361,9 +366,9 @@ func (c *Path) Match(v []string, message string) bool {
 		return true
 	}
 
-	// always match if there are no commit files (empty commit)
+	// return value based on 'fail_on_empty', if there are no commit files (empty commit)
 	if len(v) == 0 {
-		return true
+		return !c.FailOnEmpty
 	}
 
 	if len(c.Exclude) > 0 && c.Excludes(v) {

--- a/pipeline/frontend/yaml/constraint/constraint_test.go
+++ b/pipeline/frontend/yaml/constraint/constraint_test.go
@@ -261,14 +261,14 @@ func TestConstraintList(t *testing.T) {
 			want: true,
 		},
 		{
-			conf: "{ include: [ README.md ], fail_on_empty: false }",
-			with: []string{},
-			want: true,
-		},
-		{
-			conf: "{ include: [ README.md ], fail_on_empty: true }",
+			conf: "{ include: [ README.md ], on_empty: false }",
 			with: []string{},
 			want: false,
+		},
+		{
+			conf: "{ include: [ README.md ], on_empty: true }",
+			with: []string{},
+			want: true,
 		},
 	}
 	for _, test := range testdata {

--- a/pipeline/frontend/yaml/constraint/constraint_test.go
+++ b/pipeline/frontend/yaml/constraint/constraint_test.go
@@ -260,6 +260,16 @@ func TestConstraintList(t *testing.T) {
 			with: []string{},
 			want: true,
 		},
+		{
+			conf: "{ include: [ README.md ], fail_on_empty: false }",
+			with: []string{},
+			want: true,
+		},
+		{
+			conf: "{ include: [ README.md ], fail_on_empty: true }",
+			with: []string{},
+			want: false,
+		},
 	}
 	for _, test := range testdata {
 		c := parseConstraintPath(t, test.conf)

--- a/pipeline/frontend/yaml/linter/schema/.woodpecker/test-when.yaml
+++ b/pipeline/frontend/yaml/linter/schema/.woodpecker/test-when.yaml
@@ -119,6 +119,7 @@ steps:
         include: ['.woodpecker/*.yml', '*.ini']
         exclude: ['*.md', 'docs/**']
         ignore_message: '[ALL]'
+        fail_on_empty: false
 
   when-repo:
     image: alpine

--- a/pipeline/frontend/yaml/linter/schema/.woodpecker/test-when.yaml
+++ b/pipeline/frontend/yaml/linter/schema/.woodpecker/test-when.yaml
@@ -119,7 +119,7 @@ steps:
         include: ['.woodpecker/*.yml', '*.ini']
         exclude: ['*.md', 'docs/**']
         ignore_message: '[ALL]'
-        fail_on_empty: false
+        on_empty: true
 
   when-repo:
     image: alpine

--- a/pipeline/frontend/yaml/linter/schema/schema.json
+++ b/pipeline/frontend/yaml/linter/schema/schema.json
@@ -289,7 +289,7 @@
                 "ignore_message": {
                   "type": "string"
                 },
-                "fail_on_empty": {
+                "on_empty": {
                   "type": "boolean"
                 }
               },
@@ -497,7 +497,7 @@
                 "ignore_message": {
                   "type": "string"
                 },
-                "fail_on_empty": {
+                "on_empty": {
                   "type": "boolean"
                 }
               },

--- a/pipeline/frontend/yaml/linter/schema/schema.json
+++ b/pipeline/frontend/yaml/linter/schema/schema.json
@@ -288,6 +288,9 @@
                 },
                 "ignore_message": {
                   "type": "string"
+                },
+                "fail_on_empty": {
+                  "type": "boolean"
                 }
               },
               "additionalProperties": false
@@ -493,6 +496,9 @@
                 },
                 "ignore_message": {
                   "type": "string"
+                },
+                "fail_on_empty": {
+                  "type": "boolean"
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
Allow to set the behavior on empty commits evaluating `path` conditions.

default value is true, to preserve current behavior.