### PR TITLE
Add pipeline purge command to cli

### DIFF
--- a/cli/pipeline/kill.go
+++ b/cli/pipeline/kill.go
@@ -48,7 +48,7 @@ func pipelineKill(ctx context.Context, c *cli.Command) (err error) {
 		return err
 	}
 
-	err = client.PipelineKill(repoID, number)
+	err = client.PipelineDelete(repoID, number)
 	if err != nil {
 		return err
 	}

--- a/cli/pipeline/list.go
+++ b/cli/pipeline/list.go
@@ -77,14 +77,14 @@ func List(ctx context.Context, c *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	resources, err := pipelineList(ctx, c, client)
+	resources, err := pipelineList(c, client)
 	if err != nil {
 		return err
 	}
 	return pipelineOutput(c, resources)
 }
 
-func pipelineList(_ context.Context, c *cli.Command, client woodpecker.Client) ([]woodpecker.Pipeline, error) {
+func pipelineList(c *cli.Command, client woodpecker.Client) ([]woodpecker.Pipeline, error) {
 	resources := make([]woodpecker.Pipeline, 0)
 
 	repoIDOrFullName := c.Args().First()

--- a/cli/pipeline/list_test.go
+++ b/cli/pipeline/list_test.go
@@ -112,8 +112,8 @@ func TestPipelineList(t *testing.T) {
 
 			command := buildPipelineListCmd()
 			command.Writer = io.Discard
-			command.Action = func(ctx context.Context, c *cli.Command) error {
-				pipelines, err := pipelineList(ctx, c, mockClient)
+			command.Action = func(_ context.Context, c *cli.Command) error {
+				pipelines, err := pipelineList(c, mockClient)
 				if tt.wantErr != nil {
 					assert.EqualError(t, err, tt.wantErr.Error())
 					return nil

--- a/cli/pipeline/pipeline.go
+++ b/cli/pipeline/pipeline.go
@@ -46,7 +46,7 @@ var Command = &cli.Command{
 		pipelineCreateCmd,
 		log.Command,
 		deploy.Command,
-		buildPipelinePurgeCmd(),
+		pipelinePurgeCmd,
 	},
 }
 

--- a/cli/pipeline/pipeline.go
+++ b/cli/pipeline/pipeline.go
@@ -47,6 +47,7 @@ var Command = &cli.Command{
 		pipelineCreateCmd,
 		log.Command,
 		deploy.Command,
+		buildPipelinePurgeCmd(),
 	},
 }
 

--- a/cli/pipeline/purge.go
+++ b/cli/pipeline/purge.go
@@ -1,0 +1,120 @@
+// Copyright 2022 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/woodpecker/v2/cli/internal"
+	"go.woodpecker-ci.org/woodpecker/v2/woodpecker-go/woodpecker"
+)
+
+//nolint:mnd
+func buildPipelinePurgeCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "purge",
+		Usage:     "purge pipelines",
+		ArgsUsage: "<repo-id|repo-full-name>",
+		Action:    Purge,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "older-than",
+				Usage:    "remove pipelines older than the specified time limit",
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:  "keep-min",
+				Usage: "minimum number of pipelines to keep",
+				//nolint:mnd
+				Value: 10,
+			},
+		},
+	}
+}
+
+func Purge(ctx context.Context, c *cli.Command) error {
+	client, err := internal.NewClient(ctx, c)
+	if err != nil {
+		return err
+	}
+	return pipelinePurge(c, client)
+}
+
+func pipelinePurge(c *cli.Command, client woodpecker.Client) (err error) {
+	repoIDOrFullName := c.Args().First()
+	if len(repoIDOrFullName) == 0 {
+		return fmt.Errorf("missing required argument repo-id / repo-full-name")
+	}
+	repoID, err := internal.ParseRepo(client, repoIDOrFullName)
+	if err != nil {
+		return fmt.Errorf("invalid repo '%s': %w", repoIDOrFullName, err)
+	}
+
+	olderThan := c.String("older-than")
+	keepMin := c.Int("keep-min")
+
+	duration, err := time.ParseDuration(olderThan)
+	if err != nil {
+		return err
+	}
+
+	opt := woodpecker.PipelineListOptions{
+		ListOptions: woodpecker.ListOptions{
+			Page:    1,
+			PerPage: int(keepMin),
+		},
+	}
+
+	pipelinesKeep, err := client.PipelineList(repoID, opt)
+	if err != nil {
+		return err
+	}
+
+	opt.ListOptions = woodpecker.ListOptions{}
+	opt.Before = time.Now().Add(-duration)
+	opt.After = time.Now()
+
+	pipelines, err := client.PipelineList(repoID, opt)
+	if err != nil {
+		return err
+	}
+
+	// Create a map of pipeline IDs to keep
+	keepMap := make(map[int64]struct{})
+	for _, p := range pipelinesKeep {
+		keepMap[p.ID] = struct{}{}
+	}
+
+	// Filter pipelines to only include those not in keepMap
+	var pipelinesToPurge []*woodpecker.Pipeline
+	for _, p := range pipelines {
+		if _, exists := keepMap[p.ID]; !exists {
+			pipelinesToPurge = append(pipelinesToPurge, p)
+		}
+	}
+
+	for _, p := range pipelinesToPurge {
+		err := client.PipelineDelete(repoID, p.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cli/pipeline/purge.go
+++ b/cli/pipeline/purge.go
@@ -41,7 +41,6 @@ func buildPipelinePurgeCmd() *cli.Command {
 			&cli.IntFlag{
 				Name:  "keep-min",
 				Usage: "minimum number of pipelines to keep",
-				//nolint:mnd
 				Value: 10,
 			},
 		},

--- a/cli/pipeline/purge.go
+++ b/cli/pipeline/purge.go
@@ -28,30 +28,28 @@ import (
 )
 
 //nolint:mnd
-func buildPipelinePurgeCmd() *cli.Command {
-	return &cli.Command{
-		Name:      "purge",
-		Usage:     "purge pipelines",
-		ArgsUsage: "<repo-id|repo-full-name>",
-		Action:    Purge,
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:     "older-than",
-				Usage:    "remove pipelines older than the specified time limit",
-				Required: true,
-			},
-			&cli.IntFlag{
-				Name:  "keep-min",
-				Usage: "minimum number of pipelines to keep",
-				Value: 10,
-			},
-			&cli.BoolFlag{
-				Name:  "dry-run",
-				Usage: "disable non-read api calls",
-				Value: false,
-			},
+var pipelinePurgeCmd = &cli.Command{
+	Name:      "purge",
+	Usage:     "purge pipelines",
+	ArgsUsage: "<repo-id|repo-full-name>",
+	Action:    Purge,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "older-than",
+			Usage:    "remove pipelines older than the specified time limit",
+			Required: true,
 		},
-	}
+		&cli.IntFlag{
+			Name:  "keep-min",
+			Usage: "minimum number of pipelines to keep",
+			Value: 10,
+		},
+		&cli.BoolFlag{
+			Name:  "dry-run",
+			Usage: "disable non-read api calls",
+			Value: false,
+		},
+	},
 }
 
 func Purge(ctx context.Context, c *cli.Command) error {

--- a/cli/pipeline/purge_test.go
+++ b/cli/pipeline/purge_test.go
@@ -1,0 +1,96 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/woodpecker/v2/woodpecker-go/woodpecker"
+	"go.woodpecker-ci.org/woodpecker/v2/woodpecker-go/woodpecker/mocks"
+)
+
+func TestPipelinePurge(t *testing.T) {
+	tests := []struct {
+		name          string
+		repoID        int64
+		args          []string
+		pipelinesKeep []*woodpecker.Pipeline
+		pipelines     []*woodpecker.Pipeline
+		wantDelete    int
+		wantErr       error
+	}{
+		{
+			name:   "success with no pipelines to purge",
+			repoID: 1,
+			args:   []string{"purge", "--older-than", "1h", "repo/name"},
+			pipelinesKeep: []*woodpecker.Pipeline{
+				{ID: 1},
+			},
+			pipelines: []*woodpecker.Pipeline{},
+		},
+		{
+			name:   "success with pipelines to purge",
+			repoID: 1,
+			args:   []string{"purge", "--older-than", "1h", "repo/name"},
+			pipelinesKeep: []*woodpecker.Pipeline{
+				{ID: 1},
+			},
+			pipelines: []*woodpecker.Pipeline{
+				{ID: 1},
+				{ID: 2},
+				{ID: 3},
+			},
+			wantDelete: 2,
+		},
+		{
+			name:    "error on invalid duration",
+			repoID:  1,
+			args:    []string{"purge", "--older-than", "invalid", "repo/name"},
+			wantErr: errors.New("time: invalid duration \"invalid\""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := mocks.NewClient(t)
+
+			mockClient.On("RepoLookup", mock.Anything).Maybe().Return(&woodpecker.Repo{ID: tt.repoID}, nil)
+
+			mockClient.On("PipelineList", tt.repoID, mock.MatchedBy(func(opt woodpecker.PipelineListOptions) bool {
+				return opt.PerPage > 0
+			})).Maybe().Return(tt.pipelinesKeep, nil)
+
+			mockClient.On("PipelineList", tt.repoID, mock.MatchedBy(func(opt woodpecker.PipelineListOptions) bool {
+				return !opt.Before.IsZero() || !opt.After.IsZero()
+			})).Maybe().Return(tt.pipelines, nil)
+
+			if tt.wantDelete > 0 {
+				mockClient.On("PipelineDelete", tt.repoID, mock.Anything).Return(nil)
+			}
+
+			command := buildPipelinePurgeCmd()
+			command.Writer = io.Discard
+			command.Action = func(_ context.Context, c *cli.Command) error {
+				err := pipelinePurge(c, mockClient)
+
+				if tt.wantErr != nil {
+					assert.EqualError(t, err, tt.wantErr.Error())
+					return nil
+				}
+
+				assert.NoError(t, err)
+
+				mockClient.AssertNumberOfCalls(t, "PipelineDelete", tt.wantDelete)
+
+				return nil
+			}
+
+			_ = command.Run(context.Background(), tt.args)
+		})
+	}
+}

--- a/cli/pipeline/purge_test.go
+++ b/cli/pipeline/purge_test.go
@@ -84,7 +84,7 @@ func TestPipelinePurge(t *testing.T) {
 				mockClient.On("PipelineDelete", tt.repoID, mock.Anything).Return(nil).Times(tt.wantDelete)
 			}
 
-			command := buildPipelinePurgeCmd()
+			command := pipelinePurgeCmd
 			command.Writer = io.Discard
 			command.Action = func(_ context.Context, c *cli.Command) error {
 				err := pipelinePurge(c, mockClient)

--- a/cli/pipeline/purge_test.go
+++ b/cli/pipeline/purge_test.go
@@ -61,16 +61,16 @@ func TestPipelinePurge(t *testing.T) {
 			mockClient.On("RepoLookup", mock.Anything).Maybe().Return(&woodpecker.Repo{ID: tt.repoID}, nil)
 
 			mockClient.On("PipelineList", mock.Anything, mock.Anything).Return(func(_ int64, opt woodpecker.PipelineListOptions) ([]*woodpecker.Pipeline, error) {
-				// Return keep pipelines for first call without Before/After filters
-				if opt.Before.IsZero() && opt.After.IsZero() {
+				// Return keep pipelines for first call
+				if opt.After.IsZero() {
 					if opt.Page == 1 {
 						return tt.pipelinesKeep, nil
 					}
 					return []*woodpecker.Pipeline{}, nil
 				}
 
-				// Return pipelines to purge for calls with Before filter
-				if !opt.Before.IsZero() {
+				// Return pipelines to purge for calls with After filter
+				if !opt.After.IsZero() {
 					if opt.Page == 1 {
 						return tt.pipelines, nil
 					}

--- a/web/package.json
+++ b/web/package.json
@@ -72,6 +72,5 @@
     "overrides": {
       "semver@<7.5.2": ">=7.5.2"
     }
-  },
-  "packageManager": "pnpm@9.14.2+sha512.6e2baf77d06b9362294152c851c4f278ede37ab1eba3a55fda317a4a17b209f4dbb973fb250a77abc463a341fcb1f17f17cfa24091c4eb319cda0d9b84278387"
+  }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -72,5 +72,6 @@
     "overrides": {
       "semver@<7.5.2": ">=7.5.2"
     }
-  }
+  },
+  "packageManager": "pnpm@9.14.2+sha512.6e2baf77d06b9362294152c851c4f278ede37ab1eba3a55fda317a4a17b209f4dbb973fb250a77abc463a341fcb1f17f17cfa24091c4eb319cda0d9b84278387"
 }

--- a/woodpecker-go/woodpecker/interface.go
+++ b/woodpecker-go/woodpecker/interface.go
@@ -84,6 +84,8 @@ type Client interface {
 	// the specified repository.
 	PipelineList(repoID int64, opt PipelineListOptions) ([]*Pipeline, error)
 
+	PipelineDelete(repoID, pipeline int64) error
+
 	// PipelineQueue returns a list of enqueued pipelines.
 	PipelineQueue() ([]*Feed, error)
 
@@ -101,9 +103,6 @@ type Client interface {
 
 	// PipelineDecline declines a blocked pipeline.
 	PipelineDecline(repoID, pipeline int64) (*Pipeline, error)
-
-	// PipelineKill force kills the running pipeline.
-	PipelineKill(repoID, pipeline int64) error
 
 	// PipelineMetadata returns metadata for a pipeline.
 	PipelineMetadata(repoID int64, pipelineNumber int) ([]byte, error)

--- a/woodpecker-go/woodpecker/mocks/client.go
+++ b/woodpecker-go/woodpecker/mocks/client.go
@@ -1133,12 +1133,12 @@ func (_m *Client) PipelineDecline(repoID int64, pipeline int64) (*woodpecker.Pip
 	return r0, r1
 }
 
-// PipelineKill provides a mock function with given fields: repoID, pipeline
-func (_m *Client) PipelineKill(repoID int64, pipeline int64) error {
+// PipelineDelete provides a mock function with given fields: repoID, pipeline
+func (_m *Client) PipelineDelete(repoID int64, pipeline int64) error {
 	ret := _m.Called(repoID, pipeline)
 
 	if len(ret) == 0 {
-		panic("no return value specified for PipelineKill")
+		panic("no return value specified for PipelineDelete")
 	}
 
 	var r0 error

--- a/woodpecker-go/woodpecker/repo.go
+++ b/woodpecker-go/woodpecker/repo.go
@@ -321,6 +321,13 @@ func (c *client) PipelineList(repoID int64, opt PipelineListOptions) ([]*Pipelin
 	return out, err
 }
 
+// PipelineDelete deletes a pipeline by the specified repository ID and pipeline ID.
+func (c *client) PipelineDelete(repoID, pipeline int64) error {
+	uri := fmt.Sprintf(pathPipeline, c.addr, repoID, pipeline)
+	err := c.delete(uri)
+	return err
+}
+
 // PipelineCreate creates a new pipeline for the specified repository.
 func (c *client) PipelineCreate(repoID int64, options *PipelineOptions) (*Pipeline, error) {
 	var out *Pipeline
@@ -359,13 +366,6 @@ func (c *client) PipelineDecline(repoID, pipeline int64) (*Pipeline, error) {
 	uri := fmt.Sprintf(pathDecline, c.addr, repoID, pipeline)
 	err := c.post(uri, nil, out)
 	return out, err
-}
-
-// PipelineKill force kills the running pipeline.
-func (c *client) PipelineKill(repoID, pipeline int64) error {
-	uri := fmt.Sprintf(pathPipeline, c.addr, repoID, pipeline)
-	err := c.delete(uri)
-	return err
 }
 
 // LogsPurge purges the pipeline all steps logs for the specified pipeline.


### PR DESCRIPTION
```
❯ ./dist/woodpecker-cli pipeline purge -h
NAME:
   woodpecker-cli pipeline purge - purge pipelines

USAGE:
   woodpecker-cli pipeline purge [command [command options]] <repo-id|repo-full-name>

OPTIONS:
   --older-than value  remove pipelines older than the specified time limit
   --keep-min value    minimum number of pipelines to keep (default: 10)
   --help, -h          show help
```