### PR TITLE
BitbucketDC: optimize repository search

### DIFF
--- a/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
@@ -163,7 +163,7 @@ func (c *client) Repo(ctx context.Context, u *model.User, rID model.ForgeRemoteI
 
 	var repo *bb.Repository
 	if rID.IsValid() {
-		opts := &bb.RepositorySearchOptions{Permission: bb.PermissionRepoWrite, ListOptions: bb.ListOptions{Limit: listLimit}}
+		opts := &bb.RepositorySearchOptions{Name: name, ProjectKey: owner, Permission: bb.PermissionRepoWrite, ListOptions: bb.ListOptions{Limit: listLimit}}
 		for {
 			repos, resp, err := bc.Projects.SearchRepositories(ctx, opts)
 			if err != nil {


### PR DESCRIPTION
## Optimize Repository Search in Woodpecker for Bitbucket Data Center  

### Problem Statement  
I am working with **Woodpecker** and **Bitbucket Data Center**, which contains **5,000 repositories**. I noticed that after some time, clicking on a repository in Woodpecker takes **30 seconds** to load the page.  

Upon further inspection, I found that **after one hour**, Woodpecker checks repository permissions using the `Repo` function [reference link](https://github.com/woodpecker-ci/woodpecker/blob/main/server/router/middleware/session/repo.go#L125). However, in **Bitbucket Data Center**, this function **fetches all repositories unnecessarily**. Even after finding the target repository, it continues fetching results until the **end of the paginated request**, which causes unnecessary delay.  

### Solution  
This pull request optimizes the repository search by **limiting the search scope** to only:  
- **The repository name**  
- **The project (owner)**  

With this change, the function will return **only one repository instead of 5,000**, significantly improving performance.  
