### PR TITLE
Add git basic changelog

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -229,6 +229,11 @@
       "name": "Microsoft Teams Notify",
       "docs": "https://raw.githubusercontent.com/GECO-IT/woodpecker-plugin-teams-notify/refs/heads/main/docs.md",
       "verified": false
-    }
+    },
+    {
+      "name": "Basic Git Changelog",
+      "docs": "https://raw.githubusercontent.com/GECO-IT/woodpecker-plugin-git-basic-changelog/refs/heads/main/docs.md",
+      "verified": false
+    }    
   ]
 }


### PR DESCRIPTION
Hi,

We wrote a basic plugin that generate a CHANGELOG.md file with all commit logs since the last TAG

You can view sources at https://github.com/GECO-IT/woodpecker-plugin-git-basic-changelog

Here is the rendering with the release plugin

![changelog_git_release](https://private-user-images.githubusercontent.com/106256831/405189130-4bb7f7b0-d581-40f7-a9b7-68dec5d105fc.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mzc0NTgyOTQsIm5iZiI6MTczNzQ1Nzk5NCwicGF0aCI6Ii8xMDYyNTY4MzEvNDA1MTg5MTMwLTRiYjdmN2IwLWQ1ODEtNDBmNy1hOWI3LTY4ZGVjNWQxMDVmYy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwMTIxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDEyMVQxMTEzMTRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0xYjMxMmM4ZGI4NjgzZDNjMDMxYTdlMmNmZTZiOWNmZjMyMmIxYzNmYzc5MWQ2MmZkNDdkYjA5NjQxMGQ1ZDg1JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.n6_kXLfQUh1fM5hc-0DMm2Ep9PrpdgC35hgEs5RWfjI)
