### PR TITLE
Sanitize strings in table output

### DIFF
--- a/cli/output/table.go
+++ b/cli/output/table.go
@@ -147,12 +147,12 @@ func (o *Table) Write(columns []string, obj any) error {
 		colName := strings.ToLower(col)
 		if alias, ok := o.fieldAlias[colName]; ok {
 			if fn, ok := o.fieldMapping[alias]; ok {
-				out = append(out, fn(obj))
+				out = append(out, sanitizeString(fn(obj)))
 				continue
 			}
 		}
 		if fn, ok := o.fieldMapping[colName]; ok {
-			out = append(out, fn(obj))
+			out = append(out, sanitizeString(fn(obj)))
 			continue
 		}
 		if value, ok := dataL[strings.ReplaceAll(colName, "_", "")]; ok {
@@ -165,10 +165,10 @@ func (o *Table) Write(columns []string, obj any) error {
 				continue
 			}
 			if s, ok := value.(string); ok {
-				out = append(out, NA(s))
+				out = append(out, NA(sanitizeString(s)))
 				continue
 			}
-			out = append(out, fmt.Sprintf("%v", value))
+			out = append(out, sanitizeString(value))
 		}
 	}
 	_, _ = fmt.Fprintln(o.w, strings.Join(out, "\t"))
@@ -200,4 +200,10 @@ func fieldName(name string) string {
 		out = append(out, unicode.ToLower(r[i]))
 	}
 	return string(out)
+}
+
+func sanitizeString(value any) string {
+	str := fmt.Sprintf("%v", value)
+	replacer := strings.NewReplacer("\n", " ", "\r", " ")
+	return strings.TrimSpace(replacer.Replace(str))
 }

--- a/cli/pipeline/pipeline_test.go
+++ b/cli/pipeline/pipeline_test.go
@@ -23,7 +23,7 @@ func TestPipelineOutput(t *testing.T) {
 		{
 			name:     "table output with default columns",
 			args:     []string{},
-			expected: "NUMBER  STATUS   EVENT  BRANCH  MESSAGE  AUTHOR\n1       success  push   main    message  John Doe\n",
+			expected: "NUMBER  STATUS   EVENT  BRANCH  MESSAGE            AUTHOR\n1       success  push   main    message multiline  John Doe\n",
 		},
 		{
 			name:     "table output with custom columns",
@@ -33,7 +33,7 @@ func TestPipelineOutput(t *testing.T) {
 		{
 			name:     "table output with no header",
 			args:     []string{"output", "--output-no-headers"},
-			expected: "1  success  push  main  message  John Doe\n",
+			expected: "1  success  push  main  message multiline  John Doe\n",
 		},
 		{
 			name:     "go-template output",
@@ -53,8 +53,8 @@ func TestPipelineOutput(t *testing.T) {
 			Status:  "success",
 			Event:   "push",
 			Branch:  "main",
-			Message: "message\n\n",
-			Author:  "John Doe",
+			Message: "message\nmultiline",
+			Author:  "John Doe\n",
 		},
 	}
 

--- a/cli/pipeline/pipeline_test.go
+++ b/cli/pipeline/pipeline_test.go
@@ -53,7 +53,7 @@ func TestPipelineOutput(t *testing.T) {
 			Status:  "success",
 			Event:   "push",
 			Branch:  "main",
-			Message: "message",
+			Message: "message\n\n",
 			Author:  "John Doe",
 		},
 	}


### PR DESCRIPTION
Some commit messages contain newlines. While this might be a server issue, we should sanitize the output anyway.

Before:

```
❯ ./dist/woodpecker-cli pipeline ls --output table 14
NUMBER  STATUS   EVENT  BRANCH  MESSAGE  AUTHOR
13      success  push   main    trigger ci
        woodpecker
12      success  push  main  trigger ci
```

After:
```
❯ ./dist/woodpecker-cli pipeline ls --output table 14
NUMBER  STATUS   EVENT   BRANCH  MESSAGE                 AUTHOR
13      success  push    main    trigger ci              woodpecker
12      success  push    main    trigger ci              woodpecker
```