### PR TITLE
Drop dependency chain from docs workflow

### DIFF
--- a/.woodpecker/docs.yaml
+++ b/.woodpecker/docs.yaml
@@ -41,7 +41,9 @@ steps:
     image: docker.io/woodpeckerci/plugin-prettier:1.0.0
     settings:
       version: 3.3.3
-
+    when:
+      event:
+        pull_request
   build-cli:
     image: *golang_image
     commands:

--- a/.woodpecker/docs.yaml
+++ b/.woodpecker/docs.yaml
@@ -39,7 +39,6 @@ when:
 steps:
   prettier:
     image: docker.io/woodpeckerci/plugin-prettier:1.0.0
-    depends_on: []
     settings:
       version: 3.3.3
 
@@ -47,7 +46,6 @@ steps:
     image: *golang_image
     commands:
       - make docs
-    depends_on: prettier
     when:
       - path: *when_path
         event: [tag, pull_request, push]
@@ -60,9 +58,6 @@ steps:
       - corepack enable
       - pnpm install --frozen-lockfile
       - pnpm build
-    depends_on:
-      - prettier
-      - build-cli
     when:
       - path: *when_path
         event: [tag, pull_request, push]
@@ -77,9 +72,6 @@ steps:
       forge_repo_token:
         from_secret: GITHUB_TOKEN_SURGE
     failure: ignore
-    depends_on:
-      - prettier
-      - build
     when:
       event: [pull_request, pull_request_closed]
       path: *when_path
@@ -96,9 +88,6 @@ steps:
       - echo "$BOT_PRIVATE_KEY" > $HOME/.ssh/id_rsa
       - chmod 0600 $HOME/.ssh/id_rsa
       - git clone --depth 1 --single-branch git@github.com:woodpecker-ci/woodpecker-ci.github.io.git ./docs_repo
-    depends_on:
-      - prettier
-      - build
     when:
       - event: push
         path:
@@ -114,9 +103,6 @@ steps:
       - apk add jq
       - jq '.next = "next-${CI_COMMIT_SHA:0:10}"' ./docs_repo/version.json > ./docs_repo/version.json.tmp
       - mv ./docs_repo/version.json.tmp ./docs_repo/version.json
-    depends_on:
-      - prettier
-      - deploy-prepare
     when:
       - event: push
         path: *docker_path
@@ -129,9 +115,6 @@ steps:
       - if [[ "${CI_COMMIT_TAG}" != *"rc"* ]] ; then jq '.latest = "${CI_COMMIT_TAG}"' ./docs_repo/version.json > ./docs_repo/version.json.tmp && mv ./docs_repo/version.json.tmp ./docs_repo/version.json ; fi
       - jq '.rc = "${CI_COMMIT_TAG}"' ./docs_repo/version.json > ./docs_repo/version.json.tmp
       - mv ./docs_repo/version.json.tmp ./docs_repo/version.json
-    depends_on:
-      - prettier
-      - deploy-prepare
     when:
       - event: tag
 
@@ -141,9 +124,6 @@ steps:
       - apk add rsync
       # copy all docs files and delete all old ones, but leave CNAME, index.yaml and version.json untouched
       - rsync -r --exclude .git --exclude CNAME --exclude index.yaml --exclude README.md --exclude version.json --delete docs/build/ ./docs_repo
-    depends_on:
-      - prettier
-      - build
     when:
       - event: push
         path: *when_path
@@ -169,9 +149,6 @@ steps:
       - test -n "$(git status --porcelain)" || exit 0
       - git commit -m "Deploy website - based on ${CI_COMMIT_SHA}"
       - git push
-    depends_on:
-      - prettier
-      - copy-files
     when:
       - event: push
         path:

--- a/.woodpecker/docs.yaml
+++ b/.woodpecker/docs.yaml
@@ -43,6 +43,7 @@ steps:
       version: 3.3.3
     when:
       - event: pull_request
+
   build-cli:
     image: *golang_image
     commands:

--- a/.woodpecker/docs.yaml
+++ b/.woodpecker/docs.yaml
@@ -42,8 +42,7 @@ steps:
     settings:
       version: 3.3.3
     when:
-      event:
-        pull_request
+      - event: pull_request
   build-cli:
     image: *golang_image
     commands:
@@ -75,8 +74,8 @@ steps:
         from_secret: GITHUB_TOKEN_SURGE
     failure: ignore
     when:
-      event: [pull_request, pull_request_closed]
-      path: *when_path
+      - event: [pull_request, pull_request_closed]
+        path: *when_path
 
   deploy-prepare:
     image: *alpine_image


### PR DESCRIPTION
Fixes: https://ci.woodpecker-ci.org/repos/3780/pipeline/24411

Introduced in https://github.com/woodpecker-ci/woodpecker/pull/4628 and still not fixed after https://github.com/woodpecker-ci/woodpecker/pull/4637 I think we should just drop the dependency chain, see my comment in https://github.com/woodpecker-ci/woodpecker/pull/4637#issuecomment-2564373206