### PR TITLE
fix: repo/owner parsing for gitlab

### DIFF
--- a/server/forge/gitlab/convert.go
+++ b/server/forge/gitlab/convert.go
@@ -303,7 +303,9 @@ func extractFromPath(str string) (string, string, error) {
 	if len(s) < minPathComponents {
 		return "", "", fmt.Errorf("minimum match not found")
 	}
-	return s[0], s[1], nil
+	owner := strings.Join(s[:len(s)-1], "/")
+	name := s[len(s)-1]
+	return owner, name, nil
 }
 
 func convertLabels(from []*gitlab.EventLabel) []string {

--- a/server/forge/gitlab/gitlab_test.go
+++ b/server/forge/gitlab/gitlab_test.go
@@ -300,3 +300,17 @@ func Test_GitLab(t *testing.T) {
 		})
 	})
 }
+
+// Test function
+func TestExtractFromPath(t *testing.T) {
+	owner, name, err := extractFromPath("owner/group/repo")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if owner != "owner/group" {
+		t.Errorf("expected owner to be 'owner/group', got %s", owner)
+	}
+	if name != "repo" {
+		t.Errorf("expected name to be 'repo', got %s", name)
+	}
+}

--- a/server/forge/gitlab/gitlab_test.go
+++ b/server/forge/gitlab/gitlab_test.go
@@ -301,7 +301,7 @@ func Test_GitLab(t *testing.T) {
 	})
 }
 
-// Test function
+// Test extractFromPath function.
 func TestExtractFromPath(t *testing.T) {
 	owner, name, err := extractFromPath("owner/group/repo")
 	if err != nil {


### PR DESCRIPTION
`extractFromPath` wrongly splitted owner/group/repo patterns from repos in subgroups. 

Before, `owner/group/repo` resulted in `owner` (for owner) and `repo` for repo. However, it should be `owner/group` for owner. Otherwise, webhooks for repos with subpaths fail.

There was no test before, hence I added one. I want to test this first with PR images.

fix #4247 