### PR TITLE
Trim space from agent token

### DIFF
--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -133,7 +133,7 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 
 	agentConfig := readAgentConfig(agentConfigPath)
 
-	agentToken := c.String("grpc-token")
+	agentToken := strings.TrimSpace(c.String("grpc-token"))
 	grpcClientCtx, grpcClientCtxCancel := context.WithCancelCause(context.Background())
 	defer grpcClientCtxCancel(nil)
 	authClient := agent_rpc.NewAuthGrpcClient(authConn, agentToken, agentConfig.AgentID)


### PR DESCRIPTION
so e.g. newlines don't mather if you load the secret from an file