### PR TITLE
Allow renovate security updates for backport branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>woodpecker-ci/renovate-config"],
   "automergeType": "pr",
-  "baseBranches": ["main", "/^release\\/.*/"]
+  "baseBranches": ["main", "/^release\\/.*/"],
   "customManagers": [
     {
       "customType": "regex",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>woodpecker-ci/renovate-config"],
   "automergeType": "pr",
+  "baseBranches": ["main", "/^release\\/.*/"]
   "customManagers": [
     {
       "customType": "regex",
@@ -13,6 +14,10 @@
     }
   ],
   "packageRules": [
+    {
+      "matchBaseBranches": ["/^release\\/.*/"],
+      "dependencyDashboardApproval": true
+    },
     {
       "matchCurrentVersion": "<1.0.0",
       "matchPackageNames": ["github.com/distribution/reference"],


### PR DESCRIPTION
Not fully sure it will work, might need more tweaks, but let's see.

- `dependencyDashboardApproval`: this should restrict renovate to not apply dependency updates but only security updates. Non-security updates should still show in the dependency dashboard and can be triggered manually there.