### PR TITLE
Add updated, merged and declined events to bb webhook activation

### DIFF
--- a/server/forge/bitbucket/bitbucket.go
+++ b/server/forge/bitbucket/bitbucket.go
@@ -313,7 +313,7 @@ func (c *config) Activate(ctx context.Context, u *model.User, r *model.Repo, lin
 	return c.newClient(ctx, u).CreateHook(r.Owner, r.Name, &internal.Hook{
 		Active: true,
 		Desc:   rawURL.Host,
-		Events: []string{"repo:push", "pullrequest:created"},
+		Events: []string{"repo:push", "pullrequest:created", "pullrequest:updated", "pullrequest:fulfilled", "pullrequest:rejected"},
 		URL:    link,
 	})
 }


### PR DESCRIPTION
## Description
Fix Bitbucket wehbook activation. Added updated, merged, and declined events to Bitbucket webhook activation. The Woodpecker `pull_request` event is not correctly triggered without the updated, merged, and declined events. The user has to change the webhook repository by repository manually. 