### PR TITLE
Mention `backend_options` in workflow syntax docs

### DIFF
--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -512,9 +512,9 @@ Using `directory`, you can set a subdirectory of your repository or an absolute 
 
 ### `backend_options`
 
-Using `backend_options`, you may set options that are specific to the particular backend used to execute the steps. As an example, you may want to set the user and/or group used inside a Docker container; or you may want to specify the service account for Kubernetes.
+With `backend_options` you can define options that are specific to the respective backend that is used to execute the steps. For example, you can specify the user and/or group used in a Docker container or you can specify the service account for Kubernetes.
 
-For more details check the configuration docs of the backend you are using:
+Further details can be found in the documentation of the used backend:
 
 - [Docker](../30-administration/10-configuration/11-backends/10-docker.md#step-specific-configuration)
 - [Kubernetes](../30-administration/10-configuration/11-backends/20-kubernetes.md#step-specific-configuration)

--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -510,6 +510,15 @@ For more details check the [service docs](./60-services.md#detachment).
 
 Using `directory`, you can set a subdirectory of your repository or an absolute path inside the Docker container in which your commands will run.
 
+### `backend_options`
+
+Using `backend_options`, you may set options that are specific to the particular backend used to execute the steps. As an example, you may want to set the user and/or group used inside a Docker container; or you may want to specify the service account for Kubernetes.
+
+For more details check the configuration docs of the backend you are using:
+
+- [Docker](../30-administration/10-configuration/11-backends/10-docker.md#step-specific-configuration)
+- [Kubernetes](../30-administration/10-configuration/11-backends/20-kubernetes.md#step-specific-configuration)
+
 ## `services`
 
 Woodpecker can provide service containers. They can for example be used to run databases or cache containers during the execution of workflow.

--- a/docs/versioned_docs/version-3.5/20-usage/20-workflow-syntax.md
+++ b/docs/versioned_docs/version-3.5/20-usage/20-workflow-syntax.md
@@ -512,9 +512,9 @@ Using `directory`, you can set a subdirectory of your repository or an absolute 
 
 ### `backend_options`
 
-Using `backend_options`, you may set options that are specific to the particular backend used to execute the steps. As an example, you may want to set the user and/or group used inside a Docker container; or you may want to specify the service account for Kubernetes.
+With `backend_options` you can define options that are specific to the respective backend that is used to execute the steps. For example, you can specify the user and/or group used in a Docker container or you can specify the service account for Kubernetes.
 
-For more details check the configuration docs of the backend you are using:
+Further details can be found in the documentation of the used backend:
 
 - [Docker](../30-administration/10-configuration/11-backends/10-docker.md#step-specific-configuration)
 - [Kubernetes](../30-administration/10-configuration/11-backends/20-kubernetes.md#step-specific-configuration)

--- a/docs/versioned_docs/version-3.5/20-usage/20-workflow-syntax.md
+++ b/docs/versioned_docs/version-3.5/20-usage/20-workflow-syntax.md
@@ -510,6 +510,15 @@ For more details check the [service docs](./60-services.md#detachment).
 
 Using `directory`, you can set a subdirectory of your repository or an absolute path inside the Docker container in which your commands will run.
 
+### `backend_options`
+
+Using `backend_options`, you may set options that are specific to the particular backend used to execute the steps. As an example, you may want to set the user and/or group used inside a Docker container; or you may want to specify the service account for Kubernetes.
+
+For more details check the configuration docs of the backend you are using:
+
+- [Docker](../30-administration/10-configuration/11-backends/10-docker.md#step-specific-configuration)
+- [Kubernetes](../30-administration/10-configuration/11-backends/20-kubernetes.md#step-specific-configuration)
+
 ## `services`
 
 Woodpecker can provide service containers. They can for example be used to run databases or cache containers during the execution of workflow.


### PR DESCRIPTION
Hello, I am evaluating Woodpecker and it took me some time to discover the `backend_options` property (specifically to change the `user` for a Podman-in-Podman setup). This is an attempt to make the option more discoverable.