### PR TITLE
Increase log level when failing to create pipeline

### DIFF
--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -87,13 +87,13 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 
 		return nil, ErrFiltered
 	} else if configFetchErr != nil {
-		log.Debug().Str("repo", repo.FullName).Err(configFetchErr).Msgf("error while fetching config '%s' in '%s' with user: '%s'", repo.Config, pipeline.Ref, repoUser.Login)
+		log.Error().Str("repo", repo.FullName).Err(configFetchErr).Msgf("error while fetching config '%s' in '%s' with user: '%s'", repo.Config, pipeline.Ref, repoUser.Login)
 		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge: %w", err))
 	}
 
 	pipelineItems, parseErr := parsePipeline(_forge, _store, pipeline, repoUser, repo, forgeYamlConfigs, nil)
 	if pipeline_errors.HasBlockingErrors(parseErr) {
-		log.Debug().Str("repo", repo.FullName).Err(parseErr).Msg("failed to parse yaml")
+		log.Error().Str("repo", repo.FullName).Err(parseErr).Msg("failed to parse yaml")
 		return pipeline, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, parseErr)
 	} else if parseErr != nil {
 		pipeline.Errors = pipeline_errors.GetPipelineErrors(parseErr)


### PR DESCRIPTION
Increase log level when failing to create pipelines. There are situations when woodpecker server may fail to create a pipeline and will only log the error under "debug", making it hard to debug the issue unless the user has explicitly activated debug logs.

To reproduce this, set the server environment variable WOODPECKER_CONFIG_SERVICE_ENDPOINT to an invalid service, i.e.

```
WOODPECKER_CONFIG_SERVICE_ENDPOINT: "http://invalid/config"
```

And it will fail to create a pipeline, but no error logs will be displayed, only a debug log:

```
{"level":"debug","repo":"<redacted>","error":"failed to fetch config via http (0) Post \"http://ci-template-plugin/config\": dial tcp: lookup invalid on 198.18.0.1:53: no such host","time":"2024-09-13T14:06:02Z","caller":"/go/src/github.com/woodpecker-ci/woodpecker/server/pipeline/create.go:90","message":"error while fetching config '' in 'refs/heads/fernandrone-patch-1' with user: 'fernandrone'"}
```
