### PR TITLE
Do not require agent polling to make workflows that should be skiped done

### DIFF
--- a/cmd/server/grpc_server.go
+++ b/cmd/server/grpc_server.go
@@ -49,6 +49,7 @@ func runGrpcServer(ctx context.Context, c *cli.Command, _store store.Store) erro
 	)
 
 	woodpeckerServer := woodpeckerGrpcServer.NewWoodpeckerServer(
+		ctx,
 		server.Config.Services.Queue,
 		server.Config.Services.Logs,
 		server.Config.Services.Pubsub,

--- a/server/grpc/filter.go
+++ b/server/grpc/filter.go
@@ -22,6 +22,11 @@ import (
 
 func createFilterFunc(agentFilter rpc.Filter) queue.FilterFn {
 	return func(task *model.Task) (bool, int) {
+		// don't return tasks who are not ready jet
+		if !task.ShouldRun() {
+			return false, 0
+		}
+
 		score := 0
 		for taskLabel, taskLabelValue := range task.Labels {
 			// if a task label is empty it will be ignored

--- a/server/grpc/filter_test.go
+++ b/server/grpc/filter_test.go
@@ -62,7 +62,6 @@ func TestCreateFilterFunc(t *testing.T) {
 				Labels: map[string]string{"org-id": "123", "platform": "windows"},
 			},
 			wantMatched: false,
-			wantScore:   0,
 		},
 		{
 			name: "No match",
@@ -73,7 +72,6 @@ func TestCreateFilterFunc(t *testing.T) {
 				Labels: map[string]string{"org-id": "123", "platform": "windows"},
 			},
 			wantMatched: false,
-			wantScore:   0,
 		},
 		{
 			name: "Missing label",
@@ -84,7 +82,6 @@ func TestCreateFilterFunc(t *testing.T) {
 				Labels: map[string]string{"needed": "some"},
 			},
 			wantMatched: false,
-			wantScore:   0,
 		},
 		{
 			name: "Empty task labels",
@@ -118,6 +115,15 @@ func TestCreateFilterFunc(t *testing.T) {
 			},
 			wantMatched: true,
 			wantScore:   2,
+		},
+		{
+			name:        "dont match task not ready to run",
+			agentFilter: rpc.Filter{},
+			task: &model.Task{
+				Labels: map[string]string{"org-id": "123", "platform": "linux"},
+				RunOn:  []string{"success"},
+			},
+			wantMatched: false,
 		},
 	}
 

--- a/server/grpc/rpc.go
+++ b/server/grpc/rpc.go
@@ -100,6 +100,7 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 
 		workflow := new(rpc.Workflow)
 		err = json.Unmarshal(task.Data, workflow)
+
 		return workflow, err
 	}
 }

--- a/server/grpc/rpc.go
+++ b/server/grpc/rpc.go
@@ -88,6 +88,8 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 			return nil, err
 		}
 
+		// TODO: evaluate if a task should not run and mark it as done, currently require a running agent
+		// who trigger a pull. this should move into it's own go routine.
 		if task.ShouldRun() {
 			workflow := new(rpc.Workflow)
 			err = json.Unmarshal(task.Data, workflow)

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -17,6 +17,7 @@ package grpc
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	prometheus_auto "github.com/prometheus/client_golang/prometheus/promauto"
@@ -25,11 +26,15 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/rpc"
 	"go.woodpecker-ci.org/woodpecker/v2/pipeline/rpc/proto"
 	"go.woodpecker-ci.org/woodpecker/v2/server/logging"
+	"go.woodpecker-ci.org/woodpecker/v2/server/model"
 	"go.woodpecker-ci.org/woodpecker/v2/server/pubsub"
 	"go.woodpecker-ci.org/woodpecker/v2/server/queue"
 	"go.woodpecker-ci.org/woodpecker/v2/server/store"
 	"go.woodpecker-ci.org/woodpecker/v2/version"
 )
