### PR TITLE
Bump trivy plugin version and remove unused variable

### DIFF
--- a/.woodpecker/securityscan.yaml
+++ b/.woodpecker/securityscan.yaml
@@ -6,8 +6,7 @@ when:
       - renovate/*
 
 variables:
-  - &trivy_image aquasec/trivy:0.46.1
-  - &trivy_plugin woodpeckerci/plugin-trivy:1.0.1
+  - &trivy_plugin woodpeckerci/plugin-trivy:1.1.0
 
 steps:
   backend:


### PR DESCRIPTION
trivy version is inferred from the one bundled in the plugin image.

trivy 0.52.0 also adds support for pnpm lockfile v9 and should get rid of all false-positive security scan WF failures.