### PR TITLE
Make local backend work with `cli exec`

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -111,6 +111,11 @@ func runExec(ctx context.Context, c *cli.Command, file, repoPath string) error {
 		return err
 	}
 
+	// if we use the local backend we should signal to run at $repoPath
+	if c.String("backend-engine") == "local" && !c.IsSet("backend-local-exec-dir") {
+		c.Set("backend-local-exec-dir", repoPath)
+	}
+
 	axes, err := matrix.ParseString(string(dat))
 	if err != nil {
 		return fmt.Errorf("parse matrix fail")

--- a/docs/docs/30-administration/22-backends/20-local.md
+++ b/docs/docs/30-administration/22-backends/20-local.md
@@ -65,3 +65,11 @@ In the context of the local backend, plugins are simply executable binaries, whi
 > Default: default temp directory
 
 Directory to create folders for workflows.
+
+#### `WOODPECKER_BACKEND_LOCAL_EXEC_DIR`
+
+> Default: *empty*
+
+:::warning
+Only set it if you know why
+:::

--- a/pipeline/backend/local/flags.go
+++ b/pipeline/backend/local/flags.go
@@ -24,7 +24,12 @@ var Flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "backend-local-temp-dir",
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_LOCAL_TEMP_DIR"),
-		Usage:   "set a different temp dir to clone workflows into",
+		Usage:   "Set a different temp dir to clone workflows into.",
 		Value:   os.TempDir(),
+	},
+	&cli.StringFlag{
+		Name:    "backend-local-exec-dir",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_LOCAL_EXEC_DIR"),
+		Usage:   "Instead of using an tmp dir, we use this directory to exec the workflow in (mostly used by 'woodpecker-cli exec ...').",
 	},
 }


### PR DESCRIPTION
Currently if you try to exec a pipeline via the cli tool and use the local backend,  all files are missing.
This will detect this specific case and use the new added option in the local backend to specify a execution directory upfront.