### PR TITLE
Add a Home Assistant notification plugin 

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -239,6 +239,11 @@
       "name": "Basic Git Changelog",
       "docs": "https://raw.githubusercontent.com/GECO-IT/woodpecker-plugin-git-basic-changelog/refs/heads/main/docs.md",
       "verified": false
+    },
+    {
+      "name": "Home Assistant Notify",
+      "docs": "https://raw.githubusercontent.com/DHandspikerWade/woodpecker-plugin-ha-notify/refs/heads/main/docs.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
Created a plugin to send notifications to Home Assistant, a popular home automation platform. The notifications can be used to trigger home automatons or be passed on to other integrations  into the platform. 

**Plugin source**: https://github.com/DHandspikerWade/woodpecker-plugin-ha-notify
**Platform receiving notifications:** https://www.home-assistant.io/integrations/notify/

