### PR TITLE
fix: remove lower casing from orgs

### DIFF
--- a/server/store/datastore/org.go
+++ b/server/store/datastore/org.go
@@ -28,8 +28,6 @@ func (s storage) OrgCreate(org *model.Org) error {
 }
 
 func (s storage) orgCreate(org *model.Org, sess *xorm.Session) error {
-	// sanitize
-	org.Name = strings.ToLower(org.Name)
 	if org.Name == "" {
 		return fmt.Errorf("org name is empty")
 	}
@@ -48,9 +46,6 @@ func (s storage) OrgUpdate(org *model.Org) error {
 }
 
 func (s storage) orgUpdate(sess *xorm.Session, org *model.Org) error {
-	// sanitize
-	org.Name = strings.ToLower(org.Name)
-	// update
 	_, err := sess.ID(org.ID).AllCols().Update(org)
 	return err
 }
@@ -83,10 +78,8 @@ func (s storage) OrgFindByName(name string) (*model.Org, error) {
 }
 
 func (s storage) orgFindByName(sess *xorm.Session, name string) (*model.Org, error) {
-	// sanitize
-	name = strings.ToLower(name)
 	org := new(model.Org)
-	return org, wrapGet(sess.Where("name = ?", name).Get(org))
+	return org, wrapGet(sess.Where("LOWER(name) = ?", strings.ToLower(name)).Get(org))
 }
 
 func (s storage) OrgRepoList(org *model.Org, p *model.ListOptions) ([]*model.Repo, error) {


### PR DESCRIPTION
closes #3614 

After doing some research, those are some things we found out:
- (most) forges are not case-sensitive in urls (or redirect to the configured case) => we should allow searching case insensitive
- there seems to be NO concrete reason we converted org names to lower in #1873

# Changes
- [x] remove sanitizing from org names
- [ ] add migration: fetch org names from forge(s) and update in db once