### PR TITLE
Move section description to the top

### DIFF
--- a/web/src/components/form/InputField.vue
+++ b/web/src/components/form/InputField.vue
@@ -5,10 +5,10 @@
       <DocsLink v-if="docsUrl" :topic="label" :url="docsUrl" class="ml-2" />
       <slot v-else-if="$slots.titleActions" name="titleActions" />
     </div>
-    <slot :id="id" />
-    <div v-if="$slots.description" class="ml-1 mt-1 text-wp-text-alt-100">
+    <div v-if="$slots.description" class="mb-2 text-sm text-wp-text-alt-100">
       <slot name="description" />
     </div>
+    <slot :id="id" />
   </div>
 </template>
 

--- a/web/src/views/repo/settings/General.vue
+++ b/web/src/views/repo/settings/General.vue
@@ -18,22 +18,24 @@
       </InputField>
 
       <InputField
-        v-slot="{ id }"
         :label="$t('repo.settings.general.netrc_only_trusted.netrc_only_trusted')"
         docs-url="docs/usage/project-settings#custom-trusted-clone-plugins"
       >
-        <span class="mb-2 ml-1 text-wp-text-alt-100">{{ $t('repo.settings.general.netrc_only_trusted.desc') }}</span>
-
-        <div class="flex flex-col gap-2">
-          <div v-for="image in repoSettings.netrc_trusted" :key="image" class="flex gap-2">
-            <TextField :id="id" :model-value="image" disabled />
-            <Button type="button" color="gray" start-icon="trash" @click="removeImage(image)" />
+        <template #default="{ id }">
+          <div class="flex flex-col gap-2">
+            <div v-for="image in repoSettings.netrc_trusted" :key="image" class="flex gap-2">
+              <TextField :id="id" :model-value="image" disabled />
+              <Button type="button" color="gray" start-icon="trash" @click="removeImage(image)" />
+            </div>
+            <div class="flex gap-2">
+              <TextField :id="id" v-model="newImage" @keydown.enter.prevent="addNewImage" />
+              <Button type="button" color="gray" start-icon="plus" @click="addNewImage" />
+            </div>
           </div>
-          <div class="flex gap-2">
-            <TextField :id="id" v-model="newImage" @keydown.enter.prevent="addNewImage" />
-            <Button type="button" color="gray" start-icon="plus" @click="addNewImage" />
-          </div>
-        </div>
+        </template>
+        <template #description>
+          {{ $t('repo.settings.general.netrc_only_trusted.desc') }}
+        </template>
       </InputField>
 
       <InputField
@@ -82,9 +84,7 @@
           ]"
         />
         <template #description>
-          <p class="text-sm">
-            {{ $t('require_approval.desc') }}
-          </p>
+          {{ $t('require_approval.desc') }}
         </template>
       </InputField>
 
@@ -114,13 +114,15 @@
             :placeholder="$t('repo.settings.general.pipeline_path.default')"
           />
         </template>
+
+        <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
         <template #description>
-          <i18n-t keypath="repo.settings.general.pipeline_path.desc" tag="p" class="text-sm text-wp-text-alt-100">
+          <i18n-t keypath="repo.settings.general.pipeline_path.desc">
             <span class="code-box-inline">{{ $t('repo.settings.general.pipeline_path.desc_path_example') }}</span>
-            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
             <span class="code-box-inline">/</span>
           </i18n-t>
         </template>
+        <!-- eslint-enable @intlify/vue-i18n/no-raw-text -->
       </InputField>
 
       <InputField
@@ -132,9 +134,7 @@
           :options="cancelPreviousPipelineEventsOptions"
         />
         <template #description>
-          <p class="text-sm">
-            {{ $t('repo.settings.general.cancel_prev.desc') }}
-          </p>
+          {{ $t('repo.settings.general.cancel_prev.desc') }}
         </template>
       </InputField>
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -83,6 +83,7 @@ export default defineConfig({
   },
   logLevel: 'warn',
   server: {
+    allowedHosts: true,
     host: process.env.VITE_DEV_SERVER_HOST ?? '127.0.0.1',
     port: 8010,
   },


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/f5fe3d98-d712-4ed1-84e1-bd1b8b98c11e)

After:
![image](https://github.com/user-attachments/assets/683c231a-4fe6-4fe0-9ca3-130f3ac01ff2)


Other changes:

`allowedHosts: true,`: The dev server now requires setting allowed hosts, otherwise an error is shown. As we use it only for local dev, just allow all.