### PR TITLE
Increase left padding for repo items

### DIFF
--- a/web/src/components/repo/RepoItem.vue
+++ b/web/src/components/repo/RepoItem.vue
@@ -25,7 +25,7 @@
         <template v-if="lastPipeline">
           <div class="flex min-w-0 flex-1 items-center gap-x-1">
             <PipelineStatusIcon v-if="lastPipeline" :status="lastPipeline.status" />
-            <span class="overflow-hidden overflow-ellipsis whitespace-nowrap">{{ shortMessage }}</span>
+            <span class="overflow-hidden overflow-ellipsis whitespace-nowrap pl-1">{{ shortMessage }}</span>
           </div>
 
           <div class="ml-auto flex flex-shrink-0 items-center gap-x-1">


### PR DESCRIPTION
Current `next` has lost the padding between the status icon and the commit message.

Before:

<img width="286" alt="image" src="https://github.com/user-attachments/assets/9aa7ab38-5884-4791-8510-6bbe79809fd9" />

After:

<img width="289" alt="image" src="https://github.com/user-attachments/assets/cb51b9d3-e3d0-4ca6-9c7e-22d0dd22bc1f" />
