### PR TITLE
Add back button to repo pipeline list

### DIFF
--- a/web/src/views/repo/RepoWrapper.vue
+++ b/web/src/views/repo/RepoWrapper.vue
@@ -68,10 +68,10 @@ import useAuthentication from '~/compositions/useAuthentication';
 import useConfig from '~/compositions/useConfig';
 import { useForgeStore } from '~/compositions/useForgeStore';
 import useNotifications from '~/compositions/useNotifications';
+import { useRouteBack } from '~/compositions/useRouteBack';
 import type { Forge, RepoPermissions } from '~/lib/api/types';
 import { usePipelineStore } from '~/store/pipelines';
 import { useRepoStore } from '~/store/repos';
-import { useRouteBack } from '~/compositions/useRouteBack';
 
 const props = defineProps<{
   repoId: string;
@@ -89,7 +89,6 @@ const router = useRouter();
 const i18n = useI18n();
 const config = useConfig();
 const forgeStore = useForgeStore();
-
 
 const repo = repoStore.getRepo(repositoryId);
 const repoPermissions = ref<RepoPermissions>();

--- a/web/src/views/repo/RepoWrapper.vue
+++ b/web/src/views/repo/RepoWrapper.vue
@@ -4,6 +4,7 @@
     v-model:active-tab="activeTab"
     enable-tabs
     disable-tab-url-hash-mode
+    :go-back="goBack"
   >
     <template #title>
       <span class="flex">
@@ -70,6 +71,7 @@ import useNotifications from '~/compositions/useNotifications';
 import type { Forge, RepoPermissions } from '~/lib/api/types';
 import { usePipelineStore } from '~/store/pipelines';
 import { useRepoStore } from '~/store/repos';
+import { useRouteBack } from '~/compositions/useRouteBack';
 
 const props = defineProps<{
   repoId: string;
@@ -87,6 +89,7 @@ const router = useRouter();
 const i18n = useI18n();
 const config = useConfig();
 const forgeStore = useForgeStore();
+
 
 const repo = repoStore.getRepo(repositoryId);
 const repoPermissions = ref<RepoPermissions>();
@@ -153,4 +156,6 @@ const activeTab = computed({
     }
   },
 });
+
+const goBack = useRouteBack({ name: 'repos' });
 </script>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5d6439de-1eb2-4a71-b62e-49dfdeb2f1f9)


Was this button always missing? Or was it removed (by accident) at some point?