### PR TITLE
Remove enableManagers from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>woodpecker-ci/renovate-config"],
   "automergeType": "pr",
-  "enabledManagers": ["woodpecker"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Issue introduced in https://github.com/woodpecker-ci/woodpecker/pull/4276

Not sure why this config was added, but all none-experimental managers are enabled by default. Besides that, the correct way is:

```json
  "some-new-manager": {
    "enabled": true
  }
```

`enabledManagers` will automatically disable all managers and only use managers explicitly enabled by this parameter.