### PR TITLE
Make it possible to run pipeline on arm64

### DIFF
--- a/.woodpecker/binaries.yaml
+++ b/.woodpecker/binaries.yaml
@@ -5,7 +5,7 @@ when:
     path: Makefile
 
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 variables:
   - &golang_image 'docker.io/golang:1.22'

--- a/.woodpecker/binaries.yaml
+++ b/.woodpecker/binaries.yaml
@@ -4,6 +4,9 @@ when:
     branch: ${CI_REPO_DEFAULT_BRANCH}
     path: Makefile
 
+labels:
+  platform: linux/arm64
+
 variables:
   - &golang_image 'docker.io/golang:1.22'
   - &node_image 'docker.io/node:22-alpine'

--- a/.woodpecker/docker.yaml
+++ b/.woodpecker/docker.yaml
@@ -1,3 +1,6 @@
+labels:
+  platform: linux/arm64
+
 variables:
   - &golang_image 'docker.io/golang:1.22'
   - &node_image 'docker.io/node:22-alpine'

--- a/.woodpecker/docker.yaml
+++ b/.woodpecker/docker.yaml
@@ -1,5 +1,5 @@
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 variables:
   - &golang_image 'docker.io/golang:1.22'

--- a/.woodpecker/docs.yaml
+++ b/.woodpecker/docs.yaml
@@ -1,5 +1,5 @@
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 variables:
   - &golang_image 'docker.io/golang:1.22'

--- a/.woodpecker/docs.yaml
+++ b/.woodpecker/docs.yaml
@@ -1,3 +1,6 @@
+labels:
+  platform: linux/arm64
+
 variables:
   - &golang_image 'docker.io/golang:1.22'
   - &node_image 'docker.io/node:21-alpine'

--- a/.woodpecker/release-helper.yaml
+++ b/.woodpecker/release-helper.yaml
@@ -1,5 +1,5 @@
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 steps:
   release-helper:

--- a/.woodpecker/release-helper.yaml
+++ b/.woodpecker/release-helper.yaml
@@ -1,3 +1,6 @@
+labels:
+  platform: linux/arm64
+
 steps:
   release-helper:
     image: woodpeckerci/plugin-ready-release-go:1.2.0

--- a/.woodpecker/securityscan.yaml
+++ b/.woodpecker/securityscan.yaml
@@ -5,6 +5,9 @@ when:
       - ${CI_REPO_DEFAULT_BRANCH}
       - renovate/*
 
+labels:
+  platform: linux/arm64
+
 variables:
   - &trivy_plugin docker.io/woodpeckerci/plugin-trivy:1.1.0
 

--- a/.woodpecker/securityscan.yaml
+++ b/.woodpecker/securityscan.yaml
@@ -6,7 +6,7 @@ when:
       - renovate/*
 
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 variables:
   - &trivy_plugin docker.io/woodpeckerci/plugin-trivy:1.1.0

--- a/.woodpecker/social.yaml
+++ b/.woodpecker/social.yaml
@@ -6,7 +6,7 @@ when:
   - event: tag
 
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 steps:
   - name: mastodon-toot

--- a/.woodpecker/social.yaml
+++ b/.woodpecker/social.yaml
@@ -5,6 +5,9 @@ depends_on:
 when:
   - event: tag
 
+labels:
+  platform: linux/arm64
+
 steps:
   - name: mastodon-toot
     image: docker.io/woodpeckerci/plugin-mastodon-post

--- a/.woodpecker/static.yaml
+++ b/.woodpecker/static.yaml
@@ -4,7 +4,7 @@ when:
     branch: renovate/*
 
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 steps:
   - name: lint-editorconfig

--- a/.woodpecker/static.yaml
+++ b/.woodpecker/static.yaml
@@ -3,6 +3,9 @@ when:
   - event: push
     branch: renovate/*
 
+labels:
+  platform: linux/arm64
+
 steps:
   - name: lint-editorconfig
     image: docker.io/mstruebing/editorconfig-checker:v3.0.3

--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -1,5 +1,5 @@
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 variables:
   - &golang_image 'docker.io/golang:1.22'

--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -1,3 +1,6 @@
+labels:
+  platform: linux/arm64
+
 variables:
   - &golang_image 'docker.io/golang:1.22'
   - &when

--- a/.woodpecker/web.yaml
+++ b/.woodpecker/web.yaml
@@ -5,6 +5,9 @@ when:
       - release/*
       - renovate/*
 
+labels:
+  platform: linux/arm64
+
 variables:
   - &node_image 'docker.io/node:22-alpine'
   - &when

--- a/.woodpecker/web.yaml
+++ b/.woodpecker/web.yaml
@@ -6,7 +6,7 @@ when:
       - renovate/*
 
 labels:
-  platform: linux/arm64
+  platform: linux/aarch64
 
 variables:
   - &node_image 'docker.io/node:22-alpine'


### PR DESCRIPTION
test pipeline to run on arm64

```
Architecture:           aarch64
  CPU op-mode(s):       32-bit, 64-bit
  Byte Order:           Little Endian
CPU(s):                 8
  On-line CPU(s) list:  0-7
Vendor ID:              ARM
  Model name:           Neoverse-N1
    Model:              1
    Thread(s) per core: 1
    Core(s) per socket: 8
    Socket(s):          1
    Stepping:           r3p1
    BogoMIPS:           50.00
    Flags:              fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
```

## TODOs

- [ ] binaries
  - [ ] cross-compile-server: [fail](https://ci.woodpecker-ci.org/repos/3780/pipeline/7366/10) -> https://github.com/techknowlogick/xgo/issues/213
- [ ] docker
  - [ ] cross-compile-server: [fail](https://ci.woodpecker-ci.org/repos/3780/pipeline/7366/20) -> https://github.com/techknowlogick/xgo/issues/213
- [ ] docs
  - [ ] deploy-preview [error](https://ci.woodpecker-ci.org/repos/3780/pipeline/18788/17)
- [x] securityscan:  [works](https://ci.woodpecker-ci.org/repos/3780/pipeline/7363/46)
- [x] static [works](https://ci.woodpecker-ci.org/repos/3780/pipeline/18788/22)
- [x] test
  - [x] lint-editorconfig: ~~[fail](https://ci.woodpecker-ci.org/repos/3780/pipeline/7361/27)~~ -> works after image was updated on dockerhub
  - [x] codecov: fail ... will be removed
  - [x] mysql: [failed](https://ci.woodpecker-ci.org/repos/3780/pipeline/7365/42) -> service-mysql does not have arm64 image
- [x] web: [works](https://ci.woodpecker-ci.org/repos/3780/pipeline/7363/46)
