### PR TITLE
fix: addon JSON pointers

### DIFF
--- a/docs/docs/30-administration/11-forges/100-addon.md
+++ b/docs/docs/30-administration/11-forges/100-addon.md
@@ -38,7 +38,7 @@ Addons use RPC to communicate to the server and are implemented using the [`go-p
 
 This example will use the Go language.
 
-Directly import Woodpecker's Go packages (`go.woodpecker-ci.org/woodpecker/woodpecker/v2`) and use the interfaces and types defined there.
+Directly import Woodpecker's Go packages (`go.woodpecker-ci.org/woodpecker/v2`) and use the interfaces and types defined there.
 
 In the `main` function, just call `"go.woodpecker-ci.org/woodpecker/v2/server/forge/addon".Serve` with a `"go.woodpecker-ci.org/woodpecker/v2/server/forge".Forge` as argument.
 This will take care of connecting the addon forge to the server.

--- a/server/forge/addon/client.go
+++ b/server/forge/addon/client.go
@@ -139,8 +139,8 @@ func (g *RPC) Repo(_ context.Context, u *model.User, remoteID model.ForgeRemoteI
 		return nil, err
 	}
 
-	var resp *modelRepo
-	err = json.Unmarshal(jsonResp, resp)
+	var resp modelRepo
+	err = json.Unmarshal(jsonResp, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/server/forge/addon/server.go
+++ b/server/forge/addon/server.go
@@ -54,8 +54,8 @@ func (s *RPCServer) URL(_ []byte, resp *string) error {
 }
 
 func (s *RPCServer) Teams(args []byte, resp *[]byte) error {
-	var a *modelUser
-	err := json.Unmarshal(args, a)
+	var a modelUser
+	err := json.Unmarshal(args, &a)
 	if err != nil {
 		return err
 	}
@@ -82,8 +82,8 @@ func (s *RPCServer) Repo(args []byte, resp *[]byte) error {
 }
 
 func (s *RPCServer) Repos(args []byte, resp *[]byte) error {
-	var a *modelUser
-	err := json.Unmarshal(args, a)
+	var a modelUser
+	err := json.Unmarshal(args, &a)
 	if err != nil {
 		return err
 	}
@@ -261,12 +261,12 @@ func (s *RPCServer) Hook(args []byte, resp *[]byte) error {
 }
 
 func (s *RPCServer) Login(args []byte, resp *[]byte) error {
-	var a *types.OAuthRequest
-	err := json.Unmarshal(args, a)
+	var a types.OAuthRequest
+	err := json.Unmarshal(args, &a)
 	if err != nil {
 		return err
 	}
-	user, red, err := s.Impl.Login(mkCtx(), a)
+	user, red, err := s.Impl.Login(mkCtx(), &a)
 	if err != nil {
 		return err
 	}

--- a/server/services/config/forge.go
+++ b/server/services/config/forge.go
@@ -140,9 +140,9 @@ func (f *forgeFetcherContext) checkPipelineFile(c context.Context, config string
 func (f *forgeFetcherContext) getFirstAvailableConfig(c context.Context, configs []string) ([]*types.FileMeta, error) {
 	var forgeErr []error
 	for _, fileOrFolder := range configs {
+		log.Trace().Msgf("fetching %s from forge", fileOrFolder)
 		if strings.HasSuffix(fileOrFolder, "/") {
 			// config is a folder
-			log.Trace().Msgf("fetching %s from forge", fileOrFolder)
 			files, err := f.forge.Dir(c, f.user, f.repo, f.pipeline, strings.TrimSuffix(fileOrFolder, "/"))
 			// if folder is not supported we will get a "Not implemented" error and continue
 			if err != nil {


### PR DESCRIPTION
This PR fixes some issues I ran into when creating an addon forge.

- https://github.com/woodpecker-ci/woodpecker/commit/28af9baff5bc4a97ac08db99f26e9640a65b835f fixes some pointer dereference issues when unmarshaling JSON
- https://github.com/woodpecker-ci/woodpecker/commit/6211f0447ce31773061d2b27f66b491139594953 moves a trace log outside an if-check. Not strictly necessary, but was slightly confusing before when debugging
- https://github.com/woodpecker-ci/woodpecker/commit/19936f6a692133927b26ae763686e3e0e30df60a makes a minor correction to the docs for the woodpecker module