### PR TITLE
[Backport] Lint privileged plugin match and allow to be set empty

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -159,7 +159,7 @@ var flags = append([]cli.Flag{
 		Value:   time.Hour * 72,
 	},
 	&cli.StringSliceFlag{
-		Sources: cli.EnvVars("WOODPECKER_ESCALATE"),
+		Sources: cli.EnvVars("WOODPECKER_ESCALATE", "WOODPECKER_PLUGINS_PRIVILEGED"),
 		Name:    "escalate",
 		Usage:   "images to run in privileged mode",
 		Value:   constant.PrivilegedPlugins,

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -234,6 +234,9 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) error 
 	if val, set := os.LookupEnv("WOODPECKER_ESCALATE"); set && val == "" {
 		server.Config.Pipeline.Privileged = []string{}
 	}
+	if val, set := os.LookupEnv("WOODPECKER_PLUGINS_PRIVILEGED"); set && val == "" {
+		server.Config.Pipeline.Privileged = []string{}
+	}
 
 	// prometheus
 	server.Config.Prometheus.AuthToken = c.String("prometheus-auth-token")

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -226,9 +226,14 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) error 
 	server.Config.Server.CustomJsFile = strings.TrimSpace(c.String("custom-js-file"))
 	server.Config.Pipeline.Networks = c.StringSlice("network")
 	server.Config.Pipeline.Volumes = c.StringSlice("volume")
-	server.Config.Pipeline.Privileged = c.StringSlice("escalate")
 	server.Config.WebUI.EnableSwagger = c.Bool("enable-swagger")
 	server.Config.WebUI.SkipVersionCheck = c.Bool("skip-version-check")
+
+	// list has default value but should be able to be set to zero
+	server.Config.Pipeline.Privileged = c.StringSlice("escalate")
+	if val, set := os.LookupEnv("WOODPECKER_ESCALATE"); set && val == "" {
+		server.Config.Pipeline.Privileged = []string{}
+	}
 
 	// prometheus
 	server.Config.Prometheus.AuthToken = c.String("prometheus-auth-token")

--- a/pipeline/frontend/yaml/linter/linter.go
+++ b/pipeline/frontend/yaml/linter/linter.go
@@ -29,7 +29,8 @@ import (
 
 // A Linter lints a pipeline configuration.
 type Linter struct {
-	trusted bool
+	trusted           bool
+	privilegedPlugins *[]string
 }
 
 // New creates a new Linter with options.
@@ -119,6 +120,9 @@ func (l *Linter) lintContainers(config *WorkflowConfig, area string) error {
 			}
 		}
 		if err := l.lintSettings(config, container, area); err != nil {
+			linterErr = multierr.Append(linterErr, err)
+		}
+		if err := l.lintPrivilegedPlugins(config, container, area); err != nil {
 			linterErr = multierr.Append(linterErr, err)
 		}
 	}

--- a/pipeline/frontend/yaml/linter/linter.go
+++ b/pipeline/frontend/yaml/linter/linter.go
@@ -25,6 +25,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/frontend/yaml/linter/schema"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/frontend/yaml/types"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/frontend/yaml/utils"
+	"go.woodpecker-ci.org/woodpecker/v2/shared/constant"
 )
 
 // A Linter lints a pipeline configuration.
