### PR TITLE
Don't parse forge config files multiple times if no error occured (#4272)

### DIFF
--- a/server/services/config/forge.go
+++ b/server/services/config/forge.go
@@ -59,10 +59,9 @@ func (f *forgeFetcher) Fetch(ctx context.Context, forge forge.Forge, user *model
 	for i := 0; i < int(f.retryCount); i++ {
 		files, err = ffc.fetch(ctx, strings.TrimSpace(repo.Config))
 		if err != nil {
-			log.Trace().Err(err).Msgf("%d. try failed", i+1)
-		}
-		if errors.Is(err, context.DeadlineExceeded) {
-			continue
+			log.Trace().Err(err).Msgf("Fetching config files: Attempt #%d failed", i+1)
+		} else {
+			break
 		}
 	}
 

--- a/server/services/config/forge_test.go
+++ b/server/services/config/forge_test.go
@@ -287,7 +287,7 @@ func TestFetch(t *testing.T) {
 			f := new(mocks.Forge)
 			dirs := map[string][]*forge_types.FileMeta{}
 			for _, file := range tt.files {
-				f.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, file.name).Return(file.data, nil)
+				f.On("File", mock.Anything, mock.Anything, mock.Anything, mock.Anything, file.name).Once().Return(file.data, nil)
 				path := filepath.Dir(file.name)
 				if path != "." {
 					dirs[path] = append(dirs[path], &forge_types.FileMeta{
@@ -298,7 +298,7 @@ func TestFetch(t *testing.T) {
 			}
 
 			for path, files := range dirs {
-				f.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, path).Return(files, nil)
+				f.On("Dir", mock.Anything, mock.Anything, mock.Anything, mock.Anything, path).Once().Return(files, nil)
 			}
 
 			// if the previous mocks do not match return not found errors


### PR DESCRIPTION
Backport  #4272