### PR TITLE
update docs-link for todo checker

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -117,7 +117,7 @@
     },
     {
       "name": "TODO-Checker",
-      "docs": "https://codeberg.org/Epsilon_02/todo-checker/raw/branch/main/README.md",
+      "docs": "https://codeberg.org/Epsilon_02/todo-checker/raw/branch/main/DOCS.md",
       "verified": false
     },
     {


### PR DESCRIPTION
I moved the plugin documentation into a separate DOCS.md in my repository to have place in my README.md for other project related stuff. So this PR is to update the link.
