### PR TITLE
static workflow: let lychee pretend to be curl

### DIFF
--- a/.woodpecker/static.yaml
+++ b/.woodpecker/static.yaml
@@ -33,5 +33,5 @@ steps:
     depends_on: []
     commands:
       - lychee pipeline/frontend/yaml/linter/schema/schema.json
-      - lychee --exclude localhost docs/docs/
-      - lychee --exclude localhost docs/src/pages/
+      - lychee --user-agent "curl/8.4.0" --exclude localhost docs/docs/
+      - lychee --user-agent "curl/8.4.0" --exclude localhost docs/src/pages/


### PR DESCRIPTION
fix https://ci.woodpecker-ci.org/repos/3780/pipeline/20771/27

as *.gnu.org just let the link checker fail with `Network error: Too Many Requests`

upstream discussion can be found at https://github.com/lycheeverse/lychee/issues/1504