### PR TITLE
pre-commit prettier: switch to maintained fork

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
     rev: v2.13.1-beta
     hooks:
       - id: hadolint
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com//rbubley/mirrors-prettier
+    rev: v3.4.2
     hooks:
       - id: prettier
   - repo: https://github.com/adrienverge/yamllint.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v2.13.1-beta
     hooks:
       - id: hadolint
-  - repo: https://github.com//rbubley/mirrors-prettier
+  - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.4.2
     hooks:
       - id: prettier


### PR DESCRIPTION
The current one is archived and pre-commit itself doesn't maintain it anymore. It also fails with some strange errors which don't occur in the referenced fork.