### PR TITLE
Add Bitbucket fixes to Release/2.8

### DIFF
--- a/server/forge/bitbucket/bitbucket.go
+++ b/server/forge/bitbucket/bitbucket.go
@@ -290,11 +290,11 @@ func (c *config) Dir(ctx context.Context, u *model.User, r *model.Repo, p *model
 }
 
 // Status creates a pipeline status for the Bitbucket commit.
-func (c *config) Status(ctx context.Context, user *model.User, repo *model.Repo, pipeline *model.Pipeline, _ *model.Workflow) error {
+func (c *config) Status(ctx context.Context, user *model.User, repo *model.Repo, pipeline *model.Pipeline, workflow *model.Workflow) error {
 	status := internal.PipelineStatus{
 		State: convertStatus(pipeline.Status),
 		Desc:  common.GetPipelineStatusDescription(pipeline.Status),
-		Key:   "Woodpecker",
+		Key:   common.GetPipelineStatusContext(repo, pipeline, workflow),
 		URL:   common.GetPipelineStatusURL(repo, pipeline, nil),
 	}
 	return c.newClient(ctx, user).CreateStatus(repo.Owner, repo.Name, pipeline.Commit, &status)

--- a/server/forge/bitbucket/convert.go
+++ b/server/forge/bitbucket/convert.go
@@ -171,7 +171,7 @@ func convertPullHook(from *internal.PullRequestHook) *model.Pipeline {
 	pipeline := &model.Pipeline{
 		Event:  event,
 		Commit: from.PullRequest.Source.Commit.Hash,
-		Ref:    fmt.Sprintf("refs/heads/%s", from.PullRequest.Source.Branch.Name),
+		Ref:    fmt.Sprintf("refs/pull-requests/%d/from", from.PullRequest.ID),
 		Refspec: fmt.Sprintf("%s:%s",
 			from.PullRequest.Source.Branch.Name,
 			from.PullRequest.Dest.Branch.Name,

--- a/server/forge/bitbucket/convert.go
+++ b/server/forge/bitbucket/convert.go
@@ -178,7 +178,7 @@ func convertPullHook(from *internal.PullRequestHook) *model.Pipeline {
 		),
 		ForgeURL:  from.PullRequest.Links.HTML.Href,
 		Branch:    from.PullRequest.Source.Branch.Name,
-		Message:   from.PullRequest.Desc,
+		Message:   from.PullRequest.Title,
 		Avatar:    from.Actor.Links.Avatar.Href,
 		Author:    from.Actor.Login,
 		Sender:    from.Actor.Login,

--- a/server/forge/bitbucket/convert_test.go
+++ b/server/forge/bitbucket/convert_test.go
@@ -133,6 +133,7 @@ func Test_helper(t *testing.T) {
 			hook.PullRequest.Links.HTML.Href = "https://bitbucket.org/foo/bar/pulls/5"
 			hook.PullRequest.Title = "updated README"
 			hook.PullRequest.Updated = time.Now()
+			hook.PullRequest.ID = 1
 
 			pipeline := convertPullHook(hook)
 			g.Assert(pipeline.Event).Equal(model.EventPull)
@@ -141,7 +142,7 @@ func Test_helper(t *testing.T) {
 			g.Assert(pipeline.Commit).Equal(hook.PullRequest.Source.Commit.Hash)
 			g.Assert(pipeline.Branch).Equal(hook.PullRequest.Source.Branch.Name)
 			g.Assert(pipeline.ForgeURL).Equal(hook.PullRequest.Links.HTML.Href)
-			g.Assert(pipeline.Ref).Equal("refs/heads/change")
+			g.Assert(pipeline.Ref).Equal("refs/pull-requests/1/from")
 			g.Assert(pipeline.Refspec).Equal("change:main")
 			g.Assert(pipeline.Message).Equal(hook.PullRequest.Title)
 			g.Assert(pipeline.Timestamp).Equal(hook.PullRequest.Updated.Unix())

--- a/server/forge/bitbucket/convert_test.go
+++ b/server/forge/bitbucket/convert_test.go
@@ -131,7 +131,7 @@ func Test_helper(t *testing.T) {
 			hook.PullRequest.Source.Repo.FullName = "baz/bar"
 			hook.PullRequest.Source.Commit.Hash = "c8411d7"
 			hook.PullRequest.Links.HTML.Href = "https://bitbucket.org/foo/bar/pulls/5"
-			hook.PullRequest.Desc = "updated README"
+			hook.PullRequest.Title = "updated README"
 			hook.PullRequest.Updated = time.Now()
 
 			pipeline := convertPullHook(hook)
@@ -143,7 +143,7 @@ func Test_helper(t *testing.T) {
 			g.Assert(pipeline.ForgeURL).Equal(hook.PullRequest.Links.HTML.Href)
 			g.Assert(pipeline.Ref).Equal("refs/heads/change")
 			g.Assert(pipeline.Refspec).Equal("change:main")
-			g.Assert(pipeline.Message).Equal(hook.PullRequest.Desc)
+			g.Assert(pipeline.Message).Equal(hook.PullRequest.Title)
 			g.Assert(pipeline.Timestamp).Equal(hook.PullRequest.Updated.Unix())
 		})
 


### PR DESCRIPTION
## Description

We currently use a fork of the original code because the following fixes prevent us from using the upstream release. Add the Bitbucket fixes to release 2.8.1.

You are doing an amazing work! Let us know if we can help you.

