### PR TITLE
link checker: ignore failures

### DIFF
--- a/.woodpecker/links.yaml
+++ b/.woodpecker/links.yaml
@@ -5,6 +5,7 @@ when:
 steps:
   - name: links
     image: docker.io/lycheeverse/lychee:0.15.1
+    failure: ignore
     depends_on: []
     commands:
       - lychee pipeline/frontend/yaml/linter/schema/schema.json > links.md


### PR DESCRIPTION
So the next step is always executed.