### PR TITLE
Propagate version updates after artifacts are released

### DIFF
--- a/.woodpecker/docs.yaml
+++ b/.woodpecker/docs.yaml
@@ -22,6 +22,10 @@ variables:
       # Dockerfile changes
       - 'docker/**'
 
+depends_on:
+  - docker
+  - binaries
+
 when:
   - event: tag
   - event: pull_request


### PR DESCRIPTION
Wait until container images and binaries were built and uploaded successfully before publishing the `version.json` update. 