### PR TITLE
Let agents continuously report their health

### DIFF
--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -210,7 +210,6 @@ func run(c *cli.Context, backends []types.Backend) error {
 			err := client.ReportHealth(ctx)
 			if err != nil {
 				log.Err(err).Msg("failed to report health")
-				return
 			}
 
 			<-time.After(time.Second * 10)


### PR DESCRIPTION
The agent should continue to report the health status as long as it got not terminated.

extracted from #2951

Right now there exist the case where you have ''shadow agents" who pull tasks even if they don't report healthy...