### PR TITLE
docs: remove latest from docker compose example

### DIFF
--- a/docs/docs/30-administration/05-deployment-methods/10-docker-compose.md
+++ b/docs/docs/30-administration/05-deployment-methods/10-docker-compose.md
@@ -7,7 +7,7 @@ It relies on a number of environment variables that you must set before running 
 ```yaml title="docker-compose.yaml"
 services:
   woodpecker-server:
-    image: woodpeckerci/woodpecker-server:latest
+    image: woodpeckerci/woodpecker-server:v3
     ports:
       - 8000:8000
     volumes:
@@ -21,7 +21,7 @@ services:
       - WOODPECKER_AGENT_SECRET=${WOODPECKER_AGENT_SECRET}
 
   woodpecker-agent:
-    image: woodpeckerci/woodpecker-agent:latest
+    image: woodpeckerci/woodpecker-agent:v3
     command: agent
     restart: always
     depends_on:

--- a/docs/versioned_docs/version-3.0/30-administration/05-deployment-methods/10-docker-compose.md
+++ b/docs/versioned_docs/version-3.0/30-administration/05-deployment-methods/10-docker-compose.md
@@ -7,7 +7,7 @@ It relies on a number of environment variables that you must set before running 
 ```yaml title="docker-compose.yaml"
 services:
   woodpecker-server:
-    image: woodpeckerci/woodpecker-server:latest
+    image: woodpeckerci/woodpecker-server:v3
     ports:
       - 8000:8000
     volumes:
@@ -21,7 +21,7 @@ services:
       - WOODPECKER_AGENT_SECRET=${WOODPECKER_AGENT_SECRET}
 
   woodpecker-agent:
-    image: woodpeckerci/woodpecker-agent:latest
+    image: woodpeckerci/woodpecker-agent:v3
     command: agent
     restart: always
     depends_on:


### PR DESCRIPTION
As `latest` is no longer supported for v3, it should not be in the v3 documentation for the example docker compose config file.

Closes #4835
