### PR TITLE
Slugify plugin names used for urls

### DIFF
--- a/docs/plugins/woodpecker-plugins/package.json
+++ b/docs/plugins/woodpecker-plugins/package.json
@@ -19,6 +19,7 @@
     "concurrently": "^9.1.2",
     "isomorphic-dompurify": "^2.19.0",
     "marked": "^15.0.5",
+    "slugify": "^1.6.6",
     "tslib": "^2.8.1",
     "typescript": "^5.7.2"
   },

--- a/docs/plugins/woodpecker-plugins/src/index.ts
+++ b/docs/plugins/woodpecker-plugins/src/index.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import { LoadContext, Plugin, PluginContentLoadedActions } from '@docusaurus/types';
 import axios, { AxiosError } from 'axios';
+import slugify from 'slugify';
+
 
 import * as markdown from './markdown';
 import { Content, WoodpeckerPlugin, WoodpeckerPluginHeader, WoodpeckerPluginIndexEntry } from './types';
@@ -90,7 +92,7 @@ async function contentLoaded({
       const pluginJsonPath = await createData(`plugin-${i}.json`, JSON.stringify(plugin));
 
       addRoute({
-        path: `/plugins/${plugin.name}`,
+        path: `/plugins/${slugify(plugin.name, { lower: true, strict: true })}`,
         component: '@theme/WoodpeckerPlugin',
         modules: {
           plugin: pluginJsonPath,

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       marked:
         specifier: ^15.0.5
         version: 15.0.8
+      slugify:
+        specifier: ^1.6.6
+        version: 1.6.6
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -5350,6 +5353,10 @@ packages:
 
   slugify@1.4.7:
     resolution: {integrity: sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==}
+    engines: {node: '>=8.0.0'}
+
+  slugify@1.6.6:
+    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
     engines: {node: '>=8.0.0'}
 
   snake-case@3.0.4:
@@ -12736,6 +12743,8 @@ snapshots:
   slash@4.0.0: {}
 
   slugify@1.4.7: {}
+
+  slugify@1.6.6: {}
 
   snake-case@3.0.4:
     dependencies:


### PR DESCRIPTION
URLs are pretty ugly now and look even worse if they are used for links somewhere, as it contains a lot of URL encoding.

![grafik](https://github.com/user-attachments/assets/1559afe3-6f5f-4ba5-b8d2-a3bef14c6c06)

This PR introduces slugify to create proper URLs and also handles special chars and Unicode symbols properly. This change will break existing links to the plugin docs but I would accept this trade-off and fix them afterwards.