### PR TITLE
Set `/woodpecker` as default workdir for the **woodpecker-cli** container

### DIFF
--- a/docker/Dockerfile.cli.alpine.multiarch
+++ b/docker/Dockerfile.cli.alpine.multiarch
@@ -8,7 +8,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     make build-cli
 
 FROM docker.io/alpine:3.20
+WORKDIR /woodpecker
+
 RUN apk add -U --no-cache ca-certificates
+
 ENV GODEBUG=netdns=go
 ENV WOODPECKER_DISABLE_UPDATE_CHECK=true
 

--- a/docker/Dockerfile.cli.multiarch
+++ b/docker/Dockerfile.cli.multiarch
@@ -8,6 +8,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     make build-cli
 
 FROM scratch
+WORKDIR /woodpecker
+
 ENV GODEBUG=netdns=go
 ENV WOODPECKER_DISABLE_UPDATE_CHECK=true
 

--- a/docs/docs/91-migrations.md
+++ b/docs/docs/91-migrations.md
@@ -4,6 +4,7 @@ Some versions need some changes to the server configuration or the pipeline conf
 
 ## `next`
 
+- Set `/woodpecker` as defautl workdir for the **woodpecker-cli** container
 - Removed built-in environment variables:
   - `CI_COMMIT_URL` use `CI_PIPELINE_FORGE_URL`
   - `CI_STEP_FINISHED` as empty during execution


### PR DESCRIPTION
before the workdir was not specified, this set it to a defined state so user can work with that