### PR TITLE
Fix dockerhub links in docs

### DIFF
--- a/docs/docs/30-administration/00-general.md
+++ b/docs/docs/30-administration/00-general.md
@@ -37,7 +37,7 @@ No `latest` tag exists to prevent accidental major version upgrades. Either use 
 
 Images are pushed to DockerHub and Quay.
 
-- woodpecker-server ([DockerHub](https://hub.docker.com/repository/docker/woodpeckerci/woodpecker-server) or [Quay](https://quay.io/repository/woodpeckerci/woodpecker-server))
-- woodpecker-agent ([DockerHub](https://hub.docker.com/repository/docker/woodpeckerci/woodpecker-agent) or [Quay](https://quay.io/repository/woodpeckerci/woodpecker-agent))
-- woodpecker-cli ([DockerHub](https://hub.docker.com/repository/docker/woodpeckerci/woodpecker-cli) or [Quay](https://quay.io/repository/woodpeckerci/woodpecker-cli))
-- woodpecker-autoscaler ([DockerHub](https://hub.docker.com/repository/docker/woodpeckerci/autoscaler))
+- woodpecker-server ([DockerHub](https://hub.docker.com/r/woodpeckerci/woodpecker-server) or [Quay](https://quay.io/repository/woodpeckerci/woodpecker-server))
+- woodpecker-agent ([DockerHub](https://hub.docker.com/r/woodpeckerci/woodpecker-agent) or [Quay](https://quay.io/repository/woodpeckerci/woodpecker-agent))
+- woodpecker-cli ([DockerHub](https://hub.docker.com/r/woodpeckerci/woodpecker-cli) or [Quay](https://quay.io/repository/woodpeckerci/woodpecker-cli))
+- woodpecker-autoscaler ([DockerHub](https://hub.docker.com/r/woodpeckerci/autoscaler))

--- a/docs/versioned_docs/version-3.0/30-administration/04-image-variants.md
+++ b/docs/versioned_docs/version-3.0/30-administration/04-image-variants.md
@@ -18,13 +18,13 @@ This was done to prevent accidental major version upgrades.
 
 Images are pushed to DockerHub and Quay.
 
-[woodpecker-server (DockerHub)](https://hub.docker.com/repository/docker/woodpeckerci/woodpecker-server)
+[woodpecker-server (DockerHub)](https://hub.docker.com/r/woodpeckerci/woodpecker-server)
 [woodpecker-server (Quay)](https://quay.io/repository/woodpeckerci/woodpecker-server)
 
-[woodpecker-agent (DockerHub)](https://hub.docker.com/repository/docker/woodpeckerci/woodpecker-agent)
+[woodpecker-agent (DockerHub)](https://hub.docker.com/r/woodpeckerci/woodpecker-agent)
 [woodpecker-agent (Quay)](https://quay.io/repository/woodpeckerci/woodpecker-agent)
 
-[woodpecker-cli (DockerHub)](https://hub.docker.com/repository/docker/woodpeckerci/woodpecker-cli)
+[woodpecker-cli (DockerHub)](https://hub.docker.com/r/woodpeckerci/woodpecker-cli)
 [woodpecker-cli (Quay)](https://quay.io/repository/woodpeckerci/woodpecker-cli)
 
-[woodpecker-autoscaler (DockerHub)](https://hub.docker.com/repository/docker/woodpeckerci/autoscaler)
+[woodpecker-autoscaler (DockerHub)](https://hub.docker.com/r/woodpeckerci/autoscaler)


### PR DESCRIPTION
Resolves link checker issues from https://github.com/woodpecker-ci/woodpecker/issues/4514