### PR TITLE
Fix unique constraint for orgs

### DIFF
--- a/server/model/org.go
+++ b/server/model/org.go
@@ -17,8 +17,8 @@ package model
 // Org represents an organization.
 type Org struct {
 	ID      int64  `json:"id,omitempty"       xorm:"pk autoincr 'id'"`
-	ForgeID int64  `json:"forge_id,omitempty" xorm:"forge_id"`
-	Name    string `json:"name"               xorm:"UNIQUE 'name'"`
+	ForgeID int64  `json:"forge_id,omitempty" xorm:"forge_id UNIQUE(s)"`
+	Name    string `json:"name"               xorm:"'name' UNIQUE(s)"`
 	IsUser  bool   `json:"is_user"            xorm:"is_user"`
 	// if name lookup has to check for membership or not
 	Private bool `json:"-"                    xorm:"private"`


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/4918

In https://github.com/woodpecker-ci/woodpecker/pull/4817 we changed the org lookup from `name="name"` to `name="name AND forge_id="forgeid"` (https://github.com/woodpecker-ci/woodpecker/pull/4817/files#diff-eb104e63f04fbe20f88199ac5e15aa7164690f990773a43cedb458c083b16260R84) while the unique constraint was still `"UQE_orgs_name" UNIQUE, btree (name)`.

With this change, the constrained was changes to `"UQE_orgs_s" UNIQUE, btree (forge_id, name)`