### PR TITLE
Use mirror.gcr.io as `trivy` registry

### DIFF
--- a/.woodpecker/securityscan.yaml
+++ b/.woodpecker/securityscan.yaml
@@ -36,6 +36,6 @@ services:
     image: *trivy_plugin
     settings:
       service: true
-      db-repository: docker.io/aquasec/trivy-db:2
+      db-repository: mirror.gcr.io/aquasec/trivy-db:2
     ports:
       - 10000


### PR DESCRIPTION
https://github.com/aquasecurity/trivy/discussions/7538#discussioncomment-11258881