### PR TITLE
add nushell support to local backend

### DIFF
--- a/pipeline/backend/local/command.go
+++ b/pipeline/backend/local/command.go
@@ -54,6 +54,8 @@ func (e *local) genCmdByShell(shell string, cmdList []string) (args []string, er
 			script += fmt.Sprintf("echo %s\n%s || exit $status\n", strings.TrimSpace(shellescape.Quote("+ "+cmd)), cmd)
 		}
 		return []string{"-c", script}, nil
+	case "nu":
+		return []string{"--commands", script}, nil
 	case "powershell", "pwsh":
 		// cspell:disable-next-line
 		return []string{"-noprofile", "-noninteractive", "-c", "$ErrorActionPreference = \"Stop\"; " + script}, nil


### PR DESCRIPTION
Previously the default case would fail because nushell doesn't support `nu -e -c $script`.
Nushell flag docs: https://www.nushell.sh/book/configuration.html#flag-behavior

![image](https://github.com/user-attachments/assets/04846a1f-e048-402b-962b-611e99c0b9f1)
