### PR TITLE
Expand docs around the deprecation of former secret syntax

### DIFF
--- a/docs/versioned_docs/version-2.8/20-usage/40-secrets.md
+++ b/docs/versioned_docs/version-2.8/20-usage/40-secrets.md
@@ -13,6 +13,12 @@ Woodpecker provides three different levels to add secrets to your pipeline. The 
 
 ### Use secrets in commands
 
+:::warning
+The use of secrets is deprecated as of version 2.8 and planned to be removed with version 3. 
+Instead, you can use the *secrets in settings and environment* approach outlined below. 
+You can already migrate to this strategy with version 2.8.  
+:::
+
 Secrets are exposed to your pipeline steps and plugins as uppercase environment variables and can therefore be referenced in the commands section of your pipeline,
 once their usage is declared in the `secrets` section:
 
@@ -30,9 +36,30 @@ The case of the environment variables is not changed, but secret matching is don
 
 ### Use secrets in settings and environment
 
-You can set an setting or environment value from secrets using the `from_secret` syntax.
+You can set an setting or environment value from secrets using the `from_secret` syntax. 
 
-In this example, the secret named `secret_token` would be passed to the setting named `token`,which will be available in the plugin as environment variable named `PLUGIN_TOKEN` (See [plugins](./51-plugins/20-creating-plugins.md#settings) for details), and to the environment variable `TOKEN_ENV`.
+The example below passes a secret called `token` as an environment variable that will be called `ENV_TOKEN`:
+
+```diff
+ steps:
+   - name: docker
+     image: my-plugin
++    environment:
++      TOKEN_ENV:
++        from_secret: secret_token
+```
+
+You can use the same syntax to pass secrets to settings: For example, you can pass a secret named `secret_token` to the settings (here called `token`), which will then be available in the plugin as environment variable named `PLUGIN_TOKEN` (See [plugins](./51-plugins/20-creating-plugins.md#settings) for details).
+
+```diff
+ steps:
+   - name: docker
+     image: my-plugin
++    settings:
++      token:
++        from_secret: secret_token
+```
+You can also combine the two, e.g. 
 
 ```diff
  steps:


### PR DESCRIPTION
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->

I've been following along the discussion about the deprecation of the `secrets` syntax with the planned removal for 3.x. I thought it would help to make people feel better informed/have an idea of what to do if the documentation is expanded a bit on that section. 

This is my attempt at this, but please feel free to expand/edit etc as needed! 