### PR TITLE
Fix approval requirement if PR is closed

### DIFF
--- a/server/pipeline/gated.go
+++ b/server/pipeline/gated.go
@@ -48,13 +48,13 @@ func needsApproval(repo *model.Repo, pipeline *model.Pipeline) bool {
 
 	// repository requires approval for pull requests from forks
 	case model.RequireApprovalForks:
-		if pipeline.Event == model.EventPull && pipeline.FromFork {
+		if (pipeline.Event == model.EventPull || pipeline.Event == model.EventPullClosed) && pipeline.FromFork {
 			return true
 		}
 
 	// repository requires approval for pull requests
 	case model.RequireApprovalPullRequests:
-		if pipeline.Event == model.EventPull {
+		if pipeline.Event == model.EventPull || pipeline.Event == model.EventPullClosed {
 			return true
 		}
 


### PR DESCRIPTION
It is easily possible currently to go around the approval requirement for PRs, you can see that at https://ci.woodpecker-ci.org/repos/3780/pipeline/25684: If the PR is closed the config from the PR is used, but it does not need an approval.

This should be released right after merging in 3.2 I think…

But tbh I'm not really happy with the fix, as it will also need approval for merged pull requests. We don't have a way to indicate that currently though.