### PR TITLE
Add client error to sdk and fix purge cli

### DIFF
--- a/cli/pipeline/purge.go
+++ b/cli/pipeline/purge.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Woodpecker Authors
+// Copyright 2024 Woodpecker Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -121,6 +123,11 @@ func pipelinePurge(c *cli.Command, client woodpecker.Client) (err error) {
 
 		err := client.PipelineDelete(repoID, p.Number)
 		if err != nil {
+			var clientErr *woodpecker.ClientError
+			if errors.As(err, &clientErr) && clientErr.StatusCode == http.StatusUnprocessableEntity {
+				log.Error().Err(err).Msgf("failed to delete pipeline %d", p.Number)
+				continue
+			}
 			return err
 		}
 	}

--- a/web/package.json
+++ b/web/package.json
@@ -70,5 +70,6 @@
     "overrides": {
       "semver@<7.5.2": ">=7.5.2"
     }
-  }
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/web/package.json
+++ b/web/package.json
@@ -70,6 +70,5 @@
     "overrides": {
       "semver@<7.5.2": ">=7.5.2"
     }
-  },
-  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
+  }
 }

--- a/woodpecker-go/woodpecker/client.go
+++ b/woodpecker-go/woodpecker/client.go
@@ -125,10 +125,7 @@ func (c *client) do(rawURL, method string, in, out any) error {
 func (c *client) open(rawURL, method string, in any) (io.ReadCloser, error) {
 	uri, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, &ClientError{
-			StatusCode: http.StatusInternalServerError,
-			Message:    err.Error(),
-		}
+		return nil, err
 	}
 	req, err := http.NewRequest(method, uri.String(), nil)
 	if err != nil {
@@ -140,10 +137,7 @@ func (c *client) open(rawURL, method string, in any) (io.ReadCloser, error) {
 	if in != nil {
 		decoded, decodeErr := json.Marshal(in)
 		if decodeErr != nil {
-			return nil, &ClientError{
-				StatusCode: http.StatusInternalServerError,
-				Message:    decodeErr.Error(),
-			}
+			return nil, err
 		}
 		buf := bytes.NewBuffer(decoded)
 		req.Body = io.NopCloser(buf)
@@ -153,10 +147,7 @@ func (c *client) open(rawURL, method string, in any) (io.ReadCloser, error) {
 	}
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, &ClientError{
-			StatusCode: http.StatusInternalServerError,
-			Message:    err.Error(),
-		}
+		return nil, err
 	}
 	if resp.StatusCode > http.StatusPartialContent {
 		defer resp.Body.Close()

--- a/woodpecker-go/woodpecker/client.go
+++ b/woodpecker-go/woodpecker/client.go
@@ -137,7 +137,7 @@ func (c *client) open(rawURL, method string, in any) (io.ReadCloser, error) {
 	if in != nil {
 		decoded, decodeErr := json.Marshal(in)
 		if decodeErr != nil {
-			return nil, err
+			return nil, decodeErr
 		}
 		buf := bytes.NewBuffer(decoded)
 		req.Body = io.NopCloser(buf)

--- a/woodpecker-go/woodpecker/client.go
+++ b/woodpecker-go/woodpecker/client.go
@@ -129,10 +129,7 @@ func (c *client) open(rawURL, method string, in any) (io.ReadCloser, error) {
 	}
 	req, err := http.NewRequest(method, uri.String(), nil)
 	if err != nil {
-		return nil, &ClientError{
-			StatusCode: http.StatusInternalServerError,
-			Message:    err.Error(),
-		}
+		return nil, err
 	}
 	if in != nil {
 		decoded, decodeErr := json.Marshal(in)


### PR DESCRIPTION
The PR introduces a `ClientError` type to the sdk. This way, the HTTP error returned by the API can be handled more easily.  The PR also fixes a bug in the cli purge command where the purge action of a repo was interrupted on the first error. This behavior was changed to not fail on HTTP 422 errors but log the error and continue with the next pipeline instead.