### PR TITLE
Add backoff retry for store setup

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -56,6 +56,12 @@ var flags = append([]cli.Flag{
 		Usage:   "time an active connection is allowed to stay open",
 		Value:   3 * time.Second,
 	},
+	&cli.UintFlag{
+		Sources: cli.EnvVars("WOODPECKER_DATABASE_MAX_RETRIES"),
+		Name:    "db-max-retries",
+		Usage:   "max number of retries for the initial connection to the database",
+		Value:   10,
+	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_HOST"),
 		Name:    "server-host",

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -90,6 +90,10 @@ func setupStore(ctx context.Context, c *cli.Command) (store.Store, error) {
 		return nil, fmt.Errorf("could not open datastore: %w", err)
 	}
 
+	if err = store.Ping(); err != nil {
+		return nil, err
+	}
+
 	if err := store.Migrate(ctx, c.Bool("migrations-allow-long")); err != nil {
 		return nil, fmt.Errorf("could not migrate datastore: %w", err)
 	}


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/4955

```
❯ docker logs woodpecker-server -f
{"level":"info","time":"2025-03-16T11:37:01Z","message":"log level: info"}
{"level":"error","time":"2025-03-16T11:37:01Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 617.502915ms"}
{"level":"error","time":"2025-03-16T11:37:02Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 543.863548ms"}
{"level":"error","time":"2025-03-16T11:37:02Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 1.398296807s"}
{"level":"error","time":"2025-03-16T11:37:04Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 1.621304796s"}
{"level":"error","time":"2025-03-16T11:37:05Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 2.739287547s"}
{"level":"error","time":"2025-03-16T11:37:08Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 5.42803212s"}
{"level":"error","time":"2025-03-16T11:37:13Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 2.966691952s"}
{"level":"error","time":"2025-03-16T11:37:16Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 7.595004488s"}
{"level":"error","time":"2025-03-16T11:37:24Z","message":"failed to setup store: dial tcp 172.18.0.3:5432: connect: connection refused: retry in 14.908888363s"}
{"level":"error","error":"dial tcp 172.18.0.3:5432: connect: connection refused","time":"2025-03-16T11:37:39Z","message":"error running server"}
```