### PR TITLE
Disable corepack auto-pin during build

### DIFF
--- a/docker/Dockerfile.make
+++ b/docker/Dockerfile.make
@@ -1,5 +1,5 @@
-# docker build --rm  -f docker/Dockerfile.make -t woodpecker/make:local .
-FROM docker.io/golang:1.23-alpine as golang_image
+# docker build --rm -f docker/Dockerfile.make -t woodpecker/make:local .
+FROM docker.io/golang:1.23-alpine AS golang_image
 FROM docker.io/node:23-alpine
 
 RUN apk add --no-cache --update make gcc binutils-gold musl-dev protoc && \
@@ -10,6 +10,7 @@ COPY --from=golang_image /usr/local/go /usr/local/go
 COPY Makefile /
 ENV PATH=$PATH:/usr/local/go/bin
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+ENV COREPACK_ENABLE_AUTO_PIN=0
 
 # Cache tools
 RUN GOBIN=/usr/local/go/bin make install-tools && \


### PR DESCRIPTION
Disable corepack auto-pinning otherwise `packageManager` field in package.json is added, and I have committed it accidentally multiple times already. 