### PR TITLE
Trim space to all config flags that allow to read value from file

### DIFF
--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -133,7 +133,7 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 
 	agentConfig := readAgentConfig(agentConfigPath)
 
-	agentToken := strings.TrimSpace(c.String("grpc-token"))
+	agentToken := c.String("grpc-token")
 	grpcClientCtx, grpcClientCtxCancel := context.WithCancelCause(context.Background())
 	defer grpcClientCtxCancel(nil)
 	authClient := agent_rpc.NewAuthGrpcClient(authConn, agentToken, agentConfig.AgentID)

--- a/cmd/agent/core/flags.go
+++ b/cmd/agent/core/flags.go
@@ -36,6 +36,9 @@ var flags = []cli.Flag{
 		Sources: cli.NewValueSourceChain(
 			cli.File(os.Getenv("WOODPECKER_AGENT_SECRET_FILE")),
 			cli.EnvVar("WOODPECKER_AGENT_SECRET")),
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.BoolFlag{
 		Sources: cli.EnvVars("WOODPECKER_GRPC_SECURE"),

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -116,6 +116,9 @@ var flags = append([]cli.Flag{
 		Name:  "grpc-secret",
 		Usage: "grpc jwt secret",
 		Value: "secret",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_METRICS_SERVER_ADDR"),
@@ -217,6 +220,9 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_AGENT_SECRET")),
 		Name:  "agent-secret",
 		Usage: "server-agent shared password",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.BoolFlag{
 		Sources: cli.EnvVars("WOODPECKER_DISABLE_USER_AGENT_REGISTRATION"),
@@ -248,6 +254,9 @@ var flags = append([]cli.Flag{
 		Aliases: []string{"datasource"}, // TODO: remove in v4.0.0
 		Usage:   "database driver configuration string",
 		Value:   datasourceDefaultValue(),
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.NewValueSourceChain(
@@ -255,6 +264,9 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_PROMETHEUS_AUTH_TOKEN")),
 		Name:  "prometheus-auth-token",
 		Usage: "token to secure prometheus metrics endpoint",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_STATUS_CONTEXT", "WOODPECKER_GITHUB_CONTEXT", "WOODPECKER_GITEA_CONTEXT"),
@@ -354,6 +366,9 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_BITBUCKET_DC_CLIENT_ID")),
 		Name:  "forge-oauth-client",
 		Usage: "oauth2 client id",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.NewValueSourceChain(
@@ -375,6 +390,9 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_BITBUCKET_DC_CLIENT_SECRET")),
 		Name:  "forge-oauth-secret",
 		Usage: "oauth2 client secret",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.BoolFlag{
 		Name:  "forge-skip-verify",
@@ -466,6 +484,9 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_BITBUCKET_DC_GIT_USERNAME")),
 		Name:  "bitbucket-dc-git-username",
 		Usage: "Bitbucket DataCenter/Server service account username",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.NewValueSourceChain(
@@ -473,6 +494,9 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_BITBUCKET_DC_GIT_PASSWORD")),
 		Name:  "bitbucket-dc-git-password",
 		Usage: "Bitbucket DataCenter/Server service account password",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	//
 	// development flags
@@ -500,11 +524,17 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_ENCRYPTION_KEY")),
 		Name:  "encryption-raw-key",
 		Usage: "Raw encryption key",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_ENCRYPTION_TINK_KEYSET_FILE"),
 		Name:    "encryption-tink-keyset",
 		Usage:   "Google tink AEAD-compatible keyset file to encrypt secrets in DB",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.BoolFlag{
 		Sources: cli.EnvVars("WOODPECKER_ENCRYPTION_DISABLE"),


### PR DESCRIPTION
files often have a newline at the end but we expect simple values, so we should trim space for these options.

based on https://github.com/urfave/cli/issues/2013#issuecomment-2503855416

followup to https://github.com/woodpecker-ci/woodpecker/pull/4465