### PR TITLE
Use Bitbucket PR title for pipeline message

### DIFF
--- a/server/forge/bitbucket/convert.go
+++ b/server/forge/bitbucket/convert.go
@@ -178,7 +178,7 @@ func convertPullHook(from *internal.PullRequestHook) *model.Pipeline {
 		),
 		ForgeURL:  from.PullRequest.Links.HTML.Href,
 		Branch:    from.PullRequest.Source.Branch.Name,
-		Message:   from.PullRequest.Desc,
+		Message:   from.PullRequest.Title,
 		Avatar:    from.Actor.Links.Avatar.Href,
 		Author:    from.Actor.Login,
 		Sender:    from.Actor.Login,

--- a/server/forge/bitbucket/convert_test.go
+++ b/server/forge/bitbucket/convert_test.go
@@ -131,7 +131,7 @@ func Test_helper(t *testing.T) {
 			hook.PullRequest.Source.Repo.FullName = "baz/bar"
 			hook.PullRequest.Source.Commit.Hash = "c8411d7"
 			hook.PullRequest.Links.HTML.Href = "https://bitbucket.org/foo/bar/pulls/5"
-			hook.PullRequest.Desc = "updated README"
+			hook.PullRequest.Title = "updated README"
 			hook.PullRequest.Updated = time.Now()
 
 			pipeline := convertPullHook(hook)
@@ -143,7 +143,7 @@ func Test_helper(t *testing.T) {
 			g.Assert(pipeline.ForgeURL).Equal(hook.PullRequest.Links.HTML.Href)
 			g.Assert(pipeline.Ref).Equal("refs/heads/change")
 			g.Assert(pipeline.Refspec).Equal("change:main")
-			g.Assert(pipeline.Message).Equal(hook.PullRequest.Desc)
+			g.Assert(pipeline.Message).Equal(hook.PullRequest.Title)
 			g.Assert(pipeline.Timestamp).Equal(hook.PullRequest.Updated.Unix())
 		})
 


### PR DESCRIPTION
## Description
Right now the Pull Requests workflows are using the pipeline description. Identifying which pull request triggered the workflow is difficult because the description does not always match the PR title. Change the PR pipeline to use the PR title as the workflow title.