### PR TITLE
Use squared spinner for active pipelines

### DIFF
--- a/web/src/components/layout/header/ActivePipelines.vue
+++ b/web/src/components/layout/header/ActivePipelines.vue
@@ -1,21 +1,17 @@
 <template>
   <IconButton :title="$t('pipeline_feed')" class="!p-1.5 relative text-current active-pipelines-toggle" @click="toggle">
-    <div v-if="activePipelines.length > 0" class="spinner m-1">
-      <div class="spinner-ring ring1" />
-      <div class="spinner-ring ring2" />
-      <div class="spinner-ring ring3" />
-      <div class="spinner-ring ring4" />
-    </div>
+    <div v-if="activePipelines.length > 0" class="spinner" />
     <div
-      class="flex items-center justify-center h-full w-full font-bold bg-white bg-opacity-15 dark:bg-black dark:bg-opacity-10 rounded-md"
+      class="z-1 flex items-center justify-center h-full w-full font-bold bg-white bg-opacity-15 dark:bg-black dark:bg-opacity-10 rounded-md"
     >
-      {{ activePipelines.length || 0 }}
+      <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+      {{ pipelineCount > 9 ? "9+" : pipelineCount }}
     </div>
   </IconButton>
 </template>
 
 <script lang="ts" setup>
-import { onMounted, toRef } from 'vue';
+import { computed, onMounted, toRef } from 'vue';
 
 import IconButton from '~/components/atomic/IconButton.vue';
 import usePipelineFeed from '~/compositions/usePipelineFeed';
@@ -23,6 +19,8 @@ import usePipelineFeed from '~/compositions/usePipelineFeed';
 const pipelineFeed = usePipelineFeed();
 const activePipelines = toRef(pipelineFeed, 'activePipelines');
 const { toggle } = pipelineFeed;
+const pipelineCount = computed(() => activePipelines.value.length || 0);
+
 
 onMounted(async () => {
   await pipelineFeed.load();
@@ -30,29 +28,29 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.spinner {
-  @apply absolute top-0 bottom-0 left-0 right-0;
-}
-.spinner .spinner-ring {
-  animation: spinner 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
-  border-color: #fff transparent transparent transparent;
-  @apply border-3 rounded-full absolute top-1.5 bottom-1.5 left-1.5 right-1.5;
-}
-.spinner .ring1 {
-  animation-delay: -0.45s;
-}
-.spinner .ring2 {
-  animation-delay: -0.3s;
-}
-.spinner .ring3 {
-  animation-delay: -0.15s;
-}
-@keyframes spinner {
-  0% {
-    transform: rotate(0deg);
-  }
+@keyframes spinner-rotate {
   100% {
-    transform: rotate(360deg);
+    transform: rotate(1turn);
   }
+}
+.spinner {
+  @apply absolute z-0 inset-1.5 rounded-md;
+  overflow: hidden;
+}
+.spinner::before {
+  @apply absolute -z-2 bg-wp-primary-200 dark:bg-wp-primary-300 ;
+  content: "";
+  left: -50%;
+  top: -50%;
+  width: 200%;
+  height: 200%;
+  background-repeat: no-repeat;
+  background-size: 50% 50%, 50% 50%;
+  background-image: linear-gradient(#fff, transparent);
+  animation: spinner-rotate 1.5s linear infinite;
+}
+.spinner::after {
+  @apply absolute inset-0.5 rounded-md bg-blend-darken bg-wp-primary-200 dark:bg-wp-primary-300;
+  content: "";
 }
 </style>

--- a/web/src/components/layout/header/ActivePipelines.vue
+++ b/web/src/components/layout/header/ActivePipelines.vue
@@ -1,6 +1,10 @@
 <template>
-  <IconButton :title="$t('pipeline_feed')" class="!p-1.5 relative text-current active-pipelines-toggle" @click="toggle">
-    <div v-if="activePipelines.length > 0" class="spinner" />
+  <IconButton
+    :title="pipelineCount > 0 ? `${$t('pipeline_feed')} (${pipelineCount})` : $t('pipeline_feed')"
+    class="!p-1.5 relative text-current active-pipelines-toggle"
+    @click="toggle"
+  >
+    <div v-if="pipelineCount > 0" class="spinner" />
     <div
       class="z-1 flex items-center justify-center h-full w-full font-bold bg-white bg-opacity-15 dark:bg-black dark:bg-opacity-10 rounded-md"
     >

--- a/web/src/components/layout/header/ActivePipelines.vue
+++ b/web/src/components/layout/header/ActivePipelines.vue
@@ -5,7 +5,7 @@
       class="z-1 flex items-center justify-center h-full w-full font-bold bg-white bg-opacity-15 dark:bg-black dark:bg-opacity-10 rounded-md"
     >
       <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
-      {{ pipelineCount > 9 ? "9+" : pipelineCount }}
+      {{ pipelineCount > 9 ? '9+' : pipelineCount }}
     </div>
   </IconButton>
 </template>
@@ -20,7 +20,6 @@ const pipelineFeed = usePipelineFeed();
 const activePipelines = toRef(pipelineFeed, 'activePipelines');
 const { toggle } = pipelineFeed;
 const pipelineCount = computed(() => activePipelines.value.length || 0);
-
 
 onMounted(async () => {
   await pipelineFeed.load();
@@ -38,19 +37,21 @@ onMounted(async () => {
   overflow: hidden;
 }
 .spinner::before {
-  @apply absolute -z-2 bg-wp-primary-200 dark:bg-wp-primary-300 ;
-  content: "";
+  @apply absolute -z-2 bg-wp-primary-200 dark:bg-wp-primary-300;
+  content: '';
   left: -50%;
   top: -50%;
   width: 200%;
   height: 200%;
   background-repeat: no-repeat;
-  background-size: 50% 50%, 50% 50%;
+  background-size:
+    50% 50%,
+    50% 50%;
   background-image: linear-gradient(#fff, transparent);
   animation: spinner-rotate 1.5s linear infinite;
 }
 .spinner::after {
   @apply absolute inset-0.5 rounded-md bg-blend-darken bg-wp-primary-200 dark:bg-wp-primary-300;
-  content: "";
+  content: '';
 }
 </style>


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/discussions/2162#discussioncomment-8205012

- Use squared spinner to have a bit more space
- Display "9+" if more than 9 pipelines are running

https://github.com/user-attachments/assets/3f6c3836-f7c0-429f-ab76-cc8a1d22856f

