### PR TITLE
Add `sccache` plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -86,6 +86,11 @@
       "verified": true
     },
     {
+      "name": "Sccache",
+      "docs": "https://seed.radicle.garden/raw/rad:zzmCBDptFLrfUEHSjcFsLJ2Aghav/head/docs.md",
+      "verified": false
+    },
+    {
       "name": "Woodpecker Email",
       "docs": "https://gitnet.fr/deblan/woodpecker-email/raw/branch/develop/DOCS.md",
       "verified": false


### PR DESCRIPTION
Add a [`sccache`](https://github.com/mozilla/sccache) plugin that allows to set eventually any of the supported storage solutions by sccache to store, read and update the build cache of any rust, C/C++ and other languages.

### Features
- Easy integration with Woodpecker CI
- S3 compatible storage support (AWS S3, MinIO, etc.)
- Compatible with Rust, C/C++, and other sccache-supported languages
- Environment sharing between pipeline steps