### PR TITLE
Fix BB PR pipeline ref

### DIFF
--- a/server/forge/bitbucket/convert.go
+++ b/server/forge/bitbucket/convert.go
@@ -171,7 +171,7 @@ func convertPullHook(from *internal.PullRequestHook) *model.Pipeline {
 	pipeline := &model.Pipeline{
 		Event:  event,
 		Commit: from.PullRequest.Source.Commit.Hash,
-		Ref:    fmt.Sprintf("refs/heads/%s", from.PullRequest.Source.Branch.Name),
+		Ref:    fmt.Sprintf("refs/pull-requests/%d/from", from.PullRequest.ID),
 		Refspec: fmt.Sprintf("%s:%s",
 			from.PullRequest.Source.Branch.Name,
 			from.PullRequest.Dest.Branch.Name,

--- a/server/forge/bitbucket/convert_test.go
+++ b/server/forge/bitbucket/convert_test.go
@@ -133,6 +133,7 @@ func Test_helper(t *testing.T) {
 			hook.PullRequest.Links.HTML.Href = "https://bitbucket.org/foo/bar/pulls/5"
 			hook.PullRequest.Desc = "updated README"
 			hook.PullRequest.Updated = time.Now()
+			hook.PullRequest.ID = 1
 
 			pipeline := convertPullHook(hook)
 			g.Assert(pipeline.Event).Equal(model.EventPull)
@@ -141,7 +142,7 @@ func Test_helper(t *testing.T) {
 			g.Assert(pipeline.Commit).Equal(hook.PullRequest.Source.Commit.Hash)
 			g.Assert(pipeline.Branch).Equal(hook.PullRequest.Source.Branch.Name)
 			g.Assert(pipeline.ForgeURL).Equal(hook.PullRequest.Links.HTML.Href)
-			g.Assert(pipeline.Ref).Equal("refs/heads/change")
+			g.Assert(pipeline.Ref).Equal("refs/pull-requests/1/from")
 			g.Assert(pipeline.Refspec).Equal("change:main")
 			g.Assert(pipeline.Message).Equal(hook.PullRequest.Desc)
 			g.Assert(pipeline.Timestamp).Equal(hook.PullRequest.Updated.Unix())


### PR DESCRIPTION
## Description
To set the `CI_COMMIT_PULL_REQUEST` environment variable Woodpecker uses the following regexp:

https://github.com/woodpecker-ci/woodpecker/blob/61f4c6a54097a82a3cbdc2ceee2131ab2cc0d011/pipeline/frontend/metadata/environment.go#L137
https://github.com/woodpecker-ci/woodpecker/blob/61f4c6a54097a82a3cbdc2ceee2131ab2cc0d011/pipeline/frontend/metadata/environment.go#L29

The environment variable returns a blank string because the regexp can't find an integer. Fix the reference using the pull request ID.

## Test  
The workflow reference link successfully redirects the user to the PR.