### PR TITLE
Unify cli commands and flags

### DIFF
--- a/cli/admin/loglevel/loglevel.go
+++ b/cli/admin/loglevel/loglevel.go
@@ -29,7 +29,7 @@ import (
 var Command = &cli.Command{
 	Name:      "log-level",
 	ArgsUsage: "[level]",
-	Usage:     "get the logging level of the server, or set it with [level]",
+	Usage:     "retrieve log level from server, or set it with [level]",
 	Action:    logLevel,
 }
 
@@ -59,6 +59,6 @@ func logLevel(ctx context.Context, c *cli.Command) error {
 		}
 	}
 
-	log.Info().Msgf("logging level: %s", ll.Level)
+	log.Info().Msgf("Log level: %s", ll.Level)
 	return nil
 }

--- a/cli/admin/loglevel/loglevel.go
+++ b/cli/admin/loglevel/loglevel.go
@@ -59,6 +59,6 @@ func logLevel(ctx context.Context, c *cli.Command) error {
 		}
 	}
 
-	log.Info().Msgf("Log level: %s", ll.Level)
+	log.Info().Msgf("log level: %s", ll.Level)
 	return nil
 }

--- a/cli/admin/registry/registry.go
+++ b/cli/admin/registry/registry.go
@@ -26,7 +26,7 @@ var Command = &cli.Command{
 		registryCreateCmd,
 		registryDeleteCmd,
 		registryUpdateCmd,
-		registryInfoCmd,
+		registryShowCmd,
 		registryListCmd,
 	},
 }

