### PR TITLE
Fix errant apostrophe in docker-compose documentation

### DIFF
--- a/docs/docs/30-administration/05-deployment-methods/10-docker-compose.md
+++ b/docs/docs/30-administration/05-deployment-methods/10-docker-compose.md
@@ -49,7 +49,7 @@ Woodpecker needs to know its own address. You must therefore provide the public 
 +      - WOODPECKER_HOST=${WOODPECKER_HOST}
 ```
 
-Woodpecker can also have its port's configured. It uses a separate port for gRPC and for HTTP. The agent performs gRPC calls and connects to the gRPC port.
+Woodpecker can also have its ports configured. It uses a separate port for gRPC and for HTTP. The agent performs gRPC calls and connects to the gRPC port.
 They can be configured with `*_ADDR` variables:
 
 ```diff title="docker-compose.yaml"


### PR DESCRIPTION
A one character niggle, but that niggled me enough to fork :)