### PR TITLE
Use pagination helper to list pipelines in cli

### DIFF
--- a/cli/pipeline/create.go
+++ b/cli/pipeline/create.go
@@ -74,5 +74,5 @@ func pipelineCreate(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	return pipelineOutput(c, []woodpecker.Pipeline{*pipeline})
+	return pipelineOutput(c, []*woodpecker.Pipeline{pipeline})
 }

--- a/cli/pipeline/last.go
+++ b/cli/pipeline/last.go
@@ -58,5 +58,5 @@ func pipelineLast(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	return pipelineOutput(c, []woodpecker.Pipeline{*pipeline})
+	return pipelineOutput(c, []*woodpecker.Pipeline{pipeline})
 }

--- a/cli/pipeline/list.go
+++ b/cli/pipeline/list.go
@@ -78,20 +78,18 @@ func List(ctx context.Context, c *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	resources, err := pipelineList(c, client)
+	pipelines, err := pipelineList(c, client)
 	if err != nil {
 		return err
 	}
-	return pipelineOutput(c, resources)
+	return pipelineOutput(c, pipelines)
 }
 
-func pipelineList(c *cli.Command, client woodpecker.Client) ([]woodpecker.Pipeline, error) {
-	resources := make([]woodpecker.Pipeline, 0)
-
+func pipelineList(c *cli.Command, client woodpecker.Client) ([]*woodpecker.Pipeline, error) {
 	repoIDOrFullName := c.Args().First()
 	repoID, err := internal.ParseRepo(client, repoIDOrFullName)
 	if err != nil {
-		return resources, err
+		return nil, err
 	}
 
 	opt := woodpecker.PipelineListOptions{}
@@ -116,27 +114,15 @@ func pipelineList(c *cli.Command, client woodpecker.Client) ([]woodpecker.Pipeli
 				},
 				Before: opt.Before,
 				After:  opt.After,
+				Branch: branch,
+				Events: []string{event},
+				Status: status,
 			},
 		)
 	}, limit)
 	if err != nil {
-		return resources, err
+		return nil, err
 	}
 
-	var count int
-	for _, pipeline := range pipelines {
-		if branch != "" && pipeline.Branch != branch {
-			continue
-		}
-		if event != "" && pipeline.Event != event {
-			continue
-		}
-		if status != "" && pipeline.Status != status {
-			continue
-		}
-		resources = append(resources, *pipeline)
-		count++
-	}
-
-	return resources, nil
+	return pipelines, nil
 }

