### PR TITLE
add dark hover color for tabsets

### DIFF
--- a/web/src/components/layout/scaffold/Tabs.vue
+++ b/web/src/components/layout/scaffold/Tabs.vue
@@ -17,7 +17,7 @@
       />
       <Icon v-else name="blank" class="md:hidden" />
       <span
-        class="flex gap-2 items-center md:justify-center flex-row py-1 px-2 w-full min-w-20 hover:bg-wp-background-200 rounded-md"
+        class="flex gap-2 items-center md:justify-center flex-row py-1 px-2 w-full min-w-20 dark:hover:bg-wp-background-100 hover:bg-wp-background-200 rounded-md"
       >
         <Icon v-if="tab.icon" :name="tab.icon" :class="tab.iconClass" class="flex-shrink-0" size="20" />
         <span>{{ tab.title }}</span>


### PR DESCRIPTION
regression from #4431 

Before

<img width="39" alt="image" src="https://github.com/user-attachments/assets/b225c8a6-4de9-429b-8b3f-c1f49a727b38">

After

<img width="41" alt="image" src="https://github.com/user-attachments/assets/290ad7e7-4a8c-4f08-87fd-8ff382996696">
