### PR TITLE
Enforce exact matching for GitLab groups

### DIFF
--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -130,7 +130,7 @@ func PostRepo(c *gin.Context) {
 	if errors.Is(err, types.RecordNotExist) {
 		org, err = _forge.Org(c, user, repo.Owner)
 		if err != nil {
-			msg := "could not fetch organization from forge."
+			msg := fmt.Sprintf("Organization %s not found in DB. Attempting to create new one.", repo.Owner)
 			log.Error().Err(err).Msg(msg)
 			c.String(http.StatusInternalServerError, msg)
 			return
@@ -139,7 +139,7 @@ func PostRepo(c *gin.Context) {
 		org.ForgeID = user.ForgeID
 		err = _store.OrgCreate(org)
 		if err != nil {
-			msg := "could not create organization in store."
+			msg := fmt.Sprintf("Failed to create organization %s.", repo.Owner)
 			log.Error().Err(err).Msg(msg)
 			c.String(http.StatusInternalServerError, msg)
 			return

--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -749,7 +749,7 @@ func (g *GitLab) Org(ctx context.Context, u *model.User, owner string) (*model.O
 	groups, _, err := client.Groups.ListGroups(&gitlab.ListGroupsOptions{
 		ListOptions: gitlab.ListOptions{
 			Page:    1,
-			PerPage: 1,
+			PerPage: perPage,
 		},
 		Search: gitlab.Ptr(owner),
 	}, gitlab.WithContext(ctx))
@@ -757,13 +757,21 @@ func (g *GitLab) Org(ctx context.Context, u *model.User, owner string) (*model.O
 		return nil, err
 	}
 
-	if len(groups) != 1 {
+	var matchedGroup *gitlab.Group
+	for _, group := range groups {
+		if group.FullPath == owner {
+			matchedGroup = group
+			break
+		}
+	}
+
+	if matchedGroup == nil {
 		return nil, fmt.Errorf("could not find org %s", owner)
 	}
 
 	return &model.Org{
-		Name:    groups[0].FullPath,
-		Private: groups[0].Visibility != gitlab.PublicVisibility,
+		Name:    matchedGroup.FullPath,
+		Private: matchedGroup.Visibility != gitlab.PublicVisibility,
 	}, nil
 }
 


### PR DESCRIPTION
fix #2922 

Until now, GL groups were matched partially. This caused an issue in the following case:

1. In a new instance with only subgroup repos enabled
2. Enable a non-subgroup repo 
3. Partial match for the first owner/subgroup of the existing orgs
4. Attempt to (re)create owner/subgroup although it already exists -> error

By enforcing an exact match, the query returns `nil` for a non-existing top-level group and will attempt to (correctly) create a new WP org for it, letting the overall repo add operation succeed.

Fix has already been tested to work.

I don't think there should be any potential downsides when switching to exact matching.

Besides, I also updated the error message wording I encountered.

Should be backported.
