### PR TITLE
Add a pull request template with some basic guidelines

### DIFF
--- a/.github/pull_request_template.txt
+++ b/.github/pull_request_template.txt
@@ -4,7 +4,7 @@ Please check the following tips:
 
 2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
 
-3. If this pull request fixes an issue, refer to the issue with messages like `Ref #1234`, `Closes #1234`, or `Fixes #1234`.
+3. If this pull request fixes an issue, refer to the issue with messages like `Ref #1234`, `Closes #1234`, or `Fixes #1234` in the pull description.
 
 4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
 


### PR DESCRIPTION
Unfortunately, GitHub is behind Gitea and Forgejo on this. Those two can render the template as immutable text outside of the main text area; GitHub simply pastes the file into the text area.

If the result is too long, I can remove everything but the first point.

Ref https://github.com/woodpecker-ci/woodpecker/pull/3986#issuecomment-2308975003 , https://github.com/woodpecker-ci/woodpecker/pull/4048#issuecomment-2308977590

Demo: https://github.com/hg/woodpecker/compare/main...hg:woodpecker:pr-template?expand=1

See also: https://github.com/go-gitea/gitea/blob/main/.github/pull_request_template.md

@6543