### PR TITLE
Fix BB ambiguous commit status key

### DIFF
--- a/server/forge/bitbucket/bitbucket.go
+++ b/server/forge/bitbucket/bitbucket.go
@@ -290,11 +290,11 @@ func (c *config) Dir(ctx context.Context, u *model.User, r *model.Repo, p *model
 }
 
 // Status creates a pipeline status for the Bitbucket commit.
-func (c *config) Status(ctx context.Context, user *model.User, repo *model.Repo, pipeline *model.Pipeline, _ *model.Workflow) error {
+func (c *config) Status(ctx context.Context, user *model.User, repo *model.Repo, pipeline *model.Pipeline, workflow *model.Workflow) error {
 	status := internal.PipelineStatus{
 		State: convertStatus(pipeline.Status),
 		Desc:  common.GetPipelineStatusDescription(pipeline.Status),
-		Key:   "Woodpecker",
+		Key:   common.GetPipelineStatusContext(repo, pipeline, workflow),
 		URL:   common.GetPipelineStatusURL(repo, pipeline, nil),
 	}
 	return c.newClient(ctx, user).CreateStatus(repo.Owner, repo.Name, pipeline.Commit, &status)


### PR DESCRIPTION
### Description

Bitbucket commit status depends on the status key (key=id). A status with the same key overwrites the previous status, even when the triggering event is different (e.g., pull_request or branch). 

### Problem

When `pull_request` and `push` events are enabled, the commit status is overwritten by the last workflow to finish (only when there's a PR open). This happens because both workflow keys are equal. 

### Solution

Set the key depending on the pipeline context, like the BB data center. Users can use BB settings to block their PRs depending on the workflow name.

<br>

![image](https://github.com/user-attachments/assets/94b76ed3-d0ca-4e0f-9020-70c953081941)