+
+// markSkippedDoneTimeInterval is the time interval we search in the queue for workflows that can be marked as done
+const markSkippedDoneTimeInterval = 3 * time.Second
 
 // WoodpeckerServer is a grpc server implementation.
 type WoodpeckerServer struct {
@@ -37,7 +42,7 @@ type WoodpeckerServer struct {
 	peer RPC
 }
 
-func NewWoodpeckerServer(queue queue.Queue, logger logging.Log, pubsub *pubsub.Publisher, store store.Store) proto.WoodpeckerServer {
+func NewWoodpeckerServer(ctx context.Context, queue queue.Queue, logger logging.Log, pubsub *pubsub.Publisher, store store.Store) proto.WoodpeckerServer {
 	pipelineTime := prometheus_auto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "woodpecker",
 		Name:      "pipeline_time",
@@ -49,6 +54,7 @@ func NewWoodpeckerServer(queue queue.Queue, logger logging.Log, pubsub *pubsub.P
 		Help:      "Pipeline count.",
 	}, []string{"repo", "branch", "status", "pipeline"})
 	peer := RPC{
+		ctx:           ctx,
 		store:         store,
 		queue:         queue,
 		pubsub:        pubsub,
@@ -56,7 +62,35 @@ func NewWoodpeckerServer(queue queue.Queue, logger logging.Log, pubsub *pubsub.P
 		pipelineTime:  pipelineTime,
 		pipelineCount: pipelineCount,
 	}
-	return &WoodpeckerServer{peer: peer}
+	rpcServer := &WoodpeckerServer{peer: peer}
+	go rpcServer.markSkippedDone()
+	return rpcServer
+}
+
+// mark skipped tasks done, based on dependencies.
+// TODO: find better place for this background service
+func (ws *WoodpeckerServer) markSkippedDone() {
+	for {
+		select {
+		case <-time.After(markSkippedDoneTimeInterval):
+		case <-ws.peer.ctx.Done():
+			return
+		}
+
+		task, err := ws.peer.queue.Poll(ws.peer.ctx, -1, func(t *model.Task) (bool, int) {
+			if !t.ShouldRun() {
+				return true, 0
+			}
+			return false, 0
+		})
+		if err != nil {
+			log.Error().Err(err).Msg("got error while polling for tasks that should be skipped")
+			continue
+		}
+		if err := ws.peer.Done(ws.peer.ctx, task.ID, rpc.WorkflowState{}); err != nil {
+			log.Error().Err(err).Msgf("marking workflow task '%s' as done failed", task.ID)
+		}
+	}
 }
 
 func (s *WoodpeckerServer) Version(_ context.Context, _ *proto.Empty) (*proto.VersionResponse, error) {

--- a/server/pipeline/stepbuilder/stepBuilder.go
+++ b/server/pipeline/stepbuilder/stepBuilder.go
@@ -240,12 +240,13 @@ func (b *StepBuilder) environmentVariables(metadata metadata.Metadata, axis matr
 	return environ
 }
 
-func (b *StepBuilder) toInternalRepresentation(parsed *yaml_types.Workflow, environ map[string]string, metadata metadata.Metadata, workflowID int64) (*backend_types.Config, error) {
-	var secrets []compiler.Secret
-	for _, sec := range b.Secs {
-		var events []string
-		for _, event := range sec.Events {
-			events = append(events, string(event))
+func toCompilerSecrets(in []*model.Secret) []compiler.Secret {
+	secrets := make([]compiler.Secret, 0, len(in))
+
+	for _, sec := range in {
+		events := make([]string, len(sec.Events))
+		for i, event := range sec.Events {
+			events[i] = string(event)
 		}
 
 		secrets = append(secrets, compiler.Secret{
@@ -256,14 +257,24 @@ func (b *StepBuilder) toInternalRepresentation(parsed *yaml_types.Workflow, envi
 		})
 	}
 
-	var registries []compiler.Registry
-	for _, reg := range b.Regs {
+	return secrets
+}
+
+func toCompilerRegistries(in []*model.Registry) []compiler.Registry {
+	registries := make([]compiler.Registry, 0, len(in))
+	for _, reg := range in {
 		registries = append(registries, compiler.Registry{
 			Hostname: reg.Address,
 			Username: reg.Username,
 			Password: reg.Password,
 		})
 	}
+	return registries
+}
+
+func (b *StepBuilder) toInternalRepresentation(parsed *yaml_types.Workflow, environ map[string]string, metadata metadata.Metadata, workflowID int64) (*backend_types.Config, error) {
+	secrets := toCompilerSecrets(b.Secs)
+	registries := toCompilerRegistries(b.Regs)
 
 	return compiler.New(
 		compiler.WithEnviron(environ),


### PR DESCRIPTION
currently we have in the task poll logic an check that clean up the queue of tasks that should be skipped.
so it requires agents to poll to actually do stuff.

but the agent poll logic should ignore all tasks that are not ready to run and the queue maintenance should happen in an dedicated place.

this pull starts to refactor this by at least move it in it's own function and go routine in the background.