### PR TITLE
Dont center items in more menu

### DIFF
--- a/web/src/components/layout/scaffold/Tabs.vue
+++ b/web/src/components/layout/scaffold/Tabs.vue
@@ -35,7 +35,7 @@
           @click="isDropdownOpen = false"
         >
           <span
-            class="hover:bg-wp-background-200 dark:hover:bg-wp-background-100 flex w-full min-w-20 flex-row items-center justify-center gap-2 rounded-md px-2 py-1"
+            class="hover:bg-wp-background-200 dark:hover:bg-wp-background-100 flex w-full min-w-20 flex-row gap-2 rounded-md px-2 py-1"
           >
             <Icon v-if="tab.icon" :name="tab.icon" :class="tab.iconClass" class="shrink-0" />
             <span>{{ tab.title }}</span>


### PR DESCRIPTION
Centering items in the "More" menu for tabs just looks weird after adding icons.

Before:
![image](https://github.com/user-attachments/assets/1b4c210e-b0ee-4f93-a707-2abcfd25fb57)

After:
![image](https://github.com/user-attachments/assets/b873be32-1e11-47fa-b9ed-fbbcd5d11556)
