### PR TITLE
Fix cli format flag fallback

### DIFF
--- a/cli/repo/repo.go
+++ b/cli/repo/repo.go
@@ -58,7 +58,7 @@ func repoOutput(c *cli.Command, repos []*woodpecker.Repo, fd ...io.Writer) error
 		log.Warn().Msgf("the --format flag is deprecated, please use --output instead")
 
 		outFmt = "go-template"
-		outOpt = []string{legacyFmt}
+		outOpt = []string{fmt.Sprintf("{{range . }}%s{{ print \"\\n\" }}{{end}}", legacyFmt)}
 	}
 
 	var out io.Writer


### PR DESCRIPTION
While `repo ls --format` flag is deprecated, we added fallback code to not break it. However, the fallback was not working properly as the `--format` template was evaluated per item in slice while ` --output` is not.

This PR ensures the `--format` fallback wraps the given template in a range loop.

Now using the format flag is working again:

```
❯ ../../golang/woodpecker/woodpecker/dist/woodpecker-cli repo ls --format="{{ .FullName }} {{ .Name }}"
11:09PM WRN the --format flag is deprecated, please use --output instead
woodpecker-ci/foo foo
test/repo repo

```