### PR TITLE
[release/v2.8] Weakly decode backend options (#4577)

### DIFF
--- a/pipeline/backend/docker/backend_options.go
+++ b/pipeline/backend/docker/backend_options.go
@@ -1,0 +1,21 @@
+package docker
+
+import (
+	"github.com/go-viper/mapstructure/v2"
+
+	backend "go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/types"
+)
+
+// BackendOptions defines all the advanced options for the docker backend.
+type BackendOptions struct {
+	User string `mapstructure:"user"`
+}
+
+func parseBackendOptions(step *backend.Step) (BackendOptions, error) {
+	var result BackendOptions
+	if step == nil || step.BackendOptions == nil {
+		return result, nil
+	}
+	err := mapstructure.WeakDecode(step.BackendOptions[EngineName], &result)
+	return result, err
+}

--- a/pipeline/backend/kubernetes/backend_options.go
+++ b/pipeline/backend/kubernetes/backend_options.go
@@ -89,6 +89,6 @@ func parseBackendOptions(step *backend.Step) (BackendOptions, error) {
 	if step.BackendOptions == nil {
 		return result, nil
 	}
-	err := mapstructure.Decode(step.BackendOptions[EngineName], &result)
+	err := mapstructure.WeakDecode(step.BackendOptions[EngineName], &result)
 	return result, err
 }

--- a/pipeline/backend/kubernetes/backend_options_test.go
+++ b/pipeline/backend/kubernetes/backend_options_test.go
@@ -5,101 +5,143 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	backend "go.woodpecker-ci.org/woodpecker/v2/pipeline/backend/types"
+	backend "go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
 )
 
 func Test_parseBackendOptions(t *testing.T) {
-	got, err := parseBackendOptions(&backend.Step{BackendOptions: nil})
-	assert.NoError(t, err)
-	assert.Equal(t, BackendOptions{}, got)
-	got, err = parseBackendOptions(&backend.Step{BackendOptions: map[string]any{}})
-	assert.NoError(t, err)
-	assert.Equal(t, BackendOptions{}, got)
-	got, err = parseBackendOptions(&backend.Step{
-		BackendOptions: map[string]any{
-			"kubernetes": map[string]any{
-				"nodeSelector":       map[string]string{"storage": "ssd"},
-				"serviceAccountName": "wp-svc-acc",
-				"labels":             map[string]string{"app": "test"},
-				"annotations":        map[string]string{"apps.kubernetes.io/pod-index": "0"},
-				"tolerations": []map[string]any{
-					{"key": "net-port", "value": "100Mbit", "effect": TaintEffectNoSchedule},
-				},
-				"resources": map[string]any{
-					"requests": map[string]string{"memory": "128Mi", "cpu": "1000m"},
-					"limits":   map[string]string{"memory": "256Mi", "cpu": "2"},
-				},
-				"securityContext": map[string]any{
-					"privileged":   newBool(true),
-					"runAsNonRoot": newBool(true),
-					"runAsUser":    newInt64(101),
-					"runAsGroup":   newInt64(101),
-					"fsGroup":      newInt64(101),
-					"seccompProfile": map[string]any{
-						"type":             "Localhost",
-						"localhostProfile": "profiles/audit.json",
-					},
-					"apparmorProfile": map[string]any{
-						"type":             "Localhost",
-						"localhostProfile": "k8s-apparmor-example-deny-write",
-					},
-				},
-				"secrets": []map[string]any{
-					{
-						"name": "aws",
-						"key":  "access-key",
-						"target": map[string]any{
-							"env": "AWS_SECRET_ACCESS_KEY",
+	tests := []struct {
+		name    string
+		step    *backend.Step
+		want    BackendOptions
+		wantErr bool
+	}{
+		{
+			name: "nil options",
+			step: &backend.Step{BackendOptions: nil},
+			want: BackendOptions{},
+		},
+		{
+			name: "empty options",
+			step: &backend.Step{BackendOptions: map[string]any{}},
+			want: BackendOptions{},
+		},
+		{
+			name: "full k8s options",
+			step: &backend.Step{
+				BackendOptions: map[string]any{
+					"kubernetes": map[string]any{
+						"nodeSelector":       map[string]string{"storage": "ssd"},
+						"serviceAccountName": "wp-svc-acc",
+						"labels":             map[string]string{"app": "test"},
+						"annotations":        map[string]string{"apps.kubernetes.io/pod-index": "0"},
+						"tolerations": []map[string]any{
+							{"key": "net-port", "value": "100Mbit", "effect": TaintEffectNoSchedule},
+						},
+						"resources": map[string]any{
+							"requests": map[string]string{"memory": "128Mi", "cpu": "1000m"},
+							"limits":   map[string]string{"memory": "256Mi", "cpu": "2"},
+						},
+						"securityContext": map[string]any{
+							"privileged":   newBool(true),
+							"runAsNonRoot": newBool(true),
+							"runAsUser":    newInt64(101),
+							"runAsGroup":   newInt64(101),
+							"fsGroup":      newInt64(101),
+							"seccompProfile": map[string]any{
+								"type":             "Localhost",
+								"localhostProfile": "profiles/audit.json",
+							},
+							"apparmorProfile": map[string]any{
+								"type":             "Localhost",
+								"localhostProfile": "k8s-apparmor-example-deny-write",
+							},
+						},
+						"secrets": []map[string]any{
+							{
+								"name": "aws",
+								"key":  "access-key",
+								"target": map[string]any{
+									"env": "AWS_SECRET_ACCESS_KEY",
+								},
+							},
+							{
+								"name": "reg-cred",
+								"key":  ".dockerconfigjson",
+								"target": map[string]any{
+									"file": "~/.docker/config.json",
+								},
+							},
 						},
 					},
+				},
+			},
+			want: BackendOptions{
+				NodeSelector:       map[string]string{"storage": "ssd"},
+				ServiceAccountName: "wp-svc-acc",
+				Labels:             map[string]string{"app": "test"},
+				Annotations:        map[string]string{"apps.kubernetes.io/pod-index": "0"},
+				Tolerations:        []Toleration{{Key: "net-port", Value: "100Mbit", Effect: TaintEffectNoSchedule}},
+				Resources: Resources{
+					Requests: map[string]string{"memory": "128Mi", "cpu": "1000m"},
+					Limits:   map[string]string{"memory": "256Mi", "cpu": "2"},
+				},
+				SecurityContext: &SecurityContext{
+					Privileged:   newBool(true),
+					RunAsNonRoot: newBool(true),
+					RunAsUser:    newInt64(101),
+					RunAsGroup:   newInt64(101),
+					FSGroup:      newInt64(101),
+					SeccompProfile: &SecProfile{
+						Type:             "Localhost",
+						LocalhostProfile: "profiles/audit.json",
+					},
+					ApparmorProfile: &SecProfile{
+						Type:             "Localhost",
+						LocalhostProfile: "k8s-apparmor-example-deny-write",
+					},
+				},
+				Secrets: []SecretRef{
 					{
-						"name": "reg-cred",
-						"key":  ".dockerconfigjson",
-						"target": map[string]any{
-							"file": "~/.docker/config.json",
-						},
+						Name:   "aws",
+						Key:    "access-key",
+						Target: SecretTarget{Env: "AWS_SECRET_ACCESS_KEY"},
+					},
+					{
+						Name:   "reg-cred",
+						Key:    ".dockerconfigjson",
+						Target: SecretTarget{File: "~/.docker/config.json"},
 					},
 				},
 			},
 		},
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, BackendOptions{
-		NodeSelector:       map[string]string{"storage": "ssd"},
-		ServiceAccountName: "wp-svc-acc",
-		Labels:             map[string]string{"app": "test"},
-		Annotations:        map[string]string{"apps.kubernetes.io/pod-index": "0"},
-		Tolerations:        []Toleration{{Key: "net-port", Value: "100Mbit", Effect: TaintEffectNoSchedule}},
-		Resources: Resources{
-			Requests: map[string]string{"memory": "128Mi", "cpu": "1000m"},
-			Limits:   map[string]string{"memory": "256Mi", "cpu": "2"},
-		},
-		SecurityContext: &SecurityContext{
-			Privileged:   newBool(true),
-			RunAsNonRoot: newBool(true),
-			RunAsUser:    newInt64(101),
-			RunAsGroup:   newInt64(101),
-			FSGroup:      newInt64(101),
-			SeccompProfile: &SecProfile{
-				Type:             "Localhost",
-				LocalhostProfile: "profiles/audit.json",
-			},
-			ApparmorProfile: &SecProfile{
-				Type:             "Localhost",
-				LocalhostProfile: "k8s-apparmor-example-deny-write",
+		{
+			name: "number options",
+			step: &backend.Step{BackendOptions: map[string]any{
+				"kubernetes": map[string]any{
+					"resources": map[string]any{
+						"requests": map[string]int{"memory": 128, "cpu": 1000},
+						"limits":   map[string]int{"memory": 256, "cpu": 2},
+					},
+				},
+			}},
+			want: BackendOptions{
+				Resources: Resources{
+					Requests: map[string]string{"memory": "128", "cpu": "1000"},
+					Limits:   map[string]string{"memory": "256", "cpu": "2"},
+				},
 			},
 		},
-		Secrets: []SecretRef{
-			{
-				Name:   "aws",
-				Key:    "access-key",
-				Target: SecretTarget{Env: "AWS_SECRET_ACCESS_KEY"},
-			},
-			{
-				Name:   "reg-cred",
-				Key:    ".dockerconfigjson",
-				Target: SecretTarget{File: "~/.docker/config.json"},
-			},
-		},
-	}, got)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBackendOptions(tt.step)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.8`:
 - [Weakly decode backend options (#4577)](https://github.com/woodpecker-ci/woodpecker/pull/4577)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)