### PR TITLE
Don't fail user creation if org exists

### DIFF
--- a/server/store/datastore/org.go
+++ b/server/store/datastore/org.go
@@ -16,7 +16,6 @@ package datastore
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"xorm.io/xorm"
@@ -78,14 +77,12 @@ func (s storage) orgDelete(sess *xorm.Session, id int64) error {
 func (s storage) OrgFindByName(name string) (*model.Org, error) {
 	// sanitize
 	name = strings.ToLower(name)
-	// find
 	org := new(model.Org)
 	has, err := s.engine.Where("name = ?", name).Get(org)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if org exists: %w", err)
 	}
 	if !has {
-		log.Printf("Organization with name %s not found", name)
 		return nil, nil
 	}
 	return org, nil

--- a/server/store/datastore/org.go
+++ b/server/store/datastore/org.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"xorm.io/xorm"
@@ -79,7 +80,15 @@ func (s storage) OrgFindByName(name string) (*model.Org, error) {
 	name = strings.ToLower(name)
 	// find
 	org := new(model.Org)
-	return org, wrapGet(s.engine.Where("name = ?", name).Get(org))
+	has, err := s.engine.Where("name = ?", name).Get(org)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if org exists: %w", err)
+	}
+	if !has {
+		log.Printf("Organization with name %s not found", name)
+		return nil, nil
+	}
+	return org, nil
 }
 
 func (s storage) OrgRepoList(org *model.Org, p *model.ListOptions) ([]*model.Repo, error) {

--- a/server/store/datastore/user.go
+++ b/server/store/datastore/user.go
@@ -15,6 +15,8 @@
 package datastore
 
 import (
+	"fmt"
+
 	"xorm.io/xorm"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
@@ -59,9 +61,24 @@ func (s storage) CreateUser(user *model.User) error {
 		Name:   user.Login,
 		IsUser: true,
 	}
-	err := s.orgCreate(org, sess)
+
+	existingOrg, err := s.OrgFindByName(org.Name)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to check if org exists: %w", err)
+	}
+
+	if existingOrg != nil {
+		if existingOrg.Name == user.Login {
+			err = s.OrgUpdate(org)
+			if err != nil {
+				return fmt.Errorf("failed to update existing org: %w", err)
+			}
+		}
+	} else {
+		err = s.orgCreate(org, sess)
+		if err != nil {
+			return fmt.Errorf("failed to create new org: %w", err)
+		}
 	}
 	user.OrgID = org.ID
 	// only Insert set auto created ID back to object

--- a/server/store/datastore/users_test.go
+++ b/server/store/datastore/users_test.go
@@ -100,7 +100,6 @@ func TestCreateUserWithExistingOrg(t *testing.T) {
 	defer closer()
 
 	existingOrg := &model.Org{
-		ID:      1,
 		ForgeID: 1,
 		IsUser:  true,
 		Name:    "existingorg",


### PR DESCRIPTION
fix #4651

Also modified `OrgFindByName` to return `nil` if nothing is found instead of erroring with a SQL error.