### PR TITLE
Add `cli lint` option to treat warnings as errors

### DIFF
--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -40,7 +40,7 @@ steps:
       - go run go.woodpecker-ci.org/woodpecker/v2/cmd/cli lint
     environment:
       WOODPECKER_DISABLE_UPDATE_CHECK: true
-      WOODPECKER_WARNING_AS_ERROR: true
+      WOODPECKER_LINT_STRICT: true
       WOODPECKER_PLUGINS_PRIVILEGED: 'docker.io/woodpeckerci/plugin-docker-buildx:5.0.0'
     when:
       - event: pull_request

--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -40,6 +40,7 @@ steps:
       - go run go.woodpecker-ci.org/woodpecker/v2/cmd/cli lint
     environment:
       WOODPECKER_DISABLE_UPDATE_CHECK: true
+      WOODPECKER_WARNING_AS_ERROR: true
       WOODPECKER_PLUGINS_PRIVILEGED: 'docker.io/woodpeckerci/plugin-docker-buildx:5.0.0'
     when:
       - event: pull_request

--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -220,7 +220,7 @@ func execWithAxis(ctx context.Context, c *cli.Command, file, repoPath string, ax
 		Workflow:  conf,
 	}})
 	if err != nil {
-		str, err := lint.FormatLintError(file, err)
+		str, err := lint.FormatLintError(file, err, false)
 		fmt.Print(str)
 		if err != nil {
 			return err

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -48,6 +48,11 @@ var Command = &cli.Command{
 			Usage:   "Plugins which are trusted to handle the netrc info in clone steps",
 			Value:   constant.TrustedClonePlugins,
 		},
+		&cli.BoolFlag{
+			Sources: cli.EnvVars("WOODPECKER_WARNING_AS_ERROR"),
+			Name:    "warning-as-error",
+			Usage:   "treat warnings as errors",
+		},
 	},
 }
 
@@ -119,7 +124,7 @@ func lintFile(_ context.Context, c *cli.Command, file string) error {
 		linter.WithTrustedClonePlugins(c.StringSlice("plugins-trusted-clone")),
 	).Lint([]*linter.WorkflowConfig{config})
 	if err != nil {
-		str, err := FormatLintError(config.File, err)
+		str, err := FormatLintError(config.File, err, c.Bool("warning-as-error"))
 
 		if str != "" {
 			fmt.Print(str)

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -49,8 +49,8 @@ var Command = &cli.Command{
 			Value:   constant.TrustedClonePlugins,
 		},
 		&cli.BoolFlag{
-			Sources: cli.EnvVars("WOODPECKER_WARNING_AS_ERROR"),
-			Name:    "warning-as-error",
+			Sources: cli.EnvVars("WOODPECKER_LINT_STRICT"),
+			Name:    "strict",
 			Usage:   "treat warnings as errors",
 		},
 	},
@@ -124,7 +124,7 @@ func lintFile(_ context.Context, c *cli.Command, file string) error {
 		linter.WithTrustedClonePlugins(c.StringSlice("plugins-trusted-clone")),
 	).Lint([]*linter.WorkflowConfig{config})
 	if err != nil {
-		str, err := FormatLintError(config.File, err, c.Bool("warning-as-error"))
+		str, err := FormatLintError(config.File, err, c.Bool("strict"))
 
 		if str != "" {
 			fmt.Print(str)

--- a/cli/lint/utils.go
+++ b/cli/lint/utils.go
@@ -10,7 +10,7 @@ import (
 	pipeline_errors "go.woodpecker-ci.org/woodpecker/v2/pipeline/errors"
 )
 
-func FormatLintError(file string, err error) (string, error) {
+func FormatLintError(file string, err error, warningAsError bool) (string, error) {
 	if err == nil {
 		return "", nil
 	}
@@ -24,7 +24,7 @@ func FormatLintError(file string, err error) (string, error) {
 	for _, err := range linterErrors {
 		line := "  "
 
-		if err.IsWarning {
+		if !warningAsError && err.IsWarning {
 			line = fmt.Sprintf("%s ⚠️ ", line)
 			amountWarnings++
 		} else {

--- a/cli/lint/utils.go
+++ b/cli/lint/utils.go
@@ -10,7 +10,7 @@ import (
 	pipeline_errors "go.woodpecker-ci.org/woodpecker/v2/pipeline/errors"
 )
 
-func FormatLintError(file string, err error, warningAsError bool) (string, error) {
+func FormatLintError(file string, err error, strict bool) (string, error) {
 	if err == nil {
 		return "", nil
 	}
@@ -24,7 +24,7 @@ func FormatLintError(file string, err error, warningAsError bool) (string, error
 	for _, err := range linterErrors {
 		line := "  "
 
-		if !warningAsError && err.IsWarning {
+		if !strict && err.IsWarning {
 			line = fmt.Sprintf("%s ⚠️ ", line)
 			amountWarnings++
 		} else {


### PR DESCRIPTION
Add option treat warnings as errors for pipeline linter:

https://ci.woodpecker-ci.org/repos/3780/pipeline/22592/34 **FAILED SUCCESSFULLY**