### PR TITLE
Update image filter error message

### DIFF
--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -46,7 +46,7 @@ type Secret struct {
 func (s *Secret) Available(event string, container *yaml_types.Container) error {
 	onlyAllowSecretForPlugins := len(s.AllowedPlugins) > 0
 	if onlyAllowSecretForPlugins && !container.IsPlugin() {
-		return fmt.Errorf("secret %q only allowed to be used by plugins by step %q", s.Name, container.Name)
+		return fmt.Errorf("secret %q is only allowed to be used by plugins (a filter has been set on the secret). Note: Image filters do not work for normal steps.", s.Name)
 	}
 
 	if onlyAllowSecretForPlugins && !utils.MatchImageDynamic(container.Image, s.AllowedPlugins...) {

--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -46,7 +46,7 @@ type Secret struct {
 func (s *Secret) Available(event string, container *yaml_types.Container) error {
 	onlyAllowSecretForPlugins := len(s.AllowedPlugins) > 0
 	if onlyAllowSecretForPlugins && !container.IsPlugin() {
-		return fmt.Errorf("secret %q is only allowed to be used by plugins (a filter has been set on the secret). Note: Image filters do not work for normal steps.", s.Name)
+		return fmt.Errorf("secret %q is only allowed to be used by plugins (a filter has been set on the secret). Note: Image filters do not work for normal steps", s.Name)
 	}
 
 	if onlyAllowSecretForPlugins && !utils.MatchImageDynamic(container.Image, s.AllowedPlugins...) {

--- a/pipeline/frontend/yaml/compiler/compiler_test.go
+++ b/pipeline/frontend/yaml/compiler/compiler_test.go
@@ -50,7 +50,7 @@ func TestSecretAvailable(t *testing.T) {
 	assert.ErrorContains(t, secret.Available("push", &yaml_types.Container{
 		Image:    "golang",
 		Commands: yaml_base_types.StringOrSlice{"echo 'this is not a plugin'"},
-	}), "only allowed to be used by plugins by step")
+	}), "is only allowed to be used by plugins (a filter has been set on the secret). Note: Image filters do not work for normal steps.")
 	assert.ErrorContains(t, secret.Available("push", &yaml_types.Container{
 		Image:    "not-golang",
 		Commands: yaml_base_types.StringOrSlice{},

--- a/pipeline/frontend/yaml/compiler/compiler_test.go
+++ b/pipeline/frontend/yaml/compiler/compiler_test.go
@@ -50,7 +50,7 @@ func TestSecretAvailable(t *testing.T) {
 	assert.ErrorContains(t, secret.Available("push", &yaml_types.Container{
 		Image:    "golang",
 		Commands: yaml_base_types.StringOrSlice{"echo 'this is not a plugin'"},
-	}), "is only allowed to be used by plugins (a filter has been set on the secret). Note: Image filters do not work for normal steps.")
+	}), "is only allowed to be used by plugins (a filter has been set on the secret). Note: Image filters do not work for normal steps")
 	assert.ErrorContains(t, secret.Available("push", &yaml_types.Container{
 		Image:    "not-golang",
 		Commands: yaml_base_types.StringOrSlice{},

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -433,7 +433,7 @@
     "saved": "Secret saved",
     "plugins": {
       "images": "Available only for the following plugins",
-      "desc": "List of plugins images where this secret is available, leave empty to allow for all plugins and general steps."
+      "desc": "List of plugin images where this secret is available. Leave empty to allow for all plugins and normal steps."
     },
     "events": {
       "events": "Available at the following events",


### PR DESCRIPTION
The current one is somewhat confusing:

<img width="454" alt="image" src="https://github.com/user-attachments/assets/caf0c149-dcb4-4c8b-9bd9-46a95643feb7">

- the step doesn't add much information here
- "to be used by plugins by step" is strange grammar
- The actual information, that the image filter only applies to plugins, is actually missing