### PR TITLE
Add rootless (alpine) images

### DIFF
--- a/.woodpecker/docker.yaml
+++ b/.woodpecker/docker.yaml
@@ -214,6 +214,23 @@ steps:
       logins: *publish_logins
     when: *when-release
 
+  release-server-alpine-rootless:
+    depends_on:
+      - cross-compile-server
+    image: *buildx_plugin
+    settings:
+      repo: *publish_repos_server
+      dockerfile: docker/Dockerfile.server.alpine.multiarch.rootless
+      platforms: *platforms_alpine
+      tag:
+        [
+          '${CI_COMMIT_TAG%%.*}-alpine-rootless',
+          '${CI_COMMIT_TAG%.*}-alpine-rootless',
+          '${CI_COMMIT_TAG}-alpine-rootless',
+        ]
+      logins: *publish_logins
+    when: *when-release
+
   #############
   # A g e n t #
   #############
@@ -311,6 +328,27 @@ steps:
       build_args: *build_args
     when: *when-release
 
+  release-agent-alpine-rootless:
+    depends_on:
+      - vendor
+      # we also depend on cross-compile-server as we would have to hight
+      # ram usage otherwise
+      - cross-compile-server
+    image: *buildx_plugin
+    settings:
+      repo: *publish_repos_agent
+      dockerfile: docker/Dockerfile.agent.alpine.multiarch.rootless
+      platforms: *platforms_alpine
+      tag:
+        [
+          '${CI_COMMIT_TAG%%.*}-alpine-rootless',
+          '${CI_COMMIT_TAG%.*}-alpine-rootless',
+          '${CI_COMMIT_TAG}-alpine-rootless',
+        ]
+      logins: *publish_logins
+      build_args: *build_args
+    when: *when-release
+
   #########
   # C L I #
   #########
@@ -401,6 +439,27 @@ steps:
       dockerfile: docker/Dockerfile.cli.alpine.multiarch
       platforms: *platforms_alpine
       tag: ['${CI_COMMIT_TAG%%.*}-alpine', '${CI_COMMIT_TAG%.*}-alpine', '${CI_COMMIT_TAG}-alpine']
+      logins: *publish_logins
+      build_args: *build_args
+    when: *when-release
+
+  release-cli-alpine-rootless:
+    depends_on:
+      - vendor
+      # we also depend on release-agent as we would have to hight
+      # ram usage otherwise
+      - release-agent
+    image: *buildx_plugin
+    settings:
+      repo: *publish_repos_cli
+      dockerfile: docker/Dockerfile.cli.alpine.multiarch.rootless
+      platforms: *platforms_alpine
+      tag:
+        [
+          '${CI_COMMIT_TAG%%.*}-alpine-rootless',
+          '${CI_COMMIT_TAG%.*}-alpine-rootless',
+          '${CI_COMMIT_TAG}-alpine-rootless',
+        ]
       logins: *publish_logins
       build_args: *build_args
     when: *when-release

--- a/docker/Dockerfile.agent.alpine.multiarch.rootless
+++ b/docker/Dockerfile.agent.alpine.multiarch.rootless
@@ -1,0 +1,26 @@
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.23 AS build
+
+WORKDIR /src
+COPY . .
+ARG TARGETOS TARGETARCH CI_COMMIT_SHA CI_COMMIT_TAG CI_COMMIT_BRANCH
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    make build-agent
+
+FROM docker.io/alpine:3.21
+RUN apk add -U --no-cache ca-certificates
+ENV GODEBUG=netdns=go
+# Internal setting do NOT change! Signals that woodpecker is running inside a container
+ENV WOODPECKER_IN_CONTAINER=true
+EXPOSE 3000
+
+COPY --from=build /src/dist/woodpecker-agent /bin/
+RUN mkdir -p /etc/woodpecker
+
+RUN addgroup -S woodpecker && adduser -S woodpecker -G woodpecker
+RUN mkdir -p /var/lib/woodpecker && chown -R woodpecker:woodpecker /etc/woodpecker
+
+USER woodpecker
+
+HEALTHCHECK CMD ["/bin/woodpecker-agent", "ping"]
+ENTRYPOINT ["/bin/woodpecker-agent"]

--- a/docker/Dockerfile.agent.alpine.multiarch.rootless
+++ b/docker/Dockerfile.agent.alpine.multiarch.rootless
@@ -18,7 +18,7 @@ COPY --from=build /src/dist/woodpecker-agent /bin/
 RUN mkdir -p /etc/woodpecker
 
 RUN addgroup -S woodpecker && adduser -S woodpecker -G woodpecker
-RUN mkdir -p /var/lib/woodpecker && chown -R woodpecker:woodpecker /etc/woodpecker
+RUN mkdir -p /etc/woodpecker && chown -R woodpecker:woodpecker /etc/woodpecker
 
 USER woodpecker
 

