### PR TITLE
Move update notifier dot into settings button

### DIFF
--- a/web/src/components/layout/header/Navbar.vue
+++ b/web/src/components/layout/header/Navbar.vue
@@ -19,13 +19,18 @@
       }}</a>
     </div>
     <div class="flex ml-auto -m-1.5 items-center space-x-2">
-      <div v-if="user?.admin" class="relative">
-        <IconButton class="navbar-icon" :title="$t('settings')" :to="{ name: 'admin-settings' }" icon="settings" />
+      <IconButton
+        v-if="user?.admin"
+        class="navbar-icon relative"
+        :title="$t('settings')"
+        :to="{ name: 'admin-settings' }"
+      >
+        <Icon name="settings" />
         <div
           v-if="version?.needsUpdate"
           class="absolute top-2 right-2 bg-int-wp-state-error-100 rounded-full w-3 h-3"
         />
-      </div>
+      </IconButton>
 
       <ActivePipelines v-if="user" class="navbar-icon" />
       <IconButton v-if="user" :to="{ name: 'user' }" :title="$t('user.settings.settings')" class="navbar-icon !p-1.5">
@@ -41,6 +46,7 @@ import { useRoute } from 'vue-router';
 
 import WoodpeckerLogo from '~/assets/logo.svg?component';
 import Button from '~/components/atomic/Button.vue';
+import Icon from '~/components/atomic/Icon.vue';
 import IconButton from '~/components/atomic/IconButton.vue';
 import useAuthentication from '~/compositions/useAuthentication';
 import useConfig from '~/compositions/useConfig';


### PR DESCRIPTION
Fixes the dot blocking clicking the button.

The dot in question:
![image](https://github.com/user-attachments/assets/9c520a53-9e50-4ba1-a2af-8c1996365213)


<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