--- a/cli/pipeline/list_test.go
+++ b/cli/pipeline/list_test.go
@@ -41,47 +41,6 @@ func TestPipelineList(t *testing.T) {
 			},
 		},
 		{
-			name:   "filter by branch",
-			repoID: 1,
-			pipelines: []*woodpecker.Pipeline{
-				{ID: 1, Branch: "main", Event: "push", Status: "success"},
-				{ID: 2, Branch: "develop", Event: "pull_request", Status: "running"},
-				{ID: 3, Branch: "main", Event: "push", Status: "failure"},
-			},
-			args: []string{"ls", "--branch", "main", "repo/name"},
-			expected: []woodpecker.Pipeline{
-				{ID: 1, Branch: "main", Event: "push", Status: "success"},
-				{ID: 3, Branch: "main", Event: "push", Status: "failure"},
-			},
-		},
-		{
-			name:   "filter by event",
-			repoID: 1,
-			pipelines: []*woodpecker.Pipeline{
-				{ID: 1, Branch: "main", Event: "push", Status: "success"},
-				{ID: 2, Branch: "develop", Event: "pull_request", Status: "running"},
-				{ID: 3, Branch: "main", Event: "push", Status: "failure"},
-			},
-			args: []string{"ls", "--event", "push", "repo/name"},
-			expected: []woodpecker.Pipeline{
-				{ID: 1, Branch: "main", Event: "push", Status: "success"},
-				{ID: 3, Branch: "main", Event: "push", Status: "failure"},
-			},
-		},
-		{
-			name:   "filter by status",
-			repoID: 1,
-			pipelines: []*woodpecker.Pipeline{
-				{ID: 1, Branch: "main", Event: "push", Status: "success"},
-				{ID: 2, Branch: "develop", Event: "pull_request", Status: "running"},
-				{ID: 3, Branch: "main", Event: "push", Status: "failure"},
-			},
-			args: []string{"ls", "--status", "success", "repo/name"},
-			expected: []woodpecker.Pipeline{
-				{ID: 1, Branch: "main", Event: "push", Status: "success"},
-			},
-		},
-		{
 			name:   "limit results",
 			repoID: 1,
 			pipelines: []*woodpecker.Pipeline{

--- a/cli/pipeline/list_test.go
+++ b/cli/pipeline/list_test.go
@@ -22,7 +22,7 @@ func TestPipelineList(t *testing.T) {
 		pipelines   []*woodpecker.Pipeline
 		pipelineErr error
 		args        []string
-		expected    []woodpecker.Pipeline
+		expected    []*woodpecker.Pipeline
 		wantErr     error
 	}{
 		{
@@ -34,7 +34,7 @@ func TestPipelineList(t *testing.T) {
 				{ID: 3, Branch: "main", Event: "push", Status: "failure"},
 			},
 			args: []string{"ls", "repo/name"},
-			expected: []woodpecker.Pipeline{
+			expected: []*woodpecker.Pipeline{
 				{ID: 1, Branch: "main", Event: "push", Status: "success"},
 				{ID: 2, Branch: "develop", Event: "pull_request", Status: "running"},
 				{ID: 3, Branch: "main", Event: "push", Status: "failure"},
@@ -49,7 +49,7 @@ func TestPipelineList(t *testing.T) {
 				{ID: 3, Branch: "main", Event: "push", Status: "failure"},
 			},
 			args: []string{"ls", "--limit", "2", "repo/name"},
-			expected: []woodpecker.Pipeline{
+			expected: []*woodpecker.Pipeline{
 				{ID: 1, Branch: "main", Event: "push", Status: "success"},
 				{ID: 2, Branch: "develop", Event: "pull_request", Status: "running"},
 			},

--- a/cli/pipeline/list_test.go
+++ b/cli/pipeline/list_test.go
@@ -107,7 +107,15 @@ func TestPipelineList(t *testing.T) {
 	for _, tt := range testtases {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := mocks.NewClient(t)
-			mockClient.On("PipelineList", mock.Anything, mock.Anything).Return(tt.pipelines, tt.pipelineErr)
+			mockClient.On("PipelineList", mock.Anything, mock.Anything).Return(func(_ int64, opt woodpecker.PipelineListOptions) ([]*woodpecker.Pipeline, error) {
+				if tt.pipelineErr != nil {
+					return nil, tt.pipelineErr
+				}
+				if opt.Page == 1 {
+					return tt.pipelines, nil
+				}
+				return []*woodpecker.Pipeline{}, nil
+			}).Maybe()
 			mockClient.On("RepoLookup", mock.Anything).Return(&woodpecker.Repo{ID: tt.repoID}, nil)
 
 			command := buildPipelineListCmd()

--- a/cli/pipeline/pipeline.go
+++ b/cli/pipeline/pipeline.go
@@ -50,7 +50,7 @@ var Command = &cli.Command{
 	},
 }
 
-func pipelineOutput(c *cli.Command, resources []woodpecker.Pipeline, fd ...io.Writer) error {
+func pipelineOutput(c *cli.Command, pipelines []*woodpecker.Pipeline, fd ...io.Writer) error {
 	outFmt, outOpt := output.ParseOutputOptions(c.String("output"))
 	noHeader := c.Bool("output-no-headers")
 
@@ -74,7 +74,7 @@ func pipelineOutput(c *cli.Command, resources []woodpecker.Pipeline, fd ...io.Wr
 		if err != nil {
 			return err
 		}
-		if err := tmpl.Execute(out, resources); err != nil {
+		if err := tmpl.Execute(out, pipelines); err != nil {
 			return err
 		}
 	case "table":
@@ -89,7 +89,7 @@ func pipelineOutput(c *cli.Command, resources []woodpecker.Pipeline, fd ...io.Wr
 		if !noHeader {
 			table.WriteHeader(cols)
 		}
-		for _, resource := range resources {
+		for _, resource := range pipelines {
 			if err := table.Write(cols, resource); err != nil {
 				return err
 			}

--- a/cli/pipeline/pipeline_test.go
+++ b/cli/pipeline/pipeline_test.go
@@ -47,7 +47,7 @@ func TestPipelineOutput(t *testing.T) {
 		},
 	}
 
-	pipelines := []woodpecker.Pipeline{
+	pipelines := []*woodpecker.Pipeline{
 		{
 			Number:  1,
 			Status:  "success",

--- a/cli/pipeline/show.go
+++ b/cli/pipeline/show.go
@@ -65,5 +65,5 @@ func pipelineShow(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	return pipelineOutput(c, []woodpecker.Pipeline{*pipeline})
+	return pipelineOutput(c, []*woodpecker.Pipeline{pipeline})
 }

--- a/woodpecker-go/woodpecker/repo.go
+++ b/woodpecker-go/woodpecker/repo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -31,8 +32,12 @@ const (
 
 type PipelineListOptions struct {
 	ListOptions
-	Before time.Time
-	After  time.Time
+	Before      time.Time
+	After       time.Time
+	Branch      string
+	Events      []string
+	RefContains string
+	Status      string
 }
 
 type CronListOptions struct {
@@ -76,6 +81,18 @@ func (opt *PipelineListOptions) QueryEncode() string {
 	}
 	if !opt.After.IsZero() {
 		query.Add("after", opt.After.Format(time.RFC3339))
+	}
+	if opt.Branch != "" {
+		query.Add("branch", opt.Branch)
+	}
+	if len(opt.Events) > 0 {
+		query.Add("event", strings.Join(opt.Events, ","))
+	}
+	if opt.RefContains != "" {
+		query.Add("ref_contains", opt.RefContains)
+	}
+	if opt.Status != "" {
+		query.Add("status", opt.Status)
 	}
 	return query.Encode()
 }

--- a/woodpecker-go/woodpecker/repo.go
+++ b/woodpecker-go/woodpecker/repo.go
@@ -89,7 +89,7 @@ func (opt *PipelineListOptions) QueryEncode() string {
 		query.Add("event", strings.Join(opt.Events, ","))
 	}
 	if opt.RefContains != "" {
-		query.Add("ref_contains", opt.RefContains)
+		query.Add("ref", opt.RefContains)
 	}
 	if opt.Status != "" {
 		query.Add("status", opt.Status)


### PR DESCRIPTION
This PR fixes the `woodecker-cli pipeline ls` command. Before this change it was no possible to list more than 50 pipelines as this is the hardcoded limit of the API for pipelines per page.