### PR TITLE
Docs improvements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,15 @@ This website is built using [Docusaurus 3](https://docusaurus.io/), a modern sta
 pnpm install
 ```
 
+## Before your first build
+Before running `build` or `start` commands for the first time, you need to build plugins in docs/plugins/woodpecker-plugins:
+
+```bash
+cd docs/plugins/woodpecker-plugins
+pnpm build
+```
+
+## Build
 ## Local Development
 
 ```bash
@@ -15,8 +24,6 @@ pnpm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-## Build
 
 ```bash
 pnpm build

--- a/docs/docs/30-administration/22-backends/20-local.md
+++ b/docs/docs/30-administration/22-backends/20-local.md
@@ -29,7 +29,7 @@ In order to use this backend, you need to download (or build) the
 
 ## Usage
 
-To enable the local backend, set the following:
+To enable the local backend, set the following as an agent environment variable:
 
 ```ini
 WOODPECKER_BACKEND=local

--- a/docs/docs/30-administration/22-backends/20-local.md
+++ b/docs/docs/30-administration/22-backends/20-local.md
@@ -27,12 +27,33 @@ code and execute commands.
 In order to use this backend, you need to download (or build) the
 [agent](https://github.com/woodpecker-ci/woodpecker/releases/latest), configure it and run it on the host machine.
 
+## Installation
+
+Installation is possible as a build from source or pre-build packages available on the [woodpecker GitHub release page](https://github.com/woodpecker-ci/woodpecker/releases/latest).
+
+Once installed (e.g. via `dpkg -i ...`) it will add a systemd service called `woodpecker-agent`.
+
+You may  need to tune up that service config by for example adjusting the user it runs as.
+
+Additionally, you must set up the [environment variables](../15-agent-config.md) for the agent in the environment referenced by the systemd service (e.g. `/etc/woodpecker/woodpecker-agent.env`).
+
 ## Usage
 
 To enable the local backend, set the following as an agent environment variable:
 
 ```ini
 WOODPECKER_BACKEND=local
+```
+
+For more configuration options, see the [Agent  configuration](../15-agent-config.md) page.
+
+Once the agent is running, you can ensure your pipeline only is being used by that kind of agent by using proper [labels](../../20-usage/20-workflow-syntax.md#labels) configuration.
+
+e.g:
+
+```yaml
+labels:
+    backend: local
 ```
 
 ### Shell


### PR DESCRIPTION
As signalled over Matrix I prepared some docs changes that I believe would make me less confused during my initial setups where I wanted to have two agents: docker and local and pick the proper one per pipeline jobs.

On top added some references here and there in places where I felt confused as well, while not being that experienced with linux installation process and systemd setups.

Thanks again for help yesterday!