### PR TITLE
[release/v2.8] Don't fail user creation if org exists (#4687)

### DIFF
--- a/server/store/datastore/org.go
+++ b/server/store/datastore/org.go
@@ -77,9 +77,15 @@ func (s storage) orgDelete(sess *xorm.Session, id int64) error {
 func (s storage) OrgFindByName(name string) (*model.Org, error) {
 	// sanitize
 	name = strings.ToLower(name)
-	// find
 	org := new(model.Org)
-	return org, wrapGet(s.engine.Where("name = ?", name).Get(org))
+	has, err := s.engine.Where("name = ?", name).Get(org)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if org exists: %w", err)
+	}
+	if !has {
+		return nil, nil
+	}
+	return org, nil
 }
 
 func (s storage) OrgRepoList(org *model.Org, p *model.ListOptions) ([]*model.Repo, error) {

--- a/server/store/datastore/users_test.go
+++ b/server/store/datastore/users_test.go
@@ -253,3 +253,42 @@ func TestUsers(t *testing.T) {
 		})
 	})
 }
+
+func TestCreateUserWithExistingOrg(t *testing.T) {
+	store, closer := newTestStore(t, new(model.User), new(model.Org), new(model.Perm))
+	defer closer()
+
+	existingOrg := &model.Org{
+		ForgeID: 1,
+		IsUser:  true,
+		Name:    "existingorg",
+		Private: false,
+	}
+
+	err := store.OrgCreate(existingOrg)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "existingorg", existingOrg.Name)
+
+	// Create a new user with the same name as the existing organization
+	newUser := &model.User{
+		Login: "existingOrg",
+		Hash:  "A",
+	}
+	err = store.CreateUser(newUser)
+	assert.NoError(t, err)
+
+	updatedOrg, err := store.OrgGet(existingOrg.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, "existingorg", updatedOrg.Name)
+
+	newUser2 := &model.User{
+		Login: "new-user",
+		Hash:  "B",
+	}
+	err = store.CreateUser(newUser2)
+	assert.NoError(t, err)
+
+	newOrg, err := store.OrgFindByName("new-user")
+	assert.NoError(t, err)
+	assert.Equal(t, "new-user", newOrg.Name)
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.8`:
 - [Don&#x27;t fail user creation if org exists (#4687)](https://github.com/woodpecker-ci/woodpecker/pull/4687)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)