### PR TITLE
Add missing icon for changes files tab

### DIFF
--- a/web/src/components/atomic/Icon.vue
+++ b/web/src/components/atomic/Icon.vue
@@ -58,9 +58,10 @@
   <SvgIcon v-else-if="name === 'play'" :path="mdiPlay" size="1.3rem" />
   <SvgIcon v-else-if="name === 'play-outline'" :path="mdiPlayOutline" size="1.3rem" />
   <SvgIcon v-else-if="name === 'dots'" :path="mdiDotsVertical" size="1.3rem" />
-  <SvgIcon v-else-if="name === 'tray-full'" :path="mdiTrayFull" size="24" />
-  <SvgIcon v-else-if="name === 'file-cog-outlined'" :path="mdiFileCogOutline" size="24" />
-  <SvgIcon v-else-if="name === 'bug-outline'" :path="mdiBugOutline" size="24" />
+  <SvgIcon v-else-if="name === 'tray-full'" :path="mdiTrayFull" size="1.3rem" />
+  <SvgIcon v-else-if="name === 'file-cog-outline'" :path="mdiFileCogOutline" size="1.3rem" />
+  <SvgIcon v-else-if="name === 'file-edit-outline'" :path="mdiFileEditOutline" size="1.3rem" />
+  <SvgIcon v-else-if="name === 'bug-outline'" :path="mdiBugOutline" size="1.3rem" />
   <SvgIcon v-else-if="name === 'docker'" :path="mdiDocker" size="1.3rem" />
 
   <SvgIcon v-else-if="name === 'visibility-private'" :path="mdiLockOutline" size="1.3rem" />
@@ -118,6 +119,7 @@ import {
   mdiEyeOffOutline,
   mdiEyeOutline,
   mdiFileCogOutline,
+  mdiFileEditOutline,
   mdiFormatListBulleted,
   mdiFormatListGroup,
   mdiGestureTap,
@@ -211,7 +213,8 @@ export type IconNames =
   | 'visibility-internal'
   | 'dots'
   | 'tray-full'
-  | 'file-cog-outlined'
+  | 'file-cog-outline'
+  | 'file-edit-outline'
   | 'bug-outline'
   | 'list-group'
   | 'secret'

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -82,10 +82,11 @@
       :count="pipeline.errors?.length"
       :icon-class="pipeline.errors.some((e) => !e.is_warning) ? 'text-wp-error-100' : 'text-wp-state-warn-100'"
     />
-    <Tab icon="file-cog-outlined" :to="{ name: 'repo-pipeline-config' }" :title="$t('repo.pipeline.config')" />
+    <Tab icon="file-cog-outline" :to="{ name: 'repo-pipeline-config' }" :title="$t('repo.pipeline.config')" />
     <Tab
       v-if="pipeline.changed_files && pipeline.changed_files.length > 0"
       :to="{ name: 'repo-pipeline-changed-files' }"
+      icon="file-edit-outline"
       :title="$t('repo.pipeline.files')"
       :count="pipeline.changed_files?.length"
     />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/87f9cc8b-b126-4022-a8fc-984627f93eb4)

Also contains some cleanups:

- use `size="1.3rem"` for icons consistently
- name `*-outline` icons consistently