### PR TITLE
Read long log lines from file storage correctly

### DIFF
--- a/agent/logger.go
+++ b/agent/logger.go
@@ -26,12 +26,6 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/rpc"
 )
 
-const (
-	// Store not more than 1mb in a log-line as 4mb is the limit of a grpc message
-	// and log-lines needs to be parsed by the browsers later on.
-	maxLogLineLength = 1024 * 1024 // 1mb
-)
-
 func (r *Runner) createLogger(_logger zerolog.Logger, uploads *sync.WaitGroup, workflow *rpc.Workflow) pipeline.Logger {
 	return func(step *backend.Step, rc io.ReadCloser) error {
 		defer rc.Close()
@@ -50,7 +44,7 @@ func (r *Runner) createLogger(_logger zerolog.Logger, uploads *sync.WaitGroup, w
 		logger.Debug().Msg("log stream opened")
 
 		logStream := log.NewLineWriter(r.client, step.UUID, secrets...)
-		if err := log.CopyLineByLine(logStream, rc, maxLogLineLength); err != nil {
+		if err := log.CopyLineByLine(logStream, rc, pipeline.MaxLogLineLength); err != nil {
 			logger.Error().Err(err).Msg("copy limited logStream part")
 		}
 

--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -281,8 +281,7 @@ func convertPathForWindows(path string) string {
 	return filepath.ToSlash(path)
 }
 
-const maxLogLineLength = 1024 * 1024 // 1mb
 var defaultLogger = pipeline.Logger(func(step *backend_types.Step, rc io.ReadCloser) error {
 	logWriter := NewLineWriter(step.Name, step.UUID)
-	return pipelineLog.CopyLineByLine(logWriter, rc, maxLogLineLength)
+	return pipelineLog.CopyLineByLine(logWriter, rc, pipeline.MaxLogLineLength)
 })

--- a/pipeline/const.go
+++ b/pipeline/const.go
@@ -14,4 +14,10 @@
 
 package pipeline
 
-const ExitCodeKilled int = 137
+const (
+	ExitCodeKilled int = 137
+
+	// Store no more than 1mb in a log-line as 4mb is the limit of a grpc message
+	// and log-lines needs to be parsed by the browsers later on.
+	MaxLogLineLength int = 1 * 1024 * 1024 // 1mb
+)

--- a/server/services/log/file/file.go
+++ b/server/services/log/file/file.go
@@ -8,8 +8,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"go.woodpecker-ci.org/woodpecker/v2/pipeline"
 	"go.woodpecker-ci.org/woodpecker/v2/server/model"
 	"go.woodpecker-ci.org/woodpecker/v2/server/services/log"
+)
+
+const (
+	// base64 overhead + space for other JSON fields (just to be safe)
+	maxLineLength int = (pipeline.MaxLogLineLength/3)*4 + (64 * 1024)
 )
 
 type logStore struct {
@@ -43,7 +49,10 @@ func (l logStore) LogFind(step *model.Step) ([]*model.LogEntry, error) {
 		return nil, err
 	}
 
+	buf := make([]byte, 0, bufio.MaxScanTokenSize)
 	s := bufio.NewScanner(file)
+	s.Buffer(buf, maxLineLength)
+
 	var entries []*model.LogEntry
 	for s.Scan() {
 		j := s.Text()


### PR DESCRIPTION
Log lines may contain up to 1 MB of text, but with default settings `bufio.Scanner` only reads lines up to 64k in length and fails on anything larger, rendering the `Scanner` unusable.

As a result, the user won't see anything after the first very long line, including the line itself.


```yaml
when:
  event: push

steps:
  logs:
    image: ubuntu:24.04
    commands:
      - seq 1 3
      - tr -dc '[:alnum:]' </dev/urandom | head -c70k
      - echo
      - seq 4 6
```

The output should be:

```
1
2
3
zkwmLrpYmk6XcgJZiYqzNO3hsIV26HJfVQfyvSo1ccrMqP ... very long line of random text
4
5
6
```

Instead, Woodpecker cuts everything after `3`:

```
1
2
3
(end)
```

I tested this on jobs with up to 20 MBs of output (simply update `70k` with something like `20M`).