### PR TITLE
Fix schema with detached steps

### DIFF
--- a/pipeline/frontend/yaml/linter/schema/schema.json
+++ b/pipeline/frontend/yaml/linter/schema/schema.json
@@ -227,7 +227,7 @@
     },
     "step": {
       "description": "A step of your workflow executes either arbitrary commands or uses a plugin. Read more: https://woodpecker-ci.org/docs/usage/workflow-syntax#steps",
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#/definitions/commands_step"
         },
@@ -240,7 +240,33 @@
       "description": "Every step of your pipeline executes arbitrary commands inside a specified docker container. Read more: https://woodpecker-ci.org/docs/usage/workflow-syntax#steps",
       "type": "object",
       "additionalProperties": false,
-      "required": ["image", "commands"],
+      "required": ["image"],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "detach": {
+                "const": true
+              }
+            }
+          },
+          "then": {},
+          "else": {
+            "anyOf": [
+              {
+                "required": [
+                  "commands"
+                ]
+              },
+              {
+                "required": [
+                  "entrypoint"
+                ]
+              }
+            ]
+          }
+        }
+      ],
       "properties": {
         "name": {
           "description": "The name of the step. Can be used if using the array style steps list.",


### PR DESCRIPTION
`commands` is optional, when `detach` is set.

Also fixes #4065, which made `commands` required (it can be unset when `entrypoint` is available) and therefore some schema tests fail.

For a step like:
```yaml
  detached:
    image: redis
    detach: true
```

It matches `commands_step` and `plugin_step` at the same time, so change oneOf to anyOf.
