### PR TITLE
Set repo user to repairing user when old user is missing

### DIFF
--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -622,7 +622,7 @@ func repairRepo(c *gin.Context, repo *model.Repo, withPerms, skipOnErr bool) {
 			if err != nil {
 				_ = c.AbortWithError(http.StatusInternalServerError, err)
 			}
-			log.Info().Msgf("Could not find repo user with ID %d during repo repair, set to repair request user with ID %d", oldUserID, user.ID)
+			log.Debug().Msgf("Could not find repo user with ID %d during repo repair, set to repair request user with ID %d", oldUserID, user.ID)
 		} else {
 			_ = c.AbortWithError(http.StatusInternalServerError, err)
 		}

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -615,10 +615,14 @@ func repairRepo(c *gin.Context, repo *model.Repo, withPerms, skipOnErr bool) {
 	user, err := _store.GetUser(repo.UserID)
 	if err != nil {
 		if errors.Is(err, types.RecordNotExist) {
-			if !skipOnErr {
-				c.AbortWithStatus(http.StatusNotFound)
+			oldUserID := repo.UserID
+			user = session.User(c)
+			repo.UserID = user.ID
+			err = _store.UpdateRepo(repo)
+			if err != nil {
+				_ = c.AbortWithError(http.StatusInternalServerError, err)
 			}
-			log.Error().Err(err).Msg("could not get user on repo repair")
+			log.Info().Msgf("Could not find repo user with ID %d during repo repair, set to repair request user with ID %d", oldUserID, user.ID)
 		} else {
 			_ = c.AbortWithError(http.StatusInternalServerError, err)
 		}


### PR DESCRIPTION
When the user that activated a repository is deleted, the repository is broken. Also described in #571.

This PR allows to fix the situation by running repair, which is assigning the repository to the repairing user.

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
