### PR TITLE
fix `error="io: read/write on closed pipe"` on k8s backend

### DIFF
--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -379,7 +379,6 @@ func (e *kube) TailStep(ctx context.Context, step *types.Step, taskUUID string) 
 	go func() {
 		defer logs.Close()
 		defer wc.Close()
-		defer rc.Close()
 
 		_, err = io.Copy(wc, logs)
 		if err != nil {


### PR DESCRIPTION
ref #1616

Seeing these errors a lot in the k8s backend.

```
│ 8:47AM ERR copy limited logStream part error="io: read/write on closed pipe" image=docker.io/woodpeckerci/plugin-git:2.5.1 pipeline=45 repo=images/misc workflow_id=9053                                 │
│ 8:47AM ERR copy limited logStream part error="io: read/write on closed pipe" image=docker.io/woodpeckerci/plugin-git:2.5.1 pipeline=45 repo=images/misc workflow_id=9054  
```

I don't know if this fixes it but the linked fix addressed exactly that for the docker backend. Can anyone infer if this might be applicable?