### PR TITLE
Warn user when using lowercase secrets

### DIFF
--- a/pipeline/frontend/yaml/linter/linter.go
+++ b/pipeline/frontend/yaml/linter/linter.go
@@ -346,7 +346,7 @@ func (l *Linter) lintDeprecations(config *WorkflowConfig) (err error) {
 			if secret.Target != secretUpper {
 				err = multierr.Append(err, &errorTypes.PipelineError{
 					Type:    errorTypes.PipelineErrorTypeDeprecation,
-					Message: "Lower-case secret is used, uppercasing all secret env vars will be removed in 3.0; perhaps, you want to uppercase secret name in pipeline definition or lowercase env var in used commands",
+					Message: "Lower-case secret is used, uppercasing all secret env vars will be removed in 3.0. In order to prevent disruption, you can uppercase secret name in pipeline definition in advance. Additionally you can lowercase env vars in used commands after 3.0 release.",
 					Data: errors.DeprecationErrorData{
 						File:  config.File,
 						Field: fmt.Sprintf("steps.%s.secrets[%d]", step.Name, i),

--- a/pipeline/frontend/yaml/linter/linter.go
+++ b/pipeline/frontend/yaml/linter/linter.go
@@ -16,6 +16,7 @@ package linter
 
 import (
 	"fmt"
+	"strings"
 
 	"codeberg.org/6543/xyaml"
 	"go.uber.org/multierr"
@@ -332,6 +333,24 @@ func (l *Linter) lintDeprecations(config *WorkflowConfig) (err error) {
 						File:  config.File,
 						Field: fmt.Sprintf("steps.%s.secrets[%d]", step.Name, i),
 						Docs:  "https://woodpecker-ci.org/docs/usage/secrets#use-secrets-in-settings-and-environment",
+					},
+					IsWarning: true,
+				})
+			}
+		}
+	}
+
+	for _, step := range parsed.Steps.ContainerList {
+		for i, secret := range step.Secrets.Secrets {
+			secretUpper := strings.ToUpper(secret.Target)
+			if secret.Target != secretUpper {
+				err = multierr.Append(err, &errorTypes.PipelineError{
+					Type:    errorTypes.PipelineErrorTypeDeprecation,
+					Message: "Lower-case secret is used, it might not work properly since 3.0",
+					Data: errors.DeprecationErrorData{
+						File:  config.File,
+						Field: fmt.Sprintf("steps.%s.secrets[%d]", step.Name, i),
+						Docs:  "https://woodpecker-ci.org/docs/next/migrations#next",
 					},
 					IsWarning: true,
 				})

--- a/pipeline/frontend/yaml/linter/linter.go
+++ b/pipeline/frontend/yaml/linter/linter.go
@@ -346,7 +346,7 @@ func (l *Linter) lintDeprecations(config *WorkflowConfig) (err error) {
 			if secret.Target != secretUpper {
 				err = multierr.Append(err, &errorTypes.PipelineError{
 					Type:    errorTypes.PipelineErrorTypeDeprecation,
-					Message: "Lower-case secret is used, it might not work properly since 3.0",
+					Message: "Lower-case secret is used, uppercasing all secret env vars will be removed in 3.0; perhaps, you want to uppercase secret name in pipeline definition or lowercase env var in used commands",
 					Data: errors.DeprecationErrorData{
 						File:  config.File,
 						Field: fmt.Sprintf("steps.%s.secrets[%d]", step.Name, i),

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -171,7 +171,7 @@ func TestLintErrors(t *testing.T) {
 		},
 		{
 			from: "{steps: { build: { image: golang, secrets: [ 'test' ] } }, when: { event: manual } }",
-			want: "Lower-case secret is used, it might not work properly since 3.0",
+			want: "Lower-case secret is used, uppercasing all secret env vars will be removed in 3.0; perhaps, you want to uppercase secret name in pipeline definition or lowercase env var in used commands",
 		},
 	}
 

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -171,7 +171,7 @@ func TestLintErrors(t *testing.T) {
 		},
 		{
 			from: "{steps: { build: { image: golang, secrets: [ 'test' ] } }, when: { event: manual } }",
-			want: "Lower-case secret is used, uppercasing all secret env vars will be removed in 3.0; perhaps, you want to uppercase secret name in pipeline definition or lowercase env var in used commands",
+			want: "Lower-case secret is used, uppercasing all secret env vars will be removed in 3.0. In order to prevent disruption, you can uppercase secret name in pipeline definition in advance. Additionally you can lowercase env vars in used commands after 3.0 release.",
 		},
 	}
 

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -169,6 +169,10 @@ func TestLintErrors(t *testing.T) {
 			from: "{steps: { build: { image: plugins/docker, settings: { test: 'true' } } }, when: { branch: main, event: push } } }",
 			want: "Cannot use once by default privileged plugin 'plugins/docker', if needed add it too WOODPECKER_PLUGINS_PRIVILEGED",
 		},
+		{
+			from: "{steps: { build: { image: golang, secrets: [ 'test' ] } }, when: { event: manual } }",
+			want: "Lower-case secret is used, it might not work properly since 3.0",
+		},
 	}
 
 	for _, test := range testdata {


### PR DESCRIPTION
Follow up https://github.com/woodpecker-ci/woodpecker/issues/3960#issuecomment-2395470285

Lints
> Removed uppercasing all secret env vars, instead, the value of the secrets property is used