--- a/cli/admin/registry/registry_add.go
+++ b/cli/admin/registry/registry_add.go
@@ -27,7 +27,7 @@ import (
 
 var registryCreateCmd = &cli.Command{
 	Name:   "add",
-	Usage:  "adds a registry",
+	Usage:  "add a registry",
 	Action: registryCreate,
 	Flags: []cli.Flag{
 		&cli.StringFlag{

--- a/cli/admin/registry/registry_show.go
+++ b/cli/admin/registry/registry_show.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Woodpecker Authors
+// Copyright 2024 Woodpecker Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,13 +25,11 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/cli/internal"
 )
 
-var registryInfoCmd = &cli.Command{
-	Name:      "info",
-	Usage:     "display registry info",
-	ArgsUsage: "[repo-id|repo-full-name]",
-	Action:    registryInfo,
+var registryShowCmd = &cli.Command{
+	Name:   "show",
+	Usage:  "show registry information",
+	Action: registryShow,
 	Flags: []cli.Flag{
-		common.RepoFlag,
 		&cli.StringFlag{
 			Name:  "hostname",
 			Usage: "registry hostname",
@@ -41,7 +39,7 @@ var registryInfoCmd = &cli.Command{
 	},
 }
 
-func registryInfo(ctx context.Context, c *cli.Command) error {
+func registryShow(ctx context.Context, c *cli.Command) error {
 	var (
 		hostname = c.String("hostname")
 		format   = c.String("format") + "\n"
@@ -52,12 +50,7 @@ func registryInfo(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	repoID, err := parseTargetArgs(client, c)
-	if err != nil {
-		return err
-	}
-
-	registry, err := client.Registry(repoID, hostname)
+	registry, err := client.GlobalRegistry(hostname)
 	if err != nil {
 		return err
 	}

--- a/cli/admin/secret/secret.go
+++ b/cli/admin/secret/secret.go
@@ -26,7 +26,7 @@ var Command = &cli.Command{
 		secretCreateCmd,
 		secretDeleteCmd,
 		secretUpdateCmd,
-		secretInfoCmd,
+		secretShowCmd,
 		secretListCmd,
 	},
 }

--- a/cli/admin/secret/secret_add.go
+++ b/cli/admin/secret/secret_add.go
@@ -27,7 +27,7 @@ import (
 
 var secretCreateCmd = &cli.Command{
 	Name:      "add",
-	Usage:     "adds a secret",
+	Usage:     "add a secret",
 	ArgsUsage: "[repo-id|repo-full-name]",
 	Action:    secretCreate,
 	Flags: []cli.Flag{

--- a/cli/admin/user/user.go
+++ b/cli/admin/user/user.go
@@ -24,7 +24,7 @@ var Command = &cli.Command{
 	Usage: "manage users",
 	Commands: []*cli.Command{
 		userListCmd,
-		userInfoCmd,
+		userShowCmd,
 		userAddCmd,
 		userRemoveCmd,
 	},

--- a/cli/admin/user/user_add.go
+++ b/cli/admin/user/user_add.go
@@ -26,7 +26,7 @@ import (
 
 var userAddCmd = &cli.Command{
 	Name:      "add",
-	Usage:     "adds a user",
+	Usage:     "add a user",
 	ArgsUsage: "<username>",
 	Action:    userAdd,
 }

--- a/cli/common/hooks.go
+++ b/cli/common/hooks.go
@@ -35,18 +35,18 @@ func Before(ctx context.Context, c *cli.Command) (context.Context, error) {
 		waitForUpdateCheck, cancelWaitForUpdate = context.WithCancelCause(context.Background())
 		defer cancelWaitForUpdate(errors.New("update check finished"))
 
-		log.Debug().Msg("Checking for updates ...")
+		log.Debug().Msg("checking for updates ...")
 
 		newVersion, err := update.CheckForUpdate(waitForUpdateCheck, false) //nolint:contextcheck
 		if err != nil {
-			log.Error().Err(err).Msgf("Failed to check for updates")
+			log.Error().Err(err).Msgf("failed to check for updates")
 			return
 		}
 
 		if newVersion != nil {
-			log.Warn().Msgf("A new version of woodpecker-cli is available: %s. Update by running: %s update", newVersion.Version, c.Root().Name)
+			log.Warn().Msgf("new version of woodpecker-cli is available: %s, update with: %s update", newVersion.Version, c.Root().Name)
 		} else {
-			log.Debug().Msgf("No update required")
+			log.Debug().Msgf("no update required")
 		}
 	}(ctx)
 
@@ -59,7 +59,7 @@ func After(_ context.Context, _ *cli.Command) error {
 		case <-waitForUpdateCheck.Done():
 		// When the actual command already finished, we still wait 500ms for the update check to finish
 		case <-time.After(time.Millisecond * 500):
-			log.Debug().Msg("Update check stopped due to timeout")
+			log.Debug().Msg("update check stopped due to timeout")
 			cancelWaitForUpdate(errors.New("update check timeout"))
 		}
 	}

--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -161,7 +161,7 @@ func execWithAxis(ctx context.Context, c *cli.Command, file, repoPath string, ax
 		pipelineEnv[before] = after
 		if oldVar, exists := environ[before]; exists {
 			// override existing values, but print a warning
-			log.Warn().Msgf("environment variable '%s' had value '%s', but got overwritten", before, oldVar)
+			log.Warn().Msgf("Environment variable '%s' had value '%s', but got overwritten", before, oldVar)
 		}
 		environ[before] = after
 	}

--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -161,7 +161,7 @@ func execWithAxis(ctx context.Context, c *cli.Command, file, repoPath string, ax
 		pipelineEnv[before] = after
 		if oldVar, exists := environ[before]; exists {
 			// override existing values, but print a warning
-			log.Warn().Msgf("Environment variable '%s' had value '%s', but got overwritten", before, oldVar)
+			log.Warn().Msgf("environment variable '%s' had value '%s', but got overwritten", before, oldVar)
 		}
 		environ[before] = after
 	}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -44,7 +44,7 @@ func Load(ctx context.Context, c *cli.Command) error {
 	}
 
 	if config.ServerURL == "" || config.Token == "" {
-		log.Info().Msg("The woodpecker-cli is not yet set up. Please run `woodpecker-cli setup` or provide the required environment variables / flags.")
+		log.Info().Msg("woodpecker-cli is not set up, run `woodpecker-cli setup` or provide required environment variables/flags")
 		return errors.New("woodpecker-cli is not configured")
 	}
 
@@ -63,7 +63,7 @@ func Load(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	log.Debug().Any("config", config).Msg("Loaded config")
+	log.Debug().Any("config", config).Msg("loaded config")
 
 	return nil
 }
@@ -93,16 +93,16 @@ func Get(_ context.Context, c *cli.Command, _configPath string) (*Config, error)
 		return nil, err
 	}
 
-	log.Debug().Str("configPath", configPath).Msg("Checking for config file")
+	log.Debug().Str("configPath", configPath).Msg("checking for config file")
 
 	content, err := os.ReadFile(configPath)
 	switch {
 	case err != nil && !os.IsNotExist(err):
-		log.Debug().Err(err).Msg("Failed to read the config file")
+		log.Debug().Err(err).Msg("failed to read the config file")
 		return nil, err
 
 	case err != nil && os.IsNotExist(err):
-		log.Debug().Msg("The config file does not exist")
+		log.Debug().Msg("config file does not exist")
 
 	default:
 		configFromFile := &Config{}
@@ -111,7 +111,7 @@ func Get(_ context.Context, c *cli.Command, _configPath string) (*Config, error)
 			return nil, err
 		}
 		conf.MergeIfNotSet(configFromFile)
-		log.Debug().Msg("Loaded config from file")
+		log.Debug().Msg("loaded config from file")
 	}
 
 	// if server or token are explicitly set, use them
@@ -123,11 +123,11 @@ func Get(_ context.Context, c *cli.Command, _configPath string) (*Config, error)
 	service := c.Root().Name
 	secret, err := keyring.Get(service, conf.ServerURL)
 	if errors.Is(err, keyring.ErrUnsupportedPlatform) {
-		log.Warn().Msg("Keyring is not supported on this platform")
+		log.Warn().Msg("keyring is not supported on this platform")
 		return conf, nil
 	}
 	if errors.Is(err, keyring.ErrNotFound) {
-		log.Warn().Msg("Token not found in keyring")
+		log.Warn().Msg("token not found in keyring")
 		return conf, nil
 	}
 	conf.Token = secret

--- a/cli/internal/util.go
+++ b/cli/internal/util.go
@@ -56,7 +56,7 @@ func NewClient(ctx context.Context, c *cli.Command) (woodpecker.Client, error) {
 	// attempt to find system CA certs
 	certs, err := x509.SystemCertPool()
 	if err != nil {
-		log.Error().Err(err).Msg("failed to find system CA certs")
+		log.Error().Err(err).Msg("Failed to find system CA certs")
 	}
 	tlsConfig := &tls.Config{
 		RootCAs:            certs,
@@ -101,7 +101,7 @@ func getRepoFromGit(remoteName string) (string, error) {
 
 	gitRemote := strings.TrimSpace(string(stdout))
 
-	log.Debug().Str("git-remote", gitRemote).Msg("extracted remote url from git")
+	log.Debug().Str("git-remote", gitRemote).Msg("Extracted remote url from git")
 
 	if len(gitRemote) == 0 {
 		return "", fmt.Errorf("no repository provided")
@@ -113,7 +113,7 @@ func getRepoFromGit(remoteName string) (string, error) {
 	}
 
 	repoFullName := u.FullName
-	log.Debug().Str("repo", repoFullName).Msg("extracted repository from remote url")
+	log.Debug().Str("repo", repoFullName).Msg("Extracted repository from remote url")
 
 	return repoFullName, nil
 }
@@ -123,19 +123,19 @@ func ParseRepo(client woodpecker.Client, str string) (repoID int64, err error) {
 	if str == "" {
 		str, err = getRepoFromGit("upstream")
 		if err != nil {
-			log.Debug().Err(err).Msg("could not get repository from git upstream remote")
+			log.Debug().Err(err).Msg("Could not get repository from git upstream remote")
 		}
 	}
 
 	if str == "" {
 		str, err = getRepoFromGit("origin")
 		if err != nil {
-			log.Debug().Err(err).Msg("could not get repository from git origin remote")
+			log.Debug().Err(err).Msg("Could not get repository from git origin remote")
 		}
 	}
 
 	if str == "" {
-		return 0, fmt.Errorf("no repository provided")
+		return 0, fmt.Errorf("no repoSsitory provided")
 	}
 
 	if strings.Contains(str, "/") {

--- a/cli/internal/util.go
+++ b/cli/internal/util.go
@@ -56,7 +56,7 @@ func NewClient(ctx context.Context, c *cli.Command) (woodpecker.Client, error) {
 	// attempt to find system CA certs
 	certs, err := x509.SystemCertPool()
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to find system CA certs")
+		log.Error().Err(err).Msg("failed to find system CA certs")
 	}
 	tlsConfig := &tls.Config{
 		RootCAs:            certs,
@@ -101,7 +101,7 @@ func getRepoFromGit(remoteName string) (string, error) {
 
 	gitRemote := strings.TrimSpace(string(stdout))
 
-	log.Debug().Str("git-remote", gitRemote).Msg("Extracted remote url from git")
+	log.Debug().Str("git-remote", gitRemote).Msg("extracted remote url from git")
 
 	if len(gitRemote) == 0 {
 		return "", fmt.Errorf("no repository provided")
@@ -113,7 +113,7 @@ func getRepoFromGit(remoteName string) (string, error) {
 	}
 
 	repoFullName := u.FullName
-	log.Debug().Str("repo", repoFullName).Msg("Extracted repository from remote url")
+	log.Debug().Str("repo", repoFullName).Msg("extracted repository from remote url")
 
 	return repoFullName, nil
 }
@@ -123,14 +123,14 @@ func ParseRepo(client woodpecker.Client, str string) (repoID int64, err error) {
 	if str == "" {
 		str, err = getRepoFromGit("upstream")
 		if err != nil {
-			log.Debug().Err(err).Msg("Could not get repository from git upstream remote")
+			log.Debug().Err(err).Msg("could not get repository from git upstream remote")
 		}
 	}
 
 	if str == "" {
 		str, err = getRepoFromGit("origin")
 		if err != nil {
-			log.Debug().Err(err).Msg("Could not get repository from git origin remote")
+			log.Debug().Err(err).Msg("could not get repository from git origin remote")
 		}
 	}
 

--- a/cli/internal/util.go
+++ b/cli/internal/util.go
@@ -135,7 +135,7 @@ func ParseRepo(client woodpecker.Client, str string) (repoID int64, err error) {
 	}
 
 	if str == "" {
-		return 0, fmt.Errorf("no repoSsitory provided")
+		return 0, fmt.Errorf("no repository provided")
 	}
 
 	if strings.Contains(str, "/") {

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -40,12 +40,12 @@ var Command = &cli.Command{
 		&cli.StringSliceFlag{
 			Sources: cli.EnvVars("WOODPECKER_PLUGINS_PRIVILEGED"),
 			Name:    "plugins-privileged",
-			Usage:   "Allow plugins to run in privileged mode, if environment variable is defined but empty there will be none",
+			Usage:   "allow plugins to run in privileged mode, if set empty, there is no",
 		},
 		&cli.StringSliceFlag{
 			Sources: cli.EnvVars("WOODPECKER_PLUGINS_TRUSTED_CLONE"),
 			Name:    "plugins-trusted-clone",
-			Usage:   "Plugins which are trusted to handle Git credentials in clone steps",
+			Usage:   "plugins that are trusted to handle Git credentials in cloning steps",
 			Value:   constant.TrustedClonePlugins,
 		},
 		&cli.BoolFlag{

--- a/cli/org/registry/registry.go
+++ b/cli/org/registry/registry.go
@@ -30,7 +30,7 @@ var Command = &cli.Command{
 		registryCreateCmd,
 		registryDeleteCmd,
 		registryUpdateCmd,
-		registryInfoCmd,
+		registryShowCmd,
 		registryListCmd,
 	},
 }

--- a/cli/org/registry/registry_add.go
+++ b/cli/org/registry/registry_add.go
@@ -28,7 +28,7 @@ import (
 
 var registryCreateCmd = &cli.Command{
 	Name:      "add",
-	Usage:     "adds a registry",
+	Usage:     "add a registry",
 	ArgsUsage: "[org-id|org-full-name]",
 	Action:    registryCreate,
 	Flags: []cli.Flag{

--- a/cli/org/secret/secret.go
+++ b/cli/org/secret/secret.go
@@ -30,7 +30,7 @@ var Command = &cli.Command{
 		secretCreateCmd,
 		secretDeleteCmd,
 		secretUpdateCmd,
-		secretInfoCmd,
+		secretShowCmd,
 		secretListCmd,
 	},
 }

--- a/cli/org/secret/secret_add.go
+++ b/cli/org/secret/secret_add.go
@@ -28,7 +28,7 @@ import (
 
 var secretCreateCmd = &cli.Command{
 	Name:      "add",
-	Usage:     "adds a secret",
+	Usage:     "add a secret",
 	ArgsUsage: "[repo-id|repo-full-name]",
 	Action:    secretCreate,
 	Flags: []cli.Flag{

--- a/cli/org/secret/secret_set.go
+++ b/cli/org/secret/secret_set.go
@@ -43,11 +43,11 @@ var secretUpdateCmd = &cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:  "event",
-			Usage: "secret limited to these events",
+			Usage: "limit secret to these event",
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
-			Usage: "secret limited to these images",
+			Usage: "limit secret to these image",
 		},
 	},
 }

--- a/cli/pipeline/deploy/deploy.go
+++ b/cli/pipeline/deploy/deploy.go
@@ -53,7 +53,7 @@ var Command = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:    "param",
 			Aliases: []string{"p"},
-			Usage:   "custom parameters to be injected into the step environment. Format: KEY=value",
+			Usage:   "custom parameters to inject into the step environment. Format: KEY=value",
 		},
 	},
 }

--- a/cli/pipeline/last.go
+++ b/cli/pipeline/last.go
@@ -26,7 +26,7 @@ import (
 
 var pipelineLastCmd = &cli.Command{
 	Name:      "last",
-	Usage:     "show latest pipeline details",
+	Usage:     "show latest pipeline information",
 	ArgsUsage: "<repo-id|repo-full-name>",
 	Action:    pipelineLast,
 	Flags: append(common.OutputFlags("table"), []cli.Flag{

--- a/cli/pipeline/list.go
+++ b/cli/pipeline/list.go
@@ -52,7 +52,7 @@ func buildPipelineListCmd() *cli.Command {
 			},
 			&cli.TimestampFlag{
 				Name:  "before",
-				Usage: "only return pipelines before this RFC3339 date",
+				Usage: "only return pipelines before this date (RFC3339)",
 				Config: cli.TimestampConfig{
 					Layouts: []string{
 						time.RFC3339,
@@ -61,7 +61,7 @@ func buildPipelineListCmd() *cli.Command {
 			},
 			&cli.TimestampFlag{
 				Name:  "after",
-				Usage: "only return pipelines after this RFC3339 date",
+				Usage: "only return pipelines after this date (RFC3339)",
 				Config: cli.TimestampConfig{
 					Layouts: []string{
 						time.RFC3339,

--- a/cli/pipeline/pipeline.go
+++ b/cli/pipeline/pipeline.go
@@ -35,7 +35,7 @@ var Command = &cli.Command{
 	Commands: []*cli.Command{
 		buildPipelineListCmd(),
 		pipelineLastCmd,
-		pipelineInfoCmd,
+		pipelineShowCmd,
 		pipelineStopCmd,
 		pipelineStartCmd,
 		pipelineApproveCmd,

--- a/cli/pipeline/show.go
+++ b/cli/pipeline/show.go
@@ -25,15 +25,15 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/woodpecker-go/woodpecker"
 )
 
-var pipelineInfoCmd = &cli.Command{
-	Name:      "info",
-	Usage:     "show pipeline details",
+var pipelineShowCmd = &cli.Command{
+	Name:      "show",
+	Usage:     "show pipeline information",
 	ArgsUsage: "<repo-id|repo-full-name> [pipeline]",
-	Action:    pipelineInfo,
+	Action:    pipelineShow,
 	Flags:     common.OutputFlags("table"),
 }
 
-func pipelineInfo(ctx context.Context, c *cli.Command) error {
+func pipelineShow(ctx context.Context, c *cli.Command) error {
 	repoIDOrFullName := c.Args().First()
 	client, err := internal.NewClient(ctx, c)
 	if err != nil {

--- a/cli/pipeline/start.go
+++ b/cli/pipeline/start.go
@@ -35,7 +35,7 @@ var pipelineStartCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:    "param",
 			Aliases: []string{"p"},
-			Usage:   "custom parameters to be injected into the step environment. Format: KEY=value",
+			Usage:   "custom parameters to inject into the step environment. Format: KEY=value",
 		},
 	},
 }

--- a/cli/repo/cron/cron.go
+++ b/cli/repo/cron/cron.go
@@ -26,7 +26,7 @@ var Command = &cli.Command{
 		cronCreateCmd,
 		cronDeleteCmd,
 		cronUpdateCmd,
-		cronInfoCmd,
+		cronShowCmd,
 		cronListCmd,
 	},
 }

--- a/cli/repo/registry/registry.go
+++ b/cli/repo/registry/registry.go
@@ -29,7 +29,7 @@ var Command = &cli.Command{
 		registryCreateCmd,
 		registryDeleteCmd,
 		registryUpdateCmd,
-		registryInfoCmd,
+		registryShowCmd,
 		registryListCmd,
 	},
 }

--- a/cli/repo/registry/registry_add.go
+++ b/cli/repo/registry/registry_add.go
@@ -28,7 +28,7 @@ import (
 
 var registryCreateCmd = &cli.Command{
 	Name:      "add",
-	Usage:     "adds a registry",
+	Usage:     "add a registry",
 	ArgsUsage: "[repo-id|repo-full-name]",
 	Action:    registryCreate,
 	Flags: []cli.Flag{

--- a/cli/repo/registry/registry_show.go
+++ b/cli/repo/registry/registry_show.go
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package secret
+package registry
 
 import (
 	"context"
-	"fmt"
 	"html/template"
 	"os"
 
@@ -26,30 +25,27 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/cli/internal"
 )
 
-var secretInfoCmd = &cli.Command{
-	Name:      "info",
-	Usage:     "display secret info",
+var registryShowCmd = &cli.Command{
+	Name:      "show",
+	Usage:     "show registry information",
 	ArgsUsage: "[repo-id|repo-full-name]",
-	Action:    secretInfo,
+	Action:    registryShow,
 	Flags: []cli.Flag{
 		common.RepoFlag,
 		&cli.StringFlag{
-			Name:  "name",
-			Usage: "secret name",
+			Name:  "hostname",
+			Usage: "registry hostname",
+			Value: "docker.io",
 		},
-		common.FormatFlag(tmplSecretList, true),
+		common.FormatFlag(tmplRegistryList, true),
 	},
 }
 
-func secretInfo(ctx context.Context, c *cli.Command) error {
+func registryShow(ctx context.Context, c *cli.Command) error {
 	var (
-		secretName = c.String("name")
-		format     = c.String("format") + "\n"
+		hostname = c.String("hostname")
+		format   = c.String("format") + "\n"
 	)
-
-	if secretName == "" {
-		return fmt.Errorf("secret name is missing")
-	}
 
 	client, err := internal.NewClient(ctx, c)
 	if err != nil {
@@ -61,14 +57,14 @@ func secretInfo(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	secret, err := client.Secret(repoID, secretName)
+	registry, err := client.Registry(repoID, hostname)
 	if err != nil {
 		return err
 	}
 
-	tmpl, err := template.New("_").Funcs(secretFuncMap).Parse(format)
+	tmpl, err := template.New("_").Parse(format)
 	if err != nil {
 		return err
 	}
-	return tmpl.Execute(os.Stdout, secret)
+	return tmpl.Execute(os.Stdout, registry)
 }

--- a/cli/repo/repo.go
+++ b/cli/repo/repo.go
@@ -28,7 +28,7 @@ var Command = &cli.Command{
 	Usage: "manage repositories",
 	Commands: []*cli.Command{
 		repoListCmd,
-		repoInfoCmd,
+		repoShowCmd,
 		repoAddCmd,
 		repoUpdateCmd,
 		repoRemoveCmd,

--- a/cli/repo/repo_update.go
+++ b/cli/repo/repo_update.go
@@ -53,7 +53,7 @@ var repoUpdateCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "config",
-			Usage: "repository configuration path (e.g. .woodpecker.yml)",
+			Usage: "repository configuration path. Example: .woodpecker.yml",
 		},
 		&cli.IntFlag{
 			Name:  "pipeline-counter",
@@ -61,7 +61,7 @@ var repoUpdateCmd = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "unsafe",
-			Usage: "validate updating the pipeline-counter is unsafe",
+			Usage: "allow unsafe operations",
 		},
 	},
 }

--- a/cli/repo/secret/secret.go
+++ b/cli/repo/secret/secret.go
@@ -29,7 +29,7 @@ var Command = &cli.Command{
 		secretCreateCmd,
 		secretDeleteCmd,
 		secretUpdateCmd,
-		secretInfoCmd,
+		secretShowCmd,
 		secretListCmd,
 	},
 }

--- a/cli/repo/secret/secret_add.go
+++ b/cli/repo/secret/secret_add.go
@@ -28,7 +28,7 @@ import (
 
 var secretCreateCmd = &cli.Command{
 	Name:      "add",
-	Usage:     "adds a secret",
+	Usage:     "add a secret",
 	ArgsUsage: "[repo-id|repo-full-name]",
 	Action:    secretCreate,
 	Flags: []cli.Flag{
@@ -43,11 +43,11 @@ var secretCreateCmd = &cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:  "event",
-			Usage: "secret limited to these events",
+			Usage: "limit secret to these events",
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
-			Usage: "secret limited to these images",
+			Usage: "limit secret to these images",
 		},
 	},
 }

--- a/cli/repo/secret/secret_set.go
+++ b/cli/repo/secret/secret_set.go
@@ -43,11 +43,11 @@ var secretUpdateCmd = &cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:  "event",
-			Usage: "secret limited to these events",
+			Usage: "limit secret to these events",
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
-			Usage: "secret limited to these images",
+			Usage: "limit secret to these images",
 		},
 	},
 }

--- a/cli/repo/secret/secret_show.go
+++ b/cli/repo/secret/secret_show.go
@@ -26,12 +26,13 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v2/cli/internal"
 )
 
-var secretInfoCmd = &cli.Command{
-	Name:      "info",
-	Usage:     "display secret info",
+var secretShowCmd = &cli.Command{
+	Name:      "show",
+	Usage:     "show secret information",
 	ArgsUsage: "[repo-id|repo-full-name]",
-	Action:    secretInfo,
+	Action:    secretShow,
 	Flags: []cli.Flag{
+		common.RepoFlag,
 		&cli.StringFlag{
 			Name:  "name",
 			Usage: "secret name",
@@ -40,7 +41,7 @@ var secretInfoCmd = &cli.Command{
 	},
 }
 
-func secretInfo(ctx context.Context, c *cli.Command) error {
+func secretShow(ctx context.Context, c *cli.Command) error {
 	var (
 		secretName = c.String("name")
 		format     = c.String("format") + "\n"
@@ -55,7 +56,12 @@ func secretInfo(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	secret, err := client.GlobalSecret(secretName)
+	repoID, err := parseTargetArgs(client, c)
+	if err != nil {
+		return err
+	}
+
+	secret, err := client.Secret(repoID, secretName)
 	if err != nil {
 		return err
 	}

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -20,11 +20,11 @@ var Command = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "server",
-			Usage: "The URL of the woodpecker server",
+			Usage: "URL of the woodpecker server",
 		},
 		&cli.StringFlag{
 			Name:  "token",
-			Usage: "The token to authenticate with the woodpecker server",
+			Usage: "token to authenticate with the woodpecker server",
 		},
 	},
 	Action: setup,

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -41,7 +41,7 @@ func setup(ctx context.Context, c *cli.Command) error {
 		}
 
 		if !setupAgain {
-			log.Info().Msg("Configuration skipped")
+			log.Info().Msg("configuration skipped")
 			return nil
 		}
 	}
@@ -87,7 +87,7 @@ func setup(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	log.Info().Msg("The woodpecker-cli has been successfully setup")
+	log.Info().Msg("woodpecker-cli has been successfully setup")
 
 	return nil
 }

--- a/cli/setup/token_fetcher.go
+++ b/cli/setup/token_fetcher.go
@@ -24,12 +24,12 @@ func receiveTokenFromUI(c context.Context, serverURL string) (string, error) {
 	srv.Handler = setupRouter(tokenReceived)
 
 	go func() {
-		log.Debug().Msgf("Listening for token response on :%d", port)
+		log.Debug().Msgf("listening for token response on :%d", port)
 		_ = srv.ListenAndServe()
 	}()
 
 	defer func() {
-		log.Debug().Msg("Shutting down server")
+		log.Debug().Msg("shutting down server")
 		_ = srv.Shutdown(c)
 	}()
 
@@ -90,7 +90,7 @@ func setupRouter(tokenReceived chan string) *gin.Engine {
 
 		err := c.BindJSON(&data)
 		if err != nil {
-			log.Debug().Err(err).Msg("Failed to bind JSON")
+			log.Debug().Err(err).Msg("failed to bind JSON")
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": "invalid request",
 			})
@@ -110,7 +110,7 @@ func setupRouter(tokenReceived chan string) *gin.Engine {
 func openBrowser(url string) error {
 	var err error
 
-	log.Debug().Msgf("Opening browser with URL: %s", url)
+	log.Debug().Msgf("opening browser with URL: %s", url)
 
 	switch runtime.GOOS {
 	case "linux":

--- a/cli/update/command.go
+++ b/cli/update/command.go
@@ -24,7 +24,7 @@ var Command = &cli.Command{
 }
 
 func update(ctx context.Context, c *cli.Command) error {
-	log.Info().Msg("Checking for updates ...")
+	log.Info().Msg("checking for updates ...")
 
 	newVersion, err := CheckForUpdate(ctx, c.Bool("force"))
 	if err != nil {
@@ -32,11 +32,11 @@ func update(ctx context.Context, c *cli.Command) error {
 	}
 
 	if newVersion == nil {
-		fmt.Println("You are using the latest version of woodpecker-cli")
+		fmt.Println("you are using the latest version of woodpecker-cli")
 		return nil
 	}
 
-	log.Info().Msgf("New version %s is available! Updating ...", newVersion.Version)
+	log.Info().Msgf("new version %s is available! Updating ...", newVersion.Version)
 
 	var tarFilePath string
 	tarFilePath, err = downloadNewVersion(ctx, newVersion.AssetURL)
@@ -44,14 +44,14 @@ func update(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
-	log.Debug().Msgf("New version %s has been downloaded successfully! Installing ...", newVersion.Version)
+	log.Debug().Msgf("new version %s has been downloaded successfully! Installing ...", newVersion.Version)
 
 	binFile, err := extractNewVersion(tarFilePath)
 	if err != nil {
 		return err
 	}
 
-	log.Debug().Msgf("New version %s has been extracted to %s", newVersion.Version, binFile)
+	log.Debug().Msgf("new version %s has been extracted to %s", newVersion.Version, binFile)
 
 	executablePathOrSymlink, err := os.Executable()
 	if err != nil {

--- a/cli/update/updater.go
+++ b/cli/update/updater.go
@@ -22,10 +22,10 @@ func CheckForUpdate(ctx context.Context, force bool) (*NewVersion, error) {
 }
 
 func checkForUpdate(ctx context.Context, versionURL string, force bool) (*NewVersion, error) {
-	log.Debug().Msgf("Current version: %s", version.String())
+	log.Debug().Msgf("current version: %s", version.String())
 
 	if (version.String() == "dev" || strings.HasPrefix(version.String(), "next-")) && !force {
-		log.Debug().Msgf("Skipping update check for development & next versions")
+		log.Debug().Msgf("skipping update check for development/next versions")
 		return nil, nil
 	}
 
@@ -61,11 +61,11 @@ func checkForUpdate(ctx context.Context, versionURL string, force bool) (*NewVer
 
 	// using the latest release
 	if installedVersion == upstreamVersion && !force {
-		log.Debug().Msgf("No new version available")
+		log.Debug().Msgf("no new version available")
 		return nil, nil
 	}
 
-	log.Debug().Msgf("New version available: %s", upstreamVersion)
+	log.Debug().Msgf("new version available: %s", upstreamVersion)
 
 	assetURL := fmt.Sprintf(githubBinaryURL, upstreamVersion, runtime.GOOS, runtime.GOARCH)
 	return &NewVersion{
@@ -75,7 +75,7 @@ func checkForUpdate(ctx context.Context, versionURL string, force bool) (*NewVer
 }
 
 func downloadNewVersion(ctx context.Context, downloadURL string) (string, error) {
-	log.Debug().Msgf("Downloading new version from %s ...", downloadURL)
+	log.Debug().Msgf("downloading new version from %s ...", downloadURL)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
@@ -102,13 +102,13 @@ func downloadNewVersion(ctx context.Context, downloadURL string) (string, error)
 		return "", err
 	}
 
-	log.Debug().Msgf("New version downloaded to %s", file.Name())
+	log.Debug().Msgf("new version downloaded to %s", file.Name())
 
 	return file.Name(), nil
 }
 
 func extractNewVersion(tarFilePath string) (string, error) {
-	log.Debug().Msgf("Extracting new version from %s ...", tarFilePath)
+	log.Debug().Msgf("extracting new version from %s ...", tarFilePath)
 
 	tarFile, err := os.Open(tarFilePath)
 	if err != nil {
@@ -132,7 +132,7 @@ func extractNewVersion(tarFilePath string) (string, error) {
 		return "", err
 	}
 
-	log.Debug().Msgf("New version extracted to %s", tmpDir)
+	log.Debug().Msgf("new version extracted to %s", tmpDir)
 
 	return path.Join(tmpDir, "woodpecker-cli"), nil
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -17,9 +17,11 @@ package main
 import (
 	"context"
 	"os"
+	"sort"
 
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
 
 	"go.woodpecker-ci.org/woodpecker/v2/shared/utils"
 )
@@ -30,7 +32,23 @@ func main() {
 	})
 
 	app := newApp()
+
+	sortCommandsRecursive(app.Commands)
+
 	if err := app.Run(ctx, os.Args); err != nil {
 		log.Fatal().Err(err).Msg("error running cli") //nolint:forbidigo
+	}
+}
+
+func sortCommandsRecursive(commands []*cli.Command) {
+	sort.Slice(commands, func(i, j int) bool {
+		return commands[i].Name < commands[j].Name
+	})
+
+	// Recursively sort subcommands
+	for _, cmd := range commands {
+		if len(cmd.Commands) > 0 {
+			sortCommandsRecursive(cmd.Commands)
+		}
 	}
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -17,11 +17,9 @@ package main
 import (
 	"context"
 	"os"
-	"sort"
 
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/rs/zerolog/log"
-	"github.com/urfave/cli/v3"
 
 	"go.woodpecker-ci.org/woodpecker/v2/shared/utils"
 )
@@ -32,23 +30,7 @@ func main() {
 	})
 
 	app := newApp()
-
-	sortCommandsRecursive(app.Commands)
-
 	if err := app.Run(ctx, os.Args); err != nil {
 		log.Fatal().Err(err).Msg("error running cli") //nolint:forbidigo
-	}
-}
-
-func sortCommandsRecursive(commands []*cli.Command) {
-	sort.Slice(commands, func(i, j int) bool {
-		return commands[i].Name < commands[j].Name
-	})
-
-	// Recursively sort subcommands
-	for _, cmd := range commands {
-		if len(cmd.Commands) > 0 {
-			sortCommandsRecursive(cmd.Commands)
-		}
 	}
 }

--- a/docs/src/pages/migrations.md
+++ b/docs/src/pages/migrations.md
@@ -43,6 +43,7 @@ This will be the next version of Woodpecker.
   - `woodpecker-cli cron` is now `woodpecker-cli repo cron`
   - `woodpecker-cli secret [add|rm|...] --repository` is now `woodpecker-cli repo secret [add|rm|...]`
   - `woodpecker-cli pipeline logs` is now `woodpecker-cli pipeline log show`
+  - `woodpecker-cli [registry|secret|...] info` is now `woodpecker-cli [registry|secret|...] show`
 
 ## Admin migrations
 


### PR DESCRIPTION
- Unify command and flag descriptions
- Unify logs
- Rename `woodpecker-cli [registry|ssecret|...] info` commands to `woodpecker-cli [registry|ssecret|...] show`