### PR TITLE
Fix woodpecker-go repo model to match server

### DIFF
--- a/cli/pipeline/deploy/deploy.go
+++ b/cli/pipeline/deploy/deploy.go
@@ -80,7 +80,7 @@ func deploy(ctx context.Context, c *cli.Command) error {
 			return err
 		}
 
-		branch = repo.DefaultBranch
+		branch = repo.Branch
 	}
 
 	pipelineArg := c.Args().Get(1)

--- a/woodpecker-go/woodpecker/types.go
+++ b/woodpecker-go/woodpecker/types.go
@@ -46,29 +46,34 @@ type (
 		Admin  bool   `json:"admin"`
 	}
 
+	TrustedConfiguration struct {
+		Network  bool `json:"network"`
+		Volumes  bool `json:"volumes"`
+		Security bool `json:"security"`
+	}
+
 	// Repo represents a repository.
 	Repo struct {
-		ID                           int64        `json:"id,omitempty"`
-		ForgeRemoteID                string       `json:"forge_remote_id"`
-		Owner                        string       `json:"owner"`
-		Name                         string       `json:"name"`
-		FullName                     string       `json:"full_name"`
-		Avatar                       string       `json:"avatar_url,omitempty"`
-		ForgeURL                     string       `json:"forge_url,omitempty"`
-		Clone                        string       `json:"clone_url,omitempty"`
-		DefaultBranch                string       `json:"default_branch,omitempty"`
-		SCMKind                      string       `json:"scm,omitempty"`
-		Timeout                      int64        `json:"timeout,omitempty"`
-		Visibility                   string       `json:"visibility"`
-		IsSCMPrivate                 bool         `json:"private"`
-		IsTrusted                    bool         `json:"trusted"`
-		IsGated                      bool         `json:"gated,omitempty"` // TODO: remove in next major release
-		RequireApproval              ApprovalMode `json:"require_approval"`
-		IsActive                     bool         `json:"active"`
-		AllowPullRequests            bool         `json:"allow_pr"`
-		Config                       string       `json:"config_file"`
-		CancelPreviousPipelineEvents []string     `json:"cancel_previous_pipeline_events"`
-		NetrcOnlyTrusted             bool         `json:"netrc_only_trusted"`
+		ID                           int64                `json:"id,omitempty"`
+		ForgeRemoteID                string               `json:"forge_remote_id"`
+		Owner                        string               `json:"owner"`
+		Name                         string               `json:"name"`
+		FullName                     string               `json:"full_name"`
+		Avatar                       string               `json:"avatar_url,omitempty"`
+		ForgeURL                     string               `json:"forge_url,omitempty"`
+		Clone                        string               `json:"clone_url,omitempty"`
+		Branch                       string               `json:"default_branch,omitempty"`
+		SCMKind                      string               `json:"scm,omitempty"`
+		Timeout                      int64                `json:"timeout,omitempty"`
+		Visibility                   string               `json:"visibility"`
+		IsSCMPrivate                 bool                 `json:"private"`
+		Trusted                      TrustedConfiguration `json:"trusted"`
+		RequireApproval              ApprovalMode         `json:"require_approval"`
+		IsActive                     bool                 `json:"active"`
+		AllowPull                    bool                 `json:"allow_pr"`
+		Config                       string               `json:"config_file"`
+		CancelPreviousPipelineEvents []string             `json:"cancel_previous_pipeline_events"`
+		NetrcTrustedPlugins          []string             `json:"netrc_trusted"`
 	}
 
 	// RepoPatch defines a repository patch request.


### PR DESCRIPTION
The repo model in `woodpecker-go` should match the server model. Before this change, there was an error:

```
❯ ./dist/woodpecker-cli repo ls --format "{{ .FullName }}"
11:27PM FTL error running cli error="json: cannot unmarshal object into Go struct field Repo.trusted of type bool"
```