### PR TITLE
Add documentation for KUBERNETES_SERVICE_HOST in Agent

### DIFF
--- a/docs/docs/30-administration/22-backends/40-kubernetes.md
+++ b/docs/docs/30-administration/22-backends/40-kubernetes.md
@@ -231,6 +231,12 @@ See [this issue](https://github.com/woodpecker-ci/woodpecker/issues/2510) for mo
 
 These env vars can be set in the `env:` sections of the agent.
 
+### `KUBERNETES_SERVICE_HOST`
+
+> Default: empty
+
+Address of the Kubernetes API server to connect to. If running Agent within Kubernetes, this will already be set by Kubernetes and require no further configuration. If not running in a Kubernetes pod, you need to set it.
+
 ### `WOODPECKER_BACKEND_K8S_NAMESPACE`
 
 > Default: `woodpecker`


### PR DESCRIPTION
This PR adds some documentation that was missing (from my perspective as a new user). I am running the Agent outside of Kubernetes, and therefore didn't have the benefit of KUBERNETES_SERVICE_HOST already being set. Hopefully this documentation addition can help other newcomers get up and running without also needing to drill into the actual code :)

P.S. I know that this env var isn't a `WOODPECKER_BACKEND_K8S_`-prefixed one, but I figured that this was still the appropriate place to document it. Please let me know if there's a better place to put this information!