### PR TITLE
WebUI: agent edit/detail view: change the **HELP** url based on the b…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: checkmake
         exclude: '^docker/Dockerfile.make$' # actually a Dockerfile and not a makefile
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.13.0-beta
+    rev: v2.13.1-beta
     hooks:
       - id: hadolint
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/web/src/components/agent/AgentForm.vue
+++ b/web/src/components/agent/AgentForm.vue
@@ -24,7 +24,7 @@
       <InputField
         v-slot="{ id }"
         :label="$t('admin.settings.agents.backend.backend')"
-        docs-url="docs/next/administration/backends/docker"
+        :docs-url="backendDocsUrl"
       >
         <TextField :id="id" v-model="agent.backend" disabled />
       </InputField>
@@ -79,6 +79,7 @@
 </template>
 
 <script lang="ts" setup>
+import { setWith } from 'lodash';
 import { computed } from 'vue';
 
 import Button from '~/components/atomic/Button.vue';
@@ -106,6 +107,21 @@ const agent = computed({
   get: () => props.modelValue,
   set: (value) => emit('update:modelValue', value),
 });
+
+const baseDocsUrl = 'https://woodpecker-ci.org/docs/next/administration/backends/';
+
+const backendDocsUrl = computed(() =>{
+  switch(agent.value.backend?.toLowerCase()){
+    case 'local':
+      return `${baseDocsUrl}local`;
+    case 'kubernetes':
+      return `${baseDocsUrl}kubernetes`;
+    case 'custom':
+      return `${baseDocsUrl}custom-backends`;
+    default:
+      return `${baseDocsUrl}docker`
+  }
+})
 
 function updateAgent(newValues: Partial<Agent>) {
   emit('update:modelValue', { ...agent.value, ...newValues });

--- a/web/src/components/agent/AgentForm.vue
+++ b/web/src/components/agent/AgentForm.vue
@@ -26,7 +26,7 @@
         :label="$t('admin.settings.agents.backend.backend')"
         :docs-url="backendDocsUrl"
       >
-        <TextField :id="id" v-model="agent.backend" />
+        <TextField :id="id" v-model="agent.backend" disabled />
       </InputField>
 
       <InputField v-slot="{ id }" :label="$t('admin.settings.agents.platform.platform')">

--- a/web/src/components/agent/AgentForm.vue
+++ b/web/src/components/agent/AgentForm.vue
@@ -21,11 +21,7 @@
         <TextField :id="id" :model-value="agent.id?.toString()" disabled />
       </InputField>
 
-      <InputField
-        v-slot="{ id }"
-        :label="$t('admin.settings.agents.backend.backend')"
-        :docs-url="backendDocsUrl"
-      >
+      <InputField v-slot="{ id }" :label="$t('admin.settings.agents.backend.backend')" :docs-url="backendDocsUrl">
         <TextField :id="id" v-model="agent.backend" disabled />
       </InputField>
 
@@ -79,7 +75,6 @@
 </template>
 
 <script lang="ts" setup>
-import { setWith } from 'lodash';
 import { computed } from 'vue';
 
 import Button from '~/components/atomic/Button.vue';
@@ -110,14 +105,13 @@ const agent = computed({
 
 const baseDocsUrl = 'https://woodpecker-ci.org/docs/next/administration/backends/';
 
-const backendDocsUrl = computed(() =>{
+const backendDocsUrl = computed(() => {
   let backendUrlSuffix = agent.value.backend?.toLowerCase();
   if (backendUrlSuffix === 'custom') {
     backendUrlSuffix = 'custom-backends';
   }
-  return `${baseDocsUrl}${(backendUrlSuffix === '') ? 'docker' : backendUrlSuffix}`;
+  return `${baseDocsUrl}${backendUrlSuffix === '' ? 'docker' : backendUrlSuffix}`;
 });
-
 
 function updateAgent(newValues: Partial<Agent>) {
   emit('update:modelValue', { ...agent.value, ...newValues });

--- a/web/src/components/agent/AgentForm.vue
+++ b/web/src/components/agent/AgentForm.vue
@@ -26,7 +26,7 @@
         :label="$t('admin.settings.agents.backend.backend')"
         :docs-url="backendDocsUrl"
       >
-        <TextField :id="id" v-model="agent.backend" disabled />
+        <TextField :id="id" v-model="agent.backend" />
       </InputField>
 
       <InputField v-slot="{ id }" :label="$t('admin.settings.agents.platform.platform')">
@@ -111,17 +111,13 @@ const agent = computed({
 const baseDocsUrl = 'https://woodpecker-ci.org/docs/next/administration/backends/';
 
 const backendDocsUrl = computed(() =>{
-  switch(agent.value.backend?.toLowerCase()){
-    case 'local':
-      return `${baseDocsUrl}local`;
-    case 'kubernetes':
-      return `${baseDocsUrl}kubernetes`;
-    case 'custom':
-      return `${baseDocsUrl}custom-backends`;
-    default:
-      return `${baseDocsUrl}docker`
+  let backendUrlSuffix = agent.value.backend?.toLowerCase();
+  if (backendUrlSuffix === 'custom') {
+    backendUrlSuffix = 'custom-backends';
   }
-})
+  return `${baseDocsUrl}${(backendUrlSuffix === '') ? 'docker' : backendUrlSuffix}`;
+});
+
 
 function updateAgent(newValues: Partial<Agent>) {
   emit('update:modelValue', { ...agent.value, ...newValues });


### PR DESCRIPTION
Updated the agent configuration form to dynamically change the backend documentation URL based on the selected backend (Docker, Local, Kubernetes, Custom). I left the default URL as a docker.

Closes #4137