### PR TITLE
Remove related pipeline logs during pipeline deletion

### DIFF
--- a/server/store/datastore/log.go
+++ b/server/store/datastore/log.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"github.com/rs/zerolog/log"
+	"xorm.io/xorm"
 
 	"go.woodpecker-ci.org/woodpecker/v2/server/model"
 )
@@ -46,6 +47,11 @@ func (s storage) LogAppend(_ *model.Step, logEntries []*model.LogEntry) error {
 }
 
 func (s storage) LogDelete(step *model.Step) error {
-	_, err := s.engine.Where("step_id = ?", step.ID).Delete(new(model.LogEntry))
-	return err
+	sess := s.engine.NewSession()
+	defer sess.Close()
+	return logDelete(sess, step.ID)
+}
+
+func logDelete(sess *xorm.Session, stepID int64) error {
+	return wrapDelete(sess.Where("step_id = ?", &model.Step{ID: stepID}).Delete(new(model.LogEntry)))
 }

--- a/server/store/datastore/log.go
+++ b/server/store/datastore/log.go
@@ -53,5 +53,5 @@ func (s storage) LogDelete(step *model.Step) error {
 }
 
 func logDelete(sess *xorm.Session, stepID int64) error {
-	return wrapDelete(sess.Where("step_id = ?", &model.Step{ID: stepID}).Delete(new(model.LogEntry)))
+	return wrapDelete(sess.Where("step_id = ?", stepID).Delete(new(model.LogEntry)))
 }

--- a/server/store/datastore/log.go
+++ b/server/store/datastore/log.go
@@ -53,5 +53,6 @@ func (s storage) LogDelete(step *model.Step) error {
 }
 
 func logDelete(sess *xorm.Session, stepID int64) error {
-	return wrapDelete(sess.Where("step_id = ?", stepID).Delete(new(model.LogEntry)))
+	_, err := sess.Where("step_id = ?", stepID).Delete(new(model.LogEntry))
+	return err
 }

--- a/server/store/datastore/step.go
+++ b/server/store/datastore/step.go
@@ -87,8 +87,5 @@ func deleteStep(sess *xorm.Session, stepID int64) error {
 	if err := logDelete(sess, stepID); err != nil {
 		return err
 	}
-	if _, err := sess.Where("id = ?", stepID).Delete(new(model.LogEntry)); err != nil {
-		return err
-	}
 	return wrapDelete(sess.ID(stepID).Delete(new(model.Step)))
 }

--- a/server/store/datastore/step.go
+++ b/server/store/datastore/step.go
@@ -84,6 +84,9 @@ func (s storage) StepUpdate(step *model.Step) error {
 }
 
 func deleteStep(sess *xorm.Session, stepID int64) error {
+	if err := logDelete(sess, stepID); err != nil {
+		return err
+	}
 	if _, err := sess.Where("id = ?", stepID).Delete(new(model.LogEntry)); err != nil {
 		return err
 	}

--- a/server/store/datastore/workflow.go
+++ b/server/store/datastore/workflow.go
@@ -95,6 +95,10 @@ func (s storage) workflowsDelete(sess *xorm.Session, pipelineID int64) error {
 		}
 
 		for i := range stepIDs {
+			if err := s.LogDelete(&model.Step{ID: stepIDs[i]}); err != nil {
+				return err
+			}
+
 			if err := deleteStep(sess, stepIDs[i]); err != nil {
 				return err
 			}

--- a/server/store/datastore/workflow.go
+++ b/server/store/datastore/workflow.go
@@ -95,10 +95,6 @@ func (s storage) workflowsDelete(sess *xorm.Session, pipelineID int64) error {
 		}
 
 		for i := range stepIDs {
-			if err := s.LogDelete(&model.Step{ID: stepIDs[i]}); err != nil {
-				return err
-			}
-
 			if err := deleteStep(sess, stepIDs[i]); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR ensures related pipeline logs are deleted as well during pipeline deletion. To clean up orphaned log entries, I have used the following query on my postgres db:

```sql
DELETE FROM log_entries
USING (
    SELECT l.id 
    FROM log_entries l
    LEFT JOIN steps s ON l.step_id = s.id
    WHERE s.id IS NULL
) AS orphaned
WHERE log_entries.id = orphaned.id;
```

**Disclaimer:** I'm not responsible for any damage to your database, use the query at your own risk and make a backup before executing it.