### PR TITLE
Revert "Use existing WorkingDir for clone steps (#5023)"

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -56,6 +56,8 @@ MD013:
   tables: false
   # Include headings
   headings: true
+  # Include headings
+  headers: true
   # Strict length checking
   strict: false
   # Stern length checking
@@ -71,7 +73,7 @@ MD022:
 # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD024:
   # Only check sibling headings
-  siblings_only: true
+  allow_different_nesting: true
 
 # MD025/single-title/single-h1 - Multiple top-level headings in the same document
 MD025:

--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -646,13 +646,9 @@ For more details and examples check the [Advanced usage docs](./90-advanced-usag
 
 ## `clone`
 
-Woodpecker automatically configures a default clone step if it is not explicitly defined. If you are using the `local` backend, the [plugin-git](https://github.com/woodpecker-ci/plugin-git) binary must be in your `$PATH` for the default clone step to work. If this is not the case, you can still write a manual clone step.
+Woodpecker automatically configures a default clone step if not explicitly defined. When using the `local` backend, the [plugin-git](https://github.com/woodpecker-ci/plugin-git) binary must be on your `$PATH` for the default clone step to work. If not, you can still write a manual clone step.
 
-:::info
-Clone step containers use `/woodpecker` as the working directory. It is recommended that clone plugins do not rely on the working directory and use absolute paths instead.
-:::
-
-You can manually configure the clone step in your workflow to customize it:
+You can manually configure the clone step in your workflow for customization:
 
 ```diff
 +clone:
@@ -667,7 +663,7 @@ You can manually configure the clone step in your workflow to customize it:
        - go test
 ```
 
-Example configuration to override the depth:
+Example configuration to override depth:
 
 ```diff
  clone:
@@ -688,7 +684,7 @@ Example configuration to use a custom clone plugin:
 
 ### Git Submodules
 
-To use the credentials used to clone the repository to clone its submodules, update `.gitmodules` to use `https` instead of `git`:
+To use the credentials that cloned the repository to clone it's submodules, update `.gitmodules` to use `https` instead of `git`:
 
 ```diff
  [submodule "my-module"]
@@ -713,10 +709,6 @@ steps:
 ```
 
 ## `skip_clone`
-
-:::warning
-The default clone step is executed as `root` to ensure that the workspace directory can be accessed by any user (`0777`). This is necessary to allow rootless step containers to write to the workspace directory. If a rootless step container is used with `skip_clone`, the user must ensure a suitable workspace directory that can be accessed by the unprivileged container use, e.g. `/tmp`.
-:::
 
 By default Woodpecker is automatically adding a clone step. This clone step can be configured by the [clone](#clone) property. If you do not need a `clone` step at all you can skip it using:
 

--- a/docs/src/pages/migrations.md
+++ b/docs/src/pages/migrations.md
@@ -4,14 +4,6 @@ To enhance the usability of Woodpecker and meet evolving security standards, occ
 
 ## `next`
 
-### User-facing migrations
-
-#### Clone plugin working directory
-
-- Clone plugins now use `/woodpecker` as working directory instead of `/woodpecker/<workspacePath>/<directory>`. If you use the default clone plugin, you do not need to make any changes. If you use a custom clone plugin, please ensure the plugin uses absolute paths and don't rely on the working directory.
-
-#### Miscellaneous
-
 - (Kubernetes) Deprecated `step` label on pod in favor of new namespaced label `woodpecker-ci.org/step`. The `step` label will be removed in a future update.
 
 ## 3.0.0

--- a/pipeline/frontend/yaml/compiler/compiler_test.go
+++ b/pipeline/frontend/yaml/compiler/compiler_test.go
@@ -96,7 +96,7 @@ func TestCompilerCompile(t *testing.T) {
 			OnSuccess:     true,
 			Failure:       "fail",
 			Volumes:       []string{defaultVolume.Name + ":/woodpecker"},
-			WorkingDir:    "/woodpecker",
+			WorkingDir:    "/woodpecker/src/github.com/octocat/hello-world",
 			WorkspaceBase: "/woodpecker",
 			Networks:      []backend_types.Conn{{Name: "test_default", Aliases: []string{"clone"}}},
 			ExtraHosts:    []backend_types.HostAlias{},

--- a/pipeline/frontend/yaml/compiler/convert.go
+++ b/pipeline/frontend/yaml/compiler/convert.go
@@ -96,7 +96,7 @@ func (c *Compiler) createProcess(container *yaml_types.Container, workflow *yaml
 		detached = true
 	}
 
-	workingDir = c.stepWorkingDir(container, stepType)
+	workingDir = c.stepWorkingDir(container)
 
 	getSecretValue := func(name string) (string, error) {
 		name = strings.ToLower(name)
@@ -185,16 +185,13 @@ func (c *Compiler) createProcess(container *yaml_types.Container, workflow *yaml
 	}, nil
 }
 
-func (c *Compiler) stepWorkingDir(container *yaml_types.Container, stepType backend_types.StepType) string {
+func (c *Compiler) stepWorkingDir(container *yaml_types.Container) string {
 	if path.IsAbs(container.Directory) {
 		return container.Directory
 	}
 	base := c.workspaceBase
 	if container.IsPlugin() {
 		base = pluginWorkspaceBase
-	}
-	if stepType == backend_types.StepTypeClone {
-		return base
 	}
 	return path.Join(base, c.workspacePath, container.Directory)
 }


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/5045

I don't see an easy way to fix that. We could split `CI_WORKSPACE` and `PLUGIN_PATH` on the clone plugin and ensure we manually `chdir` to `CI_WORKSPACE` as first action to simulate the original `WorkingDir` behavior, but this feels kinda hacky as well and would require changes on all custom clone plugins as well.