### PR TITLE
renovate: set `automergetype=pr`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -15,6 +15,7 @@
     "apimachinery",
     "Archlinux",
     "autoincr",
+    "automerge",
     "autoscaler",
     "backporting",
     "backports",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>woodpecker-ci/renovate-config"],
+  "automergeType": "pr",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
So that PRs are raised. Otherwise, the updates are getting forgotten in the branches due to the approval requirements of WP.