### PR TITLE
Normalize aarch64 -> arm64 for docker backend (#4451)

### DIFF
--- a/pipeline/backend/docker/docker.go
+++ b/pipeline/backend/docker/docker.go
@@ -377,6 +377,8 @@ func normalizeArchType(s string) string {
 	switch s {
 	case "x86_64":
 		return "amd64"
+	case "aarch64":
+		return "arm64"
 	default:
 		return s
 	}


### PR DESCRIPTION
Backports #4451

Harmonize aarch64 - arm64

fix https://github.com/woodpecker-ci/woodpecker/issues/4051 https://github.com/woodpecker-ci/woodpecker/discussions/2861