### PR TITLE
fix(server/router/api.go): org member permissions to org secrets

### DIFF
--- a/server/router/api.go
+++ b/server/router/api.go
@@ -60,10 +60,10 @@ func apiRoutes(e *gin.RouterGroup) {
 
 				org := orgBase.Group("")
 				{
+					org.GET("/secrets", session.MustOrgMember(false), api.GetOrgSecretList)
 					org.Use(session.MustOrgMember(true))
 					org.DELETE("", session.MustAdmin(), api.DeleteOrg)
 
-					org.GET("/secrets", api.GetOrgSecretList)
 					org.POST("/secrets", api.PostOrgSecret)
 					org.GET("/secrets/:secret", api.GetOrgSecret)
 					org.PATCH("/secrets/:secret", api.PatchOrgSecret)


### PR DESCRIPTION
## Fix: Organization Members Cannot View Organization Secrets (#4543)

## Issue
Organization members(not org admin) with repository write access cannot view global secrets and organization secrets in the repository settings page. They receive an error when trying to access organization secrets, despite having the necessary permissions to use them.

## Steps to Reproduce
1. Create a global secret and an organization secret
2. Log in as an organization member (not admin)
3. Go to one of the organization repo's settings and then secrets

### Expected Behavior
As a repository writer and organization member, you should see:
1. Repository secrets
2. Organization secrets
3. Global secrets

### Actual Behavior
Only repository secrets are visible, and the following error appears:

![Error when accessing secrets](https://github.com/user-attachments/assets/1323dd5b-20fc-4fc9-95a9-ab20d672ec72)

## Root Cause
Upon investigation, the error comes from `/api/orgs/{number}/secrets`:

![API error trace](https://github.com/user-attachments/assets/815324ea-1401-4a1e-9735-c928879fbd01)

In the `api.go` file, the route `/secrets` can only be accessed by organization admins due to the middleware:
```go
org.Use(session.MustOrgMember(true))
```

However, organization members should be able to view (but not modify) organization secrets they can use in their repositories.

## Solution
Move the GET endpoint for `/secrets` before the admin middleware and limit it to organization members (not requiring admin status).

## Code Changes
```diff
org := orgBase.Group("")
{
+	org.GET("/secrets", session.MustOrgMember(false), api.GetOrgSecretList)
	org.Use(session.MustOrgMember(true))
	org.DELETE("", session.MustAdmin(), api.DeleteOrg)
-	org.GET("/secrets", api.GetOrgSecretList)
	org.POST("/secrets", api.PostOrgSecret)
	org.GET("/secrets/:secret", api.GetOrgSecret)
	org.PATCH("/secrets/:secret", api.PatchOrgSecret)
```

## Result
After applying this change, organization members can now see all secrets they have access to:

![Fixed view showing all accessible secrets](https://github.com/user-attachments/assets/d421a724-a9f9-46b9-914f-407284a4bc94)