### PR TITLE
Fix admin badge alignment

### DIFF
--- a/web/src/views/admin/AdminUsers.vue
+++ b/web/src/views/admin/AdminUsers.vue
@@ -26,7 +26,7 @@
         <IconButton
           icon="edit"
           :title="$t('admin.settings.users.edit_user')"
-          class="md:display-unset ml-auto h-8 w-8"
+          class="md:display-unset h-8 w-8"
           :class="{ 'ml-auto': !user.admin, 'ml-2': user.admin }"
           @click="editUser(user)"
         />


### PR DESCRIPTION
before:
![grafik](https://github.com/user-attachments/assets/6ae776a3-c424-49e0-9a5a-163dcf0b0133)

(now it's directly next to the icon buttons)