### PR TITLE
[release/v2.8] Remove related pipeline logs during pipeline deletion (#4572)

### DIFF
--- a/server/store/datastore/log.go
+++ b/server/store/datastore/log.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"github.com/rs/zerolog/log"
+	"xorm.io/xorm"
 
 	"go.woodpecker-ci.org/woodpecker/v2/server/model"
 )
@@ -46,6 +47,12 @@ func (s storage) LogAppend(_ *model.Step, logEntries []*model.LogEntry) error {
 }
 
 func (s storage) LogDelete(step *model.Step) error {
-	_, err := s.engine.Where("step_id = ?", step.ID).Delete(new(model.LogEntry))
+	sess := s.engine.NewSession()
+	defer sess.Close()
+	return logDelete(sess, step.ID)
+}
+
+func logDelete(sess *xorm.Session, stepID int64) error {
+	_, err := sess.Where("step_id = ?", stepID).Delete(new(model.LogEntry))
 	return err
 }

--- a/server/store/datastore/step.go
+++ b/server/store/datastore/step.go
@@ -84,7 +84,7 @@ func (s storage) StepUpdate(step *model.Step) error {
 }
 
 func deleteStep(sess *xorm.Session, stepID int64) error {
-	if _, err := sess.Where("id = ?", stepID).Delete(new(model.LogEntry)); err != nil {
+	if err := logDelete(sess, stepID); err != nil {
 		return err
 	}
 	return wrapDelete(sess.ID(stepID).Delete(new(model.Step)))


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.8`:
 - [Remove related pipeline logs during pipeline deletion (#4572)](https://github.com/woodpecker-ci/woodpecker/pull/4572)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)