--- a/docker/Dockerfile.cli.alpine.multiarch.rootless
+++ b/docker/Dockerfile.cli.alpine.multiarch.rootless
@@ -1,0 +1,25 @@
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.23 AS build
+
+WORKDIR /src
+COPY . .
+ARG TARGETOS TARGETARCH CI_COMMIT_SHA CI_COMMIT_TAG CI_COMMIT_BRANCH
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    make build-cli
+
+FROM docker.io/alpine:3.21
+WORKDIR /woodpecker
+
+RUN apk add -U --no-cache ca-certificates
+
+ENV GODEBUG=netdns=go
+ENV WOODPECKER_DISABLE_UPDATE_CHECK=true
+
+COPY --from=build /src/dist/woodpecker-cli /bin/
+
+RUN addgroup -S woodpecker && adduser -S woodpecker -G woodpecker
+
+USER woodpecker
+
+HEALTHCHECK CMD ["/bin/woodpecker-cli", "ping"]
+ENTRYPOINT ["/bin/woodpecker-cli"]

--- a/docker/Dockerfile.server.alpine.multiarch.rootless
+++ b/docker/Dockerfile.server.alpine.multiarch.rootless
@@ -1,0 +1,18 @@
+FROM docker.io/alpine:3.21
+
+ARG TARGETOS TARGETARCH
+RUN apk add -U --no-cache ca-certificates
+ENV GODEBUG=netdns=go
+# Internal setting do NOT change! Signals that woodpecker is running inside a container
+ENV WOODPECKER_IN_CONTAINER=true
+ENV XDG_CACHE_HOME=/var/lib/woodpecker
+ENV XDG_DATA_HOME=/var/lib/woodpecker
+EXPOSE 8000 9000 80 443
+
+COPY dist/server/${TARGETOS}_${TARGETARCH}/woodpecker-server /bin/
+
+RUN addgroup -S woodpecker && adduser -S woodpecker -G woodpecker
+RUN mkdir -p /var/lib/woodpecker && chown -R woodpecker:woodpecker /var/lib/woodpecker
+
+HEALTHCHECK CMD ["/bin/woodpecker-server", "ping"]
+ENTRYPOINT ["/bin/woodpecker-server"]

--- a/docker/Dockerfile.server.alpine.multiarch.rootless
+++ b/docker/Dockerfile.server.alpine.multiarch.rootless
@@ -14,5 +14,7 @@ COPY dist/server/${TARGETOS}_${TARGETARCH}/woodpecker-server /bin/
 RUN addgroup -S woodpecker && adduser -S woodpecker -G woodpecker
 RUN mkdir -p /var/lib/woodpecker && chown -R woodpecker:woodpecker /var/lib/woodpecker
 
+USER woodpecker
+
 HEALTHCHECK CMD ["/bin/woodpecker-server", "ping"]
 ENTRYPOINT ["/bin/woodpecker-server"]

--- a/docs/docs/30-administration/04-image-variants.md
+++ b/docs/docs/30-administration/04-image-variants.md
@@ -1,0 +1,3 @@
+# Image variants
+
+FIXME


### PR DESCRIPTION
## Background

Currently, two image variants exist:

- scratch-based images
- alpine-based

The former is a few MB smaller than the alpine one but lacks the ability to exec into it as it has no shell.
The latter has a shell but as both run as `root` user, using the alpine image is somewhat risky.

## Possible solutions

There are two ways to approach this:

1. Add a new `rootless` variant for the alpine variant (-> allows to exec into the pod but without being `root`)
2. Replace the `scratch` variant by a rootless alpine variant and make it the default 

With (1), there would be three image variants that need to be build and maintained. Having this many, possible confusion among users exists. Also sticking with the `scratch` image as the default is not super convenient as adminds always have to switch to the alpine one first for interactive actions

With (2), there would be only two image variants (`alpine-rootless` and `alpine-rootful`). Making `alpine-rootless` the default (i.e. tagging with only semver versions) provides the same security as before because running rootless = same as using `scratch`, one cannot do anything destructive within the container.)

It would additionally provide the ability to exec into the container/pod. A possible downside would be that the image is a few MB bigger (e.g. 17mb instead of 13mb for the server image).

I'd like to get a maintainers vote here how to proceed. Based on that, I would like to a add a new docs page which explains the existing tags and their indented usage, similar to what has been added recently to the repository descriptions on DockerHub.

@woodpecker-ci/maintainers 
Vote with 🚀 for keeping `scratch` and having a new `alpine-rootless` variant.
Vote with 👀 for dropping `scratch` and replacing it with the new `alpine-rootless` variant.

PS: I tested the server and agent images in a k8s instance. The CLI image was tested locally.