### PR TITLE
feat(bitbucketdatacenter.go): Add unique key to build , and add ref f…

### DIFF
--- a/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
@@ -313,8 +313,9 @@ func (c *client) Status(ctx context.Context, u *model.User, repo *model.Repo, pi
 	status := &bb.BuildStatus{
 		State:       convertStatus(pipeline.Status),
 		URL:         common.GetPipelineStatusURL(repo, pipeline, workflow),
-		Key:         common.GetPipelineStatusContext(repo, pipeline, workflow),
+		Key:         fmt.Sprintf("%s-%d", common.GetPipelineStatusContext(repo, pipeline, workflow), pipeline.Number),
 		Description: common.GetPipelineStatusDescription(pipeline.Status),
+		Ref:         pipeline.Ref,
 	}
 	_, err = bc.Projects.CreateBuildStatus(ctx, repo.Owner, repo.Name, pipeline.Commit, status)
 	return err


### PR DESCRIPTION
**Problem**
Previously, all build statuses sent to Bitbucket Datacenter shared the same key. This caused newer build statuses to overwrite earlier ones, resulting in only one build status being visible at any time.
![Screenshot From 2025-01-13 12-45-28](https://github.com/user-attachments/assets/17ab9739-e8bb-4cc6-a52a-5b885833de8f)

**Solution**
Unique Keys: Updated the key used in the build status to include the pipeline number. This ensures each build has a unique key, preventing overwrites.
Git Reference Association: Added the Git ref field to the Bitbucket request. This explicitly associates each build with the correct branch or tag in Bitbucket, improving traceability.
![Screenshot From 2025-01-13 13-39-10](https://github.com/user-attachments/assets/6e4d2d43-dc9c-429e-a478-33cb74497475)

Impact
Multiple build statuses for pipelines will now be displayed in Bitbucket, allowing users to see all relevant build information.
Enhanced association between builds and branches for better clarity and context in the development workflow.