### PR TITLE
Correctly init workflow metadata for cli exec

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -132,7 +132,7 @@ func runExec(ctx context.Context, c *cli.Command, file, repoPath string, singleE
 }
 
 func execWithAxis(ctx context.Context, c *cli.Command, file, repoPath string, axis matrix.Axis, singleExec bool) error {
-	var metadataWorkflow *metadata.Workflow
+	metadataWorkflow := &metadata.Workflow{}
 	if !singleExec {
 		// TODO: proper try to use the engine to generate the same metadata for workflows
 		// https://github.com/woodpecker-ci/woodpecker/pull/3967


### PR DESCRIPTION
fix regression of https://github.com/woodpecker-ci/woodpecker/pull/4103