### PR TITLE
disable cron event for securityscan job

### DIFF
--- a/.woodpecker/links.yaml
+++ b/.woodpecker/links.yaml
@@ -14,13 +14,13 @@ steps:
       - echo -e "\nLast checked:$(date)" >> links.md
 
   - name: Update issue
-    image: docker.io/curlimages/curl:8.11.0
+    image: docker.io/alpine:3.21
     depends_on: links
     environment:
       GITHUB_TOKEN:
         from_secret: github_token
     commands:
-      - apk add -q --no-cache jq
+      - apk add -q --no-cache jq curl
       - export ISSUE_NUMBER=4514
       - export DESCRIPTION=$(cat links.md)
       - |

--- a/.woodpecker/securityscan.yaml
+++ b/.woodpecker/securityscan.yaml
@@ -1,5 +1,5 @@
 when:
-  - event: [pull_request, cron]
+  - event: [pull_request]
   - event: push
     branch:
       - ${CI_REPO_DEFAULT_BRANCH}


### PR DESCRIPTION
- because there is no cron job configured for it and it should not run when running the link checker
- replace curl image with alpine as the former is rootless and hence cannot install `jq` interactively