### PR TITLE
Don't expose task data via api

### DIFF
--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -5064,12 +5064,6 @@ const docTemplate = `{
                 "agent_id": {
                     "type": "integer"
                 },
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
                 "dep_status": {
                     "type": "object",
                     "additionalProperties": {

--- a/server/api/agent.go
+++ b/server/api/agent.go
@@ -97,7 +97,10 @@ func GetAgentTasks(c *gin.Context) {
 	info := server.Config.Services.Queue.Info(c)
 	for _, task := range info.Running {
 		if task.AgentID == agent.ID {
-			tasks = append(tasks, task)
+			t := *task
+			// we copy the task and remove sensitive data
+			t.Data = nil
+			tasks = append(tasks, &t)
 		}
 	}
 

--- a/server/api/agent.go
+++ b/server/api/agent.go
@@ -97,10 +97,7 @@ func GetAgentTasks(c *gin.Context) {
 	info := server.Config.Services.Queue.Info(c)
 	for _, task := range info.Running {
 		if task.AgentID == agent.ID {
-			t := *task
-			// we copy the task and remove sensitive data
-			t.Data = nil
-			tasks = append(tasks, &t)
+			tasks = append(tasks, task)
 		}
 	}
 

--- a/server/model/task.go
+++ b/server/model/task.go
@@ -22,7 +22,7 @@ import (
 // Task defines scheduled pipeline Task.
 type Task struct {
 	ID           string                 `json:"id"           xorm:"PK UNIQUE 'id'"`
-	Data         []byte                 `json:"data"         xorm:"LONGBLOB 'data'"`
+	Data         []byte                 `json:"-"            xorm:"LONGBLOB 'data'"`
 	Labels       map[string]string      `json:"labels"       xorm:"json 'labels'"`
 	Dependencies []string               `json:"dependencies" xorm:"json 'dependencies'"`
 	RunOn        []string               `json:"run_on"       xorm:"json 'run_on'"`

--- a/web/src/lib/api/types/queue.ts
+++ b/web/src/lib/api/types/queue.ts
@@ -1,6 +1,5 @@
 export interface Task {
   id: number;
-  data: string;
   labels: { [key: string]: string };
   dependencies: string[];
   dep_status: { [key: string]: string };

--- a/woodpecker-go/woodpecker/agent_test.go
+++ b/woodpecker-go/woodpecker/agent_test.go
@@ -431,16 +431,14 @@ func TestClient_AgentTasksList(t *testing.T) {
 			agentID: 1,
 			expected: []*Task{
 				{
-					ID:   "4696",
-					Data: []byte{},
+					ID: "4696",
 					Labels: map[string]string{
 						"platform": "linux/amd64",
 						"repo":     "woodpecker-ci/woodpecker",
 					},
 				},
 				{
-					ID:   "4697",
-					Data: []byte{},
+					ID: "4697",
 					Labels: map[string]string{
 						"platform": "linux/arm64",
 						"repo":     "woodpecker-ci/woodpecker",

--- a/woodpecker-go/woodpecker/queue_test.go
+++ b/woodpecker-go/woodpecker/queue_test.go
@@ -49,8 +49,7 @@ func TestClient_QueueInfo(t *testing.T) {
 			expected: &Info{
 				Running: []Task{
 					{
-						ID:   "4696",
-						Data: []byte{},
+						ID: "4696",
 						Labels: map[string]string{
 							"platform": "linux/amd64",
 							"repo":     "woodpecker-ci/woodpecker",

--- a/woodpecker-go/woodpecker/types.go
+++ b/woodpecker-go/woodpecker/types.go
@@ -246,7 +246,6 @@ type (
 	// Task is the JSON data for a task.
 	Task struct {
 		ID           string            `json:"id"`
-		Data         []byte            `json:"data"`
 		Labels       map[string]string `json:"labels"`
 		Dependencies []string          `json:"dependencies"`
 		RunOn        []string          `json:"run_on"`


### PR DESCRIPTION
Currently an instance admin can just querny all secrets of active or pending workflows:

```sh
curl 'http://1.2.3.4:8000/api/queue/info' -H 'Cookie: user_sess=some.jwt.token' | jq .pending[].data | tr -d '"' | base64 -d | jq .config.secrets
```

this is not an serious issue but we never use this info in the webui anyway so we should just not make it available
