### PR TITLE
Disable package name linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -160,6 +160,13 @@ linters:
         - strings.Split
         - callerName
         - securecookie.GenerateRandomKey
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - []
+            - []
+            - - skipPackageNameChecks: true
   exclusions:
     generated: lax
     presets:

--- a/server/store/context.go
+++ b/server/store/context.go
@@ -40,5 +40,5 @@ func ToContext(c *gin.Context, store Store) {
 }
 
 func InjectToContext(ctx context.Context, store Store) context.Context {
-	return context.WithValue(ctx, key, store) //nolint:revive,staticcheck
+	return context.WithValue(ctx, key, store) //nolint:staticcheck
 }


### PR DESCRIPTION
Fix the current linter problems by disabling this new rule. I guess we will not rename packages like `types` or `utils`