### PR TITLE
Only allow docker-buildx plugin >= 5.0.0 to be priviledged by default

### DIFF
--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -19,8 +19,10 @@ var PrivilegedPlugins = []string{
 	"plugins/docker",
 	"plugins/gcr",
 	"plugins/ecr",
-	"woodpeckerci/plugin-docker-buildx",
-	"codeberg.org/woodpecker-plugins/docker-buildx",
+	"woodpeckerci/plugin-docker-buildx:5",
+	"codeberg.org/woodpecker-plugins/docker-buildx:5",
+	"woodpeckerci/plugin-docker-buildx:latest",
+	"codeberg.org/woodpecker-plugins/docker-buildx:latest",
 }
 
 // DefaultConfigOrder represent the priority in witch woodpecker search for a pipeline config by default

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -21,6 +21,10 @@ var PrivilegedPlugins = []string{
 	"plugins/ecr",
 	"woodpeckerci/plugin-docker-buildx:5",
 	"codeberg.org/woodpecker-plugins/docker-buildx:5",
+	"woodpeckerci/plugin-docker-buildx:5.0",
+	"codeberg.org/woodpecker-plugins/docker-buildx:5.0",
+	"woodpeckerci/plugin-docker-buildx:5.0.0",
+	"codeberg.org/woodpecker-plugins/docker-buildx:5.0.0",
 	"woodpeckerci/plugin-docker-buildx:latest",
 	"codeberg.org/woodpecker-plugins/docker-buildx:latest",
 }


### PR DESCRIPTION
bump buildx plugin to only be privileged if version is pinned and greater than v5.0.0 or latest.

https://codeberg.org/woodpecker-plugins/docker-buildx/releases/tag/v5.0.0

so by default only this images will get privildges:
- `woodpeckerci/plugin-docker-buildx` (latest)
- `woodpeckerci/plugin-docker-buildx:latest`
- `woodpeckerci/plugin-docker-buildx:5`
- `woodpeckerci/plugin-docker-buildx:5.0`
- `woodpeckerci/plugin-docker-buildx:5.0.0`
