### PR TITLE
docs: Fix spelling

### DIFF
--- a/docs/docs/92-development/01-getting-started.md
+++ b/docs/docs/92-development/01-getting-started.md
@@ -44,9 +44,9 @@ For dependency installation (`node_modules`) of UI and documentation of Woodpeck
 Woodpecker uses [`pre-commit`](https://pre-commit.com/) to allow you to easily autofix your code.
 To apply it during local development, take a look at [`pre-commit`s documentation](https://pre-commit.com/#usage).
 
-### Create an `.env` file with your development configuration
+### Create a `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/docs/92-development/01-getting-started.md
+++ b/docs/docs/92-development/01-getting-started.md
@@ -44,9 +44,9 @@ For dependency installation (`node_modules`) of UI and documentation of Woodpeck
 Woodpecker uses [`pre-commit`](https://pre-commit.com/) to allow you to easily autofix your code.
 To apply it during local development, take a look at [`pre-commit`s documentation](https://pre-commit.com/#usage).
 
-### Create a `.env` file with your development configuration
+### Create an `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` in the root of the Woodpecker project and add any need config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/versioned_docs/version-1.0/92-development/01-getting-started.md
+++ b/docs/versioned_docs/version-1.0/92-development/01-getting-started.md
@@ -37,9 +37,9 @@ Install [Node.js (>=14)](https://nodejs.org/en/download/) if you want to build W
 
 For dependencies installation (node_modules) for the UI and documentation of Woodpecker the package-manager pnpm is used. The installation of pnpm is described by [this guide](https://pnpm.io/installation).
 
-### Create a `.env` file with your development configuration
+### Create an `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` in the root of the Woodpecker project and add any need config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/versioned_docs/version-1.0/92-development/01-getting-started.md
+++ b/docs/versioned_docs/version-1.0/92-development/01-getting-started.md
@@ -37,9 +37,9 @@ Install [Node.js (>=14)](https://nodejs.org/en/download/) if you want to build W
 
 For dependencies installation (node_modules) for the UI and documentation of Woodpecker the package-manager pnpm is used. The installation of pnpm is described by [this guide](https://pnpm.io/installation).
 
-### Create an `.env` file with your development configuration
+### Create a `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/versioned_docs/version-2.4/92-development/01-getting-started.md
+++ b/docs/versioned_docs/version-2.4/92-development/01-getting-started.md
@@ -44,9 +44,9 @@ For dependency installation (`node_modules`) of UI and documentation of Woodpeck
 Woodpecker uses [`pre-commit`](https://pre-commit.com/) to allow you to easily autofix your code.
 To apply it during local development, take a look at [`pre-commit`s documentation](https://pre-commit.com/#usage).
 
-### Create an `.env` file with your development configuration
+### Create a `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/versioned_docs/version-2.4/92-development/01-getting-started.md
+++ b/docs/versioned_docs/version-2.4/92-development/01-getting-started.md
@@ -44,9 +44,9 @@ For dependency installation (`node_modules`) of UI and documentation of Woodpeck
 Woodpecker uses [`pre-commit`](https://pre-commit.com/) to allow you to easily autofix your code.
 To apply it during local development, take a look at [`pre-commit`s documentation](https://pre-commit.com/#usage).
 
-### Create a `.env` file with your development configuration
+### Create an `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` in the root of the Woodpecker project and add any need config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/versioned_docs/version-2.5/92-development/01-getting-started.md
+++ b/docs/versioned_docs/version-2.5/92-development/01-getting-started.md
@@ -44,9 +44,9 @@ For dependency installation (`node_modules`) of UI and documentation of Woodpeck
 Woodpecker uses [`pre-commit`](https://pre-commit.com/) to allow you to easily autofix your code.
 To apply it during local development, take a look at [`pre-commit`s documentation](https://pre-commit.com/#usage).
 
-### Create an `.env` file with your development configuration
+### Create a `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/versioned_docs/version-2.5/92-development/01-getting-started.md
+++ b/docs/versioned_docs/version-2.5/92-development/01-getting-started.md
@@ -44,9 +44,9 @@ For dependency installation (`node_modules`) of UI and documentation of Woodpeck
 Woodpecker uses [`pre-commit`](https://pre-commit.com/) to allow you to easily autofix your code.
 To apply it during local development, take a look at [`pre-commit`s documentation](https://pre-commit.com/#usage).
 
-### Create a `.env` file with your development configuration
+### Create an `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` in the root of the Woodpecker project and add any need config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/versioned_docs/version-2.6/92-development/01-getting-started.md
+++ b/docs/versioned_docs/version-2.6/92-development/01-getting-started.md
@@ -44,9 +44,9 @@ For dependency installation (`node_modules`) of UI and documentation of Woodpeck
 Woodpecker uses [`pre-commit`](https://pre-commit.com/) to allow you to easily autofix your code.
 To apply it during local development, take a look at [`pre-commit`s documentation](https://pre-commit.com/#usage).
 
-### Create an `.env` file with your development configuration
+### Create a `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 

--- a/docs/versioned_docs/version-2.6/92-development/01-getting-started.md
+++ b/docs/versioned_docs/version-2.6/92-development/01-getting-started.md
@@ -44,9 +44,9 @@ For dependency installation (`node_modules`) of UI and documentation of Woodpeck
 Woodpecker uses [`pre-commit`](https://pre-commit.com/) to allow you to easily autofix your code.
 To apply it during local development, take a look at [`pre-commit`s documentation](https://pre-commit.com/#usage).
 
-### Create a `.env` file with your development configuration
+### Create an `.env` file with your development configuration
 
-Similar to the environment variables you can set for your production setup of Woodpecker, you can create a `.env` in the root of the Woodpecker project and add any need config to it.
+Similar to the environment variables you can set for your production setup of Woodpecker, you can create an `.env` file in the root of the Woodpecker project and add any needed config to it.
 
 A common config for debugging would look like this:
 


### PR DESCRIPTION
Use "an" instead of "a" for "`.env` file" and use the correct tense.