### PR TITLE
BitbucketDC: add event pull request opened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "woodpecker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "woodpecker",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
@@ -423,7 +423,7 @@ func (c *client) Activate(ctx context.Context, u *model.User, r *model.Repo, lin
 	webhook := &bb.Webhook{
 		Name:   "Woodpecker",
 		URL:    link,
-		Events: []bb.EventKey{bb.EventKeyRepoRefsChanged, bb.EventKeyPullRequestFrom, bb.EventKeyPullRequestMerged, bb.EventKeyPullRequestDeclined, bb.EventKeyPullRequestDeleted},
+		Events: []bb.EventKey{bb.EventKeyRepoRefsChanged, bb.EventKeyPullRequestFrom, bb.EventKeyPullRequestMerged, bb.EventKeyPullRequestDeclined, bb.EventKeyPullRequestDeleted, bb.EventKeyPullRequestOpened},
 		Active: true,
 		Config: &bb.WebhookConfiguration{
 			Secret: r.Hash,


### PR DESCRIPTION
# Fix: Trigger `pull_request` Event on Pull Request Opened

## Issue  
In Bitbucket Data Center, the `pull_request` event is not triggered when a pull request is opened because the **"pull request opened"** event is missing from webhooks.  
As a result, our developers currently have to push an additional commit after opening a pull request just to trigger the event.  

This behavior differs from **Bitbucket Cloud**, where the event is triggered upon pull request creation.  
**Reference:** [Bitbucket implementation in Woodpecker CI](https://github.com/woodpecker-ci/woodpecker/blob/main/server/forge/bitbucket/bitbucket.go#L316C34-L316C45).  

I tested this change in my **home lab**, and it now works as expected.  

