### PR TITLE
Move link checks into cron-curated issue dashboard

### DIFF
--- a/.woodpecker/links.yaml
+++ b/.woodpecker/links.yaml
@@ -1,0 +1,30 @@
+when:
+  - event: cron
+    cron: links
+
+steps:
+  - name: links
+    image: docker.io/lycheeverse/lychee:0.15.1
+    depends_on: []
+    commands:
+      - lychee pipeline/frontend/yaml/linter/schema/schema.json > links.md
+      - lychee --exclude localhost docs/docs/ >> links.md
+      - lychee --exclude localhost docs/src/pages/ >> links.md
+      - echo -e "\nLast checked:$(date)" >> links.md
+
+  - name: Update issue
+    image: docker.io/curlimages/curl:8.10.1
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - ISSUE_NUMBER=4514
+      - REPO_OWNER=woodpecker-ci
+      - REPO_NAME=woodpecker
+      - DESCRIPTION=$(cat links.md)
+      - |
+        curl -X PATCH \
+          -H "Authorization: token ${GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER} \
+          -d "$(jq -n --arg body "$DESCRIPTION" '{body: $body}')"

--- a/.woodpecker/static.yaml
+++ b/.woodpecker/static.yaml
@@ -23,11 +23,3 @@ steps:
     depends_on: []
     settings:
       version: 3.3.3
-
-  - name: links
-    image: docker.io/lycheeverse/lychee:0.15.1
-    depends_on: []
-    commands:
-      - lychee pipeline/frontend/yaml/linter/schema/schema.json
-      - lychee --user-agent "curl/8.4.0" --exclude localhost docs/docs/
-      - lychee --user-agent "curl/8.4.0" --exclude localhost docs/src/pages/


### PR DESCRIPTION
Link checks often indicate failed CI checks. While the `static` run is not required, it takes time to inspect the failure and move on.
This is irritating and not helpful, as failing link checks often do not have any relation to the PR at hand.

This change moves the link checks out of the PR checks into a static issue dashboard which is updated daily by a CRON job.

This way:

- `static.yaml` could be added as a required CI check
- False-positive CI check noise gets reduced
- A static issue dashboard shows the up-to-date state of all links