### PR TITLE
Increase `WOODPECKER_FORGE_TIMEOUT` to fix config fetching for GitLab

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -287,7 +287,7 @@ var flags = append([]cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_FORGE_TIMEOUT"),
 		Name:    "forge-timeout",
 		Usage:   "how many seconds before timeout when fetching the Woodpecker configuration from a Forge",
-		Value:   time.Second * 3,
+		Value:   time.Second * 5,
 	},
 	&cli.UintFlag{
 		Sources: cli.EnvVars("WOODPECKER_FORGE_RETRY"),

--- a/docs/docs/30-administration/10-server-config.md
+++ b/docs/docs/30-administration/10-server-config.md
@@ -484,7 +484,7 @@ Specify a configuration service endpoint, see [Configuration Extension](./40-adv
 
 ### `WOODPECKER_FORGE_TIMEOUT`
 
-> Default: 3s
+> Default: 5s
 
 Specify timeout when fetching the Woodpecker configuration from forge. See <https://pkg.go.dev/time#ParseDuration> for syntax reference.
 

--- a/server/services/config/forge.go
+++ b/server/services/config/forge.go
@@ -143,11 +143,12 @@ func (f *forgeFetcherContext) getFirstAvailableConfig(c context.Context, configs
 	for _, fileOrFolder := range configs {
 		if strings.HasSuffix(fileOrFolder, "/") {
 			// config is a folder
+			log.Trace().Msgf("fetching 'fileOrFolder' %s from forge", fileOrFolder)
 			files, err := f.forge.Dir(c, f.user, f.repo, f.pipeline, strings.TrimSuffix(fileOrFolder, "/"))
 			// if folder is not supported we will get a "Not implemented" error and continue
 			if err != nil {
 				if !(errors.Is(err, types.ErrNotImplemented) || errors.Is(err, &types.ErrConfigNotFound{})) {
-					log.Error().Err(err).Str("repo", f.repo.FullName).Str("user", f.user.Login).Msg("could not get folder from forge")
+					log.Error().Err(err).Str("repo", f.repo.FullName).Str("user", f.user.Login).Msgf("could not get folder from forge: %s", err)
 					forgeErr = append(forgeErr, err)
 				}
 				continue

--- a/server/services/config/forge.go
+++ b/server/services/config/forge.go
@@ -59,7 +59,7 @@ func (f *forgeFetcher) Fetch(ctx context.Context, forge forge.Forge, user *model
 	for i := 0; i < int(f.retryCount); i++ {
 		files, err = ffc.fetch(ctx, strings.TrimSpace(repo.Config))
 		if err != nil {
-			log.Trace().Err(err).Msgf("%d. try failed", i+1)
+			log.Trace().Err(err).Msgf("Attempt #%d failed", i+1)
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			continue
@@ -143,7 +143,7 @@ func (f *forgeFetcherContext) getFirstAvailableConfig(c context.Context, configs
 	for _, fileOrFolder := range configs {
 		if strings.HasSuffix(fileOrFolder, "/") {
 			// config is a folder
-			log.Trace().Msgf("fetching 'fileOrFolder' %s from forge", fileOrFolder)
+			log.Trace().Msgf("fetching %s from forge", fileOrFolder)
 			files, err := f.forge.Dir(c, f.user, f.repo, f.pipeline, strings.TrimSuffix(fileOrFolder, "/"))
 			// if folder is not supported we will get a "Not implemented" error and continue
 			if err != nil {


### PR DESCRIPTION
fix #4260 

Config fetching on GL takes a bit longer due to the subgroup fetching and permissions checks.
In my case, I had 1/6 repos failing with the default of 3s. The repo only had two workflow files. Both were somewhat complex.

I assume that the workflow parsing combined with the subgroup checks exceeded the 3s here.
After bumping `WOODPECKER_FORGE_TIMEOUT` to 5s, it worked.
Getting the initial config fetched seems to speed up future config pull as afterwards I was able to reduce `WOODPECKER_FORGE_TIMEOUT` again to 3s.

However, to avoid such issues for users I think the default value should be bumped to (at least) 5s.

Additionally, I improved some of the log/trace outputs which helped me a bit along the way.