### PR TITLE
Fix exclude path constraint behavior

### DIFF
--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -388,14 +388,19 @@ func (c *Path) Includes(v []string) bool {
 	return false
 }
 
-// Excludes returns true if the string matches any of the exclude patterns.
+// Excludes returns true if all of the strings match any of the exclude patterns.
 func (c *Path) Excludes(v []string) bool {
-	for _, pattern := range c.Exclude {
-		for _, file := range v {
+	for _, file := range v {
+		matched := false
+		for _, pattern := range c.Exclude {
 			if ok, _ := doublestar.Match(pattern, file); ok {
-				return true
+				matched = true
+				break
 			}
 		}
+		if !matched {
+			return false
+		}
 	}
-	return false
+	return true
 }

--- a/pipeline/frontend/yaml/constraint/constraint_test.go
+++ b/pipeline/frontend/yaml/constraint/constraint_test.go
@@ -233,7 +233,22 @@ func TestConstraintList(t *testing.T) {
 		{
 			conf: "{ include: [ '*.md' ], exclude: [ CHANGELOG.md ] }",
 			with: []string{"README.md", "CHANGELOG.md"},
+			want: true,
+		},
+		{
+			conf: "{ exclude: [ CHANGELOG.md ] }",
+			with: []string{"README.md", "CHANGELOG.md"},
+			want: true,
+		},
+		{
+			conf: "{ exclude: [ CHANGELOG.md, docs/**/*.md ] }",
+			with: []string{"docs/main.md", "CHANGELOG.md"},
 			want: false,
+		},
+		{
+			conf: "{ exclude: [ CHANGELOG.md, docs/**/*.md ] }",
+			with: []string{"docs/main.md", "CHANGELOG.md", "README.md"},
+			want: true,
 		},
 		// commit message ignore matches
 		{


### PR DESCRIPTION
When an exclude pattern is present, only skip a workflow or step if all of the changed files match at least one the exclude patterns.

Fixes: https://github.com/woodpecker-ci/woodpecker/issues/5041