### PR TITLE
cspell: ignore all Go files generated by protobuf

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -230,7 +230,7 @@
     "Makefile",
     "flake.nix",
     "go.mod",
-    "pipeline/rpc/proto/woodpecker.pb.go",
+    "**/*.pb.go",
     "server/store/datastore/migration/**/*",
     "web/components.d.ts",
     "web/src/assets/locales/**/*",


### PR DESCRIPTION
Following on this failure:

https://ci.woodpecker-ci.org/repos/3780/pipeline/19677/21#L17

As one protobuf-generated file was already ignored, all the other ones probably should be there too.