### PR TITLE
Move pipeline logs command

### DIFF
--- a/cli/pipeline/log/log.go
+++ b/cli/pipeline/log/log.go
@@ -23,6 +23,7 @@ var Command = &cli.Command{
 	Name:  "log",
 	Usage: "manage logs",
 	Commands: []*cli.Command{
+		logShowCmd,
 		logPurgeCmd,
 	},
 }

--- a/cli/pipeline/pipeline.go
+++ b/cli/pipeline/pipeline.go
@@ -35,7 +35,6 @@ var Command = &cli.Command{
 	Commands: []*cli.Command{
 		buildPipelineListCmd(),
 		pipelineLastCmd,
-		pipelineLogsCmd,
 		pipelineInfoCmd,
 		pipelineStopCmd,
 		pipelineStartCmd,

--- a/docs/src/pages/migrations.md
+++ b/docs/src/pages/migrations.md
@@ -42,6 +42,7 @@ This will be the next version of Woodpecker.
   - `woodpecker-cli log` is now `woodpecker-cli pipeline log`
   - `woodpecker-cli cron` is now `woodpecker-cli repo cron`
   - `woodpecker-cli secret [add|rm|...] --repository` is now `woodpecker-cli repo secret [add|rm|...]`
+  - `woodpecker-cli pipeline logs` is now `woodpecker-cli pipeline log show`
 
 ## Admin migrations
 


### PR DESCRIPTION
After restructuring the cli we had `woodpecker-cli pipeline log purge` and `woodpecker-cli pipeline logs` command. This PR moves `woodpecker-cli pipeline logs` to `woodpecker-cli pipeline log show` command.