@@ -138,15 +139,11 @@ func (l *Linter) lintImage(config *WorkflowConfig, c *types.Container, area stri
 }
 
 func (l *Linter) lintPrivilegedPlugins(config *WorkflowConfig, c *types.Container, area string) error {
-	// lint for conflicts of https://github.com/woodpecker-ci/woodpecker/pull/3918
-	if utils.MatchImage(c.Image, "plugins/docker", "plugins/gcr", "plugins/ecr", "woodpeckerci/plugin-docker-buildx") {
+	if utils.MatchImage(c.Image, constant.PrivilegedPlugins...) {
 		msg := fmt.Sprintf("Cannot use once by default privileged plugin '%s', if needed add it too WOODPECKER_PLUGINS_PRIVILEGED", c.Image)
 		// check first if user did not add them back
 		if l.privilegedPlugins != nil && !utils.MatchImageDynamic(c.Image, *l.privilegedPlugins...) {
 			return newLinterError(msg, config.File, fmt.Sprintf("%s.%s", area, c.Name), false)
-		} else if l.privilegedPlugins == nil {
-			// if linter has no info of current privileged plugins, it's just a warning
-			return newLinterError(msg, config.File, fmt.Sprintf("%s.%s", area, c.Name), true)
 		}
 	}
 

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -166,16 +166,8 @@ func TestLintErrors(t *testing.T) {
 			want: "Should not configure both environment and settings",
 		},
 		{
-			from: "{pipeline: { build: { image: golang, settings: { test: 'true' } } }, when: { branch: main, event: push } }",
-			want: "Additional property pipeline is not allowed",
-		},
-		{
 			from: "{steps: { build: { image: plugins/docker, settings: { test: 'true' } } }, when: { branch: main, event: push } } }",
 			want: "Cannot use once by default privileged plugin 'plugins/docker', if needed add it too WOODPECKER_PLUGINS_PRIVILEGED",
-		},
-		{
-			from: "{steps: { build: { image: golang, settings: { test: 'true' } } }, when: { branch: main, event: push }, clone: { git: { image: some-other/plugin-git:v1.1.0 } } }",
-			want: "Specified clone image does not match allow list, netrc will not be injected",
 		},
 	}
 
@@ -183,7 +175,9 @@ func TestLintErrors(t *testing.T) {
 		conf, err := yaml.ParseString(test.from)
 		assert.NoError(t, err)
 
-		lerr := linter.New().Lint([]*linter.WorkflowConfig{{
+		lerr := linter.New(
+			linter.PrivilegedPlugins([]string{"woodpeckerci/plugin-docker-buildx"}),
+		).Lint([]*linter.WorkflowConfig{{
 			File:      test.from,
 			RawConfig: test.from,
 			Workflow:  conf,

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -165,6 +165,18 @@ func TestLintErrors(t *testing.T) {
 			from: "steps: { build: { image: golang, settings: { test: 'true' }, environment: [ 'TEST=true' ] } }",
 			want: "Should not configure both environment and settings",
 		},
+		{
+			from: "{pipeline: { build: { image: golang, settings: { test: 'true' } } }, when: { branch: main, event: push } }",
+			want: "Additional property pipeline is not allowed",
+		},
+		{
+			from: "{steps: { build: { image: plugins/docker, settings: { test: 'true' } } }, when: { branch: main, event: push } } }",
+			want: "Cannot use once by default privileged plugin 'plugins/docker', if needed add it too WOODPECKER_PLUGINS_PRIVILEGED",
+		},
+		{
+			from: "{steps: { build: { image: golang, settings: { test: 'true' } } }, when: { branch: main, event: push }, clone: { git: { image: some-other/plugin-git:v1.1.0 } } }",
+			want: "Specified clone image does not match allow list, netrc will not be injected",
+		},
 	}
 
 	for _, test := range testdata {

--- a/pipeline/frontend/yaml/linter/option.go
+++ b/pipeline/frontend/yaml/linter/option.go
@@ -23,3 +23,10 @@ func WithTrusted(trusted bool) Option {
 		linter.trusted = trusted
 	}
 }
+
+// PrivilegedPlugins adds the list of privileged plugins.
+func PrivilegedPlugins(plugins []string) Option {
+	return func(linter *Linter) {
+		linter.privilegedPlugins = &plugins
+	}
+}

--- a/server/pipeline/stepbuilder/stepBuilder.go
+++ b/server/pipeline/stepbuilder/stepBuilder.go
@@ -142,6 +142,7 @@ func (b *StepBuilder) genItemForWorkflow(workflow *model.Workflow, axis matrix.A
 	// lint pipeline
 	errorsAndWarnings = multierr.Append(errorsAndWarnings, linter.New(
 		linter.WithTrusted(b.Repo.IsTrusted),
+		linter.PrivilegedPlugins(server.Config.Pipeline.Privileged),
 	).Lint([]*linter.WorkflowConfig{{
 		Workflow:  parsed,
 		File:      workflow.Name,


### PR DESCRIPTION
Partially Backport https://github.com/woodpecker-ci/woodpecker/pull/4053 and https://github.com/woodpecker-ci/woodpecker/pull/4083

also let it understand `WOODPECKER_PLUGINS_PRIVILEGED` but not enforce any change