### PR TITLE
Fix syntax for dynamic docs versioning

### DIFF
--- a/docs/.prettierrc.js
+++ b/docs/.prettierrc.js
@@ -1,9 +1,6 @@
-import { readFile } from 'node:fs/promises';
+const config = require('../.prettierrc.json');
 
-// eslint-disable-next-line antfu/no-top-level-await
-const config = JSON.parse(await readFile(new URL('../.prettierrc.json', import.meta.url)));
-
-export default {
+module.exports = {
   ...config,
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,19 +1,21 @@
 import * as path from 'path';
+import type { VersionBanner, VersionOptions } from '@docusaurus/plugin-content-docs';
 import type * as Preset from '@docusaurus/preset-classic';
 import type { Config } from '@docusaurus/types';
 import { themes } from 'prism-react-renderer';
+
 import * as versions from './versions.json';
 
-const docsVersions = {
+const docsVersions: { [version: string]: VersionOptions } = {
   current: {
     label: 'Next 🚧',
-    banner: 'unreleased',
+    banner: 'unreleased' as VersionBanner,
   },
 };
 
-const includeVersions = ['current', versions.default[0]];
+const includeVersions = ['current', versions[0]];
 
-versions.default.forEach((v, index) => {
+versions.forEach((v, index) => {
   const version = {
     label: `${v}.x${index === 0 ? '' : ' 💀'}`,
   };
@@ -257,7 +259,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/woodpecker-ci/woodpecker/edit/main/docs/',
           includeCurrentVersion: true,
-          lastVersion: versions.default[0],
+          lastVersion: versions[0],
           onlyIncludeVersions: includeVersions,
           versions: docsVersions,
         },

--- a/docs/package.json
+++ b/docs/package.json
@@ -41,6 +41,7 @@
     "@docusaurus/module-type-aliases": "^3.7.0",
     "@docusaurus/tsconfig": "3.7.0",
     "@docusaurus/types": "^3.7.0",
+    "@ianvs/prettier-plugin-sort-imports": "^4.4.0",
     "@types/node": "^22.10.5",
     "@types/react": "^19.0.0",
     "@types/react-helmet": "^6.1.11",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@docusaurus/types':
         specifier: ^3.7.0
         version: 3.7.0(@swc/core@1.10.4)(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@ianvs/prettier-plugin-sort-imports':
+        specifier: ^4.4.0
+        version: 4.4.0(prettier@3.4.2)
       '@types/node':
         specifier: ^22.10.5
         version: 22.10.5
@@ -1253,6 +1256,15 @@ packages:
 
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@ianvs/prettier-plugin-sort-imports@4.4.0':
+    resolution: {integrity: sha512-f4/e+/ANGk3tHuwRW0uh2YuBR50I4h1ZjGQ+5uD8sWfinHTivQsnieR5cz24t8M6Vx4rYvZ5v/IEKZhYpzQm9Q==}
+    peerDependencies:
+      '@vue/compiler-sfc': 2.7.x || 3.x
+      prettier: 2 || 3
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -5058,6 +5070,11 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prettier@3.4.2:
+    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
 
@@ -7981,7 +7998,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.0.0)':
     dependencies:
-      '@types/react': 18.3.18
+      '@types/react': 19.0.4
       react: 19.0.0
 
   '@docusaurus/theme-classic@3.7.0(@docusaurus/faster@3.7.0(@docusaurus/types@3.7.0(@swc/core@1.10.4)(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(@swc/core@1.10.4)(@types/react@19.0.4)(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
@@ -8276,6 +8293,17 @@ snapshots:
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
+
+  '@ianvs/prettier-plugin-sort-imports@4.4.0(prettier@3.4.2)':
+    dependencies:
+      '@babel/generator': 7.26.3
+      '@babel/parser': 7.26.3
+      '@babel/traverse': 7.26.4
+      '@babel/types': 7.26.3
+      prettier: 3.4.2
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -12705,6 +12733,8 @@ snapshots:
       nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prettier@3.4.2: {}
 
   pretty-error@4.0.0:
     dependencies:


### PR DESCRIPTION
Regression-of: https://github.com/woodpecker-ci/woodpecker/pull/4707

- There were some linter warnings in vscode `Property 'default' does not exist on type 'string[]'.ts(2339)` and `Type '{ current: { label: string; banner: string; }; }' is not assignable to type '{ [versionName: string]: VersionOptions; }'` which got fixed
- I also changed the `prettierrc.js` to fix 
  ```
  ["ERROR" - 18:25:47] Cannot use import statement outside a module
  ~/Devel/golang/woodpecker/woodpecker/docs/.prettierrc.js:1
  import { readFile } from 'node:fs/promises';
  ^^^^^^
  ```
- Its also required to add the plugin to the dev deps, as vscode will fail otherwise