### PR TITLE
Reduce interactive WP icon size

### DIFF
--- a/web/src/components/repo/pipeline/PipelineItem.vue
+++ b/web/src/components/repo/pipeline/PipelineItem.vue
@@ -11,7 +11,7 @@
           'bg-wp-state-info-100': pipelineStatusColors[pipeline.status] === 'blue',
         }"
       />
-      <div class="flex h-full w-8 flex-wrap items-center justify-between">
+      <div class="flex h-full w-6 flex-wrap items-center justify-between">
         <PipelineRunningIcon v-if="pipeline.status === 'started' || pipeline.status === 'running'" />
         <PipelineStatusIcon v-else class="mx-2 md:mx-3" :status="pipeline.status" />
       </div>


### PR DESCRIPTION
This appears somewhat to big now IMO with all the other resizings that were lately applied.

Proposal: reduce the size of the WP icon on running pipelines.
The full sized one almost looks a bit "confined". Giving it a bit more space looks smoother imo.

Also, in 2.8.2 it didn't fill all the vertical space.

Before:

<img width="90" alt="image" src="https://github.com/user-attachments/assets/299d270d-acda-49f5-b37e-f6b68a5ab983" />

After:

<img width="88" alt="image" src="https://github.com/user-attachments/assets/f7ec3f63-f128-4a0e-b058-0c485c6ae1c7" />
