### PR TITLE
Fix fs owner in scratch-based container images

### DIFF
--- a/docker/Dockerfile.agent.multiarch
+++ b/docker/Dockerfile.agent.multiarch
@@ -2,8 +2,7 @@ FROM --platform=$BUILDPLATFORM docker.io/golang:1.24 AS build
 
 RUN groupadd -g 1000 woodpecker && \
   useradd -u 1000 -g 1000 woodpecker && \
-  mkdir -p /etc/woodpecker && \
-  chown -R woodpecker:woodpecker /etc/woodpecker
+  mkdir -p /etc/woodpecker
 
 WORKDIR /src
 COPY . .
@@ -22,7 +21,7 @@ EXPOSE 3000
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 # copy agent binary
 COPY --from=build /src/dist/woodpecker-agent /bin/
-COPY --from=build /etc/woodpecker /etc
+COPY --from=build --chown=woodpecker:woodpecker /etc/woodpecker /etc
 COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /etc/group /etc/group
 

--- a/docker/Dockerfile.server.multiarch.rootless
+++ b/docker/Dockerfile.server.multiarch.rootless
@@ -2,8 +2,7 @@ FROM --platform=$BUILDPLATFORM docker.io/golang:1.24 AS build
 
 RUN groupadd -g 1000 woodpecker && \
   useradd -u 1000 -g 1000 woodpecker && \
-  mkdir -p /var/lib/woodpecker && \
-  chown -R woodpecker:woodpecker /var/lib/woodpecker
+  mkdir -p /var/lib/woodpecker
 
 FROM scratch
 ARG TARGETOS TARGETARCH
@@ -20,7 +19,7 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY dist/server/${TARGETOS}_${TARGETARCH}/woodpecker-server /bin/
 COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /etc/group /etc/group
-COPY --from=build /var/lib/woodpecker /var/lib/woodpecker
+COPY --from=build --chown=woodpecker:woodpecker /var/lib/woodpecker /var/lib/woodpecker
 
 USER woodpecker
 


### PR DESCRIPTION
The ownership is not preserved by the `COPY` action to the final image, use `--chown` option instead. 

```
❯ docker compose -f .local/docker-compose-debug.yaml up --remove-orphans 
[+] Running 3/3
 ✔ Network local_default                      Created                                                                                                                                    0.2s 
 ✔ Volume "local_woodpecker-server-fresh"     Created                                                                                                                                    0.0s 
 ✔ Container local-woodpecker-server-fresh-1  Created                                                                                                                                    0.0s 
Attaching to woodpecker-server-fresh-1
woodpecker-server-fresh-1  | {"level":"info","time":"2025-03-15T15:35:22Z","message":"log level: info"}
woodpecker-server-fresh-1  | {"level":"warn","time":"2025-03-15T15:35:22Z","message":"WOODPECKER_HOST should probably be publicly accessible (not localhost)"}
woodpecker-server-fresh-1  | {"level":"warn","time":"2025-03-15T15:35:22Z","message":"no sqlite3 file found, will create one at '/var/lib/woodpecker/woodpecker.sqlite'"}
woodpecker-server-fresh-1  | {"level":"info","time":"2025-03-15T15:35:22Z","message":"Initializing Schema"}
```

```
❯ sudo ls -lnd /var/lib/docker/volumes/local_woodpecker-server-fresh/_data
drwxr-xr-x. 2 1000 1000 31 15. Mär 16:35 /var/lib/docker/volumes/local_woodpecker-server-fresh/_data
```

Fixes: https://github.com/woodpecker-ci/woodpecker/issues/4939