### PR TITLE
feat(k8s): k8s namespace per organization

### DIFF
--- a/pipeline/backend/kubernetes/flags.go
+++ b/pipeline/backend/kubernetes/flags.go
@@ -22,8 +22,14 @@ var Flags = []cli.Flag{
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_NAMESPACE"),
 		Name:    "backend-k8s-namespace",
-		Usage:   "backend k8s namespace",
+		Usage:   "backend k8s namespace, if used with WOODPECKER_BACKEND_K8S_NAMESPACE_PER_ORGANISATION, this will be the prefix for the namespace appended with the organization name.",
 		Value:   "woodpecker",
+	},
+	&cli.BoolFlag{
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_NAMESPACE_PER_ORGANIZATION"),
+		Name:    "backend-k8s-namespace-per-org",
+		Usage:   "Whether to enable namespace segregation per organization feature. When enabled, Woodpecker will create the Kubernetes resources to separated Kubernetes namespaces per Woodpecker organization.",
+		Value:   false,
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_VOLUME_SIZE"),

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"runtime"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -56,6 +57,7 @@ type kube struct {
 
 type config struct {
 	Namespace                   string
+	EnableNamespacePerOrg       bool
 	StorageClass                string
 	VolumeSize                  string
 	StorageRwx                  bool
@@ -68,6 +70,14 @@ type config struct {
 	SecurityContext             SecurityContextConfig
 	NativeSecretsAllowFromStep  bool
 }
+
+func (c *config) K8sNamespace(owner string) string {
+	if c.EnableNamespacePerOrg {
+		return strings.ToLower(fmt.Sprintf("%s-%s", c.Namespace, owner))
+	}
+	return c.Namespace
+}
+
 type SecurityContextConfig struct {
 	RunAsNonRoot bool
 	FSGroup      *int64
@@ -88,6 +98,7 @@ func configFromCliContext(ctx context.Context) (*config, error) {
 		if c, ok := ctx.Value(types.CliCommand).(*cli.Command); ok {
 			config := config{
 				Namespace:                   c.String("backend-k8s-namespace"),
+				EnableNamespacePerOrg:       c.Bool("backend-k8s-namespace-per-org"),
 				StorageClass:                c.String("backend-k8s-storage-class"),
 				VolumeSize:                  c.String("backend-k8s-volume-size"),
 				StorageRwx:                  c.Bool("backend-k8s-storage-rwx"),
@@ -191,7 +202,16 @@ func (e *kube) getConfig() *config {
 func (e *kube) SetupWorkflow(ctx context.Context, conf *types.Config, taskUUID string) error {
 	log.Trace().Str("taskUUID", taskUUID).Msgf("Setting up Kubernetes primitives")
 
-	_, err := startVolume(ctx, e, conf.Volume)
+	namespace := e.config.K8sNamespace(conf.Stages[0].Steps[0].Owner)
+
+	if e.config.EnableNamespacePerOrg {
+		err := ensureNamespaceExists(ctx, e, namespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := startVolume(ctx, e, conf.Volume, namespace)
 	if err != nil {
 		return err
 	}
@@ -269,7 +289,7 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 		}
 	}
 
-	si := informers.NewSharedInformerFactoryWithOptions(e.client, defaultResyncDuration, informers.WithNamespace(e.config.Namespace))
+	si := informers.NewSharedInformerFactoryWithOptions(e.client, defaultResyncDuration, informers.WithNamespace(e.config.K8sNamespace(step.Owner)))
 	if _, err := si.Core().V1().Pods().Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			UpdateFunc: podUpdated,
@@ -285,7 +305,7 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 	// TODO: Cancel on ctx.Done
 	<-finished
 
-	pod, err := e.client.CoreV1().Pods(e.config.Namespace).Get(ctx, podName, meta_v1.GetOptions{})
+	pod, err := e.client.CoreV1().Pods(e.config.K8sNamespace(step.Owner)).Get(ctx, podName, meta_v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +364,7 @@ func (e *kube) TailStep(ctx context.Context, step *types.Step, taskUUID string) 
 		}
 	}
 
-	si := informers.NewSharedInformerFactoryWithOptions(e.client, defaultResyncDuration, informers.WithNamespace(e.config.Namespace))
+	si := informers.NewSharedInformerFactoryWithOptions(e.client, defaultResyncDuration, informers.WithNamespace(e.config.K8sNamespace(step.Owner)))
 	if _, err := si.Core().V1().Pods().Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			UpdateFunc: podUpdated,
@@ -365,7 +385,7 @@ func (e *kube) TailStep(ctx context.Context, step *types.Step, taskUUID string) 
 	}
 
 	logs, err := e.client.CoreV1().RESTClient().Get().
-		Namespace(e.config.Namespace).
+		Namespace(e.config.K8sNamespace(step.Owner)).
 		Name(podName).
 		Resource("pods").
 		SubResource("log").
@@ -425,7 +445,7 @@ func (e *kube) DestroyWorkflow(ctx context.Context, conf *types.Config, taskUUID
 		}
 	}
 
-	err := stopVolume(ctx, e, conf.Volume, defaultDeleteOptions)
+	err := stopVolume(ctx, e, conf.Volume, e.config.K8sNamespace(conf.Stages[0].Steps[0].Owner), defaultDeleteOptions)
 	if err != nil {
 		return err
 	}

--- a/pipeline/backend/kubernetes/namespace.go
+++ b/pipeline/backend/kubernetes/namespace.go
@@ -1,0 +1,43 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ensureNamespaceExists(ctx context.Context, engine *kube, namespace string) error {
+	// Check if a namespace already exists
+	_, err := engine.client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err == nil {
+		// Namespace already exists
+		log.Trace().Str("namespace", namespace).Msg("Kubernetes namespace already exists")
+		return nil
+	}
+
+	// If the error is not "not found", return the error
+	if !errors.IsNotFound(err) {
+		log.Trace().Err(err).Str("namespace", namespace).Msg("failed to check Kubernetes namespace existence")
+		return err
+	}
+
+	// Namespace doesn't exist, create it
+	log.Trace().Str("namespace", namespace).Msg("creating Kubernetes namespace")
+
+	_, err = engine.client.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		log.Error().Err(err).Str("namespace", namespace).Msg("failed to create Kubernetes namespace")
+		return err
+	}
+
+	log.Trace().Str("namespace", namespace).Msg("Kubernetes namespace created successfully")
+	return nil
+}

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -88,7 +88,7 @@ func podMeta(step *types.Step, config *config, options BackendOptions, podName s
 	var err error
 	meta := meta_v1.ObjectMeta{
 		Name:        podName,
-		Namespace:   config.Namespace,
+		Namespace:   config.K8sNamespace(step.Owner),
 		Annotations: podAnnotations(config, options),
 	}
 
@@ -558,7 +558,7 @@ func startPod(ctx context.Context, engine *kube, step *types.Step, options Backe
 	}
 
 	log.Trace().Msgf("creating pod: %s", pod.Name)
-	return engine.client.CoreV1().Pods(engineConfig.Namespace).Create(ctx, pod, meta_v1.CreateOptions{})
+	return engine.client.CoreV1().Pods(engineConfig.K8sNamespace(step.Owner)).Create(ctx, pod, meta_v1.CreateOptions{})
 }
 
 func stopPod(ctx context.Context, engine *kube, step *types.Step, deleteOpts meta_v1.DeleteOptions) error {
@@ -569,7 +569,7 @@ func stopPod(ctx context.Context, engine *kube, step *types.Step, deleteOpts met
 
 	log.Trace().Str("name", podName).Msg("deleting pod")
 
-	err = engine.client.CoreV1().Pods(engine.config.Namespace).Delete(ctx, podName, deleteOpts)
+	err = engine.client.CoreV1().Pods(engine.config.K8sNamespace(step.Owner)).Delete(ctx, podName, deleteOpts)
 	if errors.IsNotFound(err) {
 		// Don't abort on 404 errors from k8s, they most likely mean that the pod hasn't been created yet, usually because pipeline was canceled before running all steps.
 		return nil

--- a/pipeline/backend/kubernetes/secrets.go
+++ b/pipeline/backend/kubernetes/secrets.go
@@ -237,7 +237,7 @@ func mkRegistrySecret(step *types.Step, config *config) (*v1.Secret, error) {
 
 	return &v1.Secret{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: config.Namespace,
+			Namespace: config.K8sNamespace(step.Owner),
 			Name:      name,
 			Labels:    labels,
 		},
@@ -288,7 +288,7 @@ func startRegistrySecret(ctx context.Context, engine *kube, step *types.Step) er
 		return err
 	}
 	log.Trace().Msgf("creating secret: %s", secret.Name)
-	_, err = engine.client.CoreV1().Secrets(engine.config.Namespace).Create(ctx, secret, meta_v1.CreateOptions{})
+	_, err = engine.client.CoreV1().Secrets(engine.config.K8sNamespace(step.Owner)).Create(ctx, secret, meta_v1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,7 @@ func stopRegistrySecret(ctx context.Context, engine *kube, step *types.Step, del
 	}
 	log.Trace().Str("name", name).Msg("deleting secret")
 
-	err = engine.client.CoreV1().Secrets(engine.config.Namespace).Delete(ctx, name, deleteOpts)
+	err = engine.client.CoreV1().Secrets(engine.config.K8sNamespace(step.Owner)).Delete(ctx, name, deleteOpts)
 	if errors.IsNotFound(err) {
 		return nil
 	}

--- a/pipeline/backend/kubernetes/service.go
+++ b/pipeline/backend/kubernetes/service.go
@@ -52,7 +52,7 @@ func mkService(step *types.Step, config *config) (*v1.Service, error) {
 	return &v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name,
-			Namespace: config.Namespace,
+			Namespace: config.K8sNamespace(step.Owner),
 		},
 		Spec: v1.ServiceSpec{
 			Type:     v1.ServiceTypeClusterIP,
@@ -85,7 +85,7 @@ func startService(ctx context.Context, engine *kube, step *types.Step) (*v1.Serv
 	}
 
 	log.Trace().Str("name", svc.Name).Interface("selector", svc.Spec.Selector).Interface("ports", svc.Spec.Ports).Msg("creating service")
-	return engine.client.CoreV1().Services(engineConfig.Namespace).Create(ctx, svc, meta_v1.CreateOptions{})
+	return engine.client.CoreV1().Services(engineConfig.K8sNamespace(step.Owner)).Create(ctx, svc, meta_v1.CreateOptions{})
 }
 
 func stopService(ctx context.Context, engine *kube, step *types.Step, deleteOpts meta_v1.DeleteOptions) error {
@@ -95,7 +95,7 @@ func stopService(ctx context.Context, engine *kube, step *types.Step, deleteOpts
 	}
 	log.Trace().Str("name", svcName).Msg("deleting service")
 
-	err = engine.client.CoreV1().Services(engine.config.Namespace).Delete(ctx, svcName, deleteOpts)
+	err = engine.client.CoreV1().Services(engine.config.K8sNamespace(step.Owner)).Delete(ctx, svcName, deleteOpts)
 	if errors.IsNotFound(err) {
 		// Don't abort on 404 errors from k8s, they most likely mean that the pod hasn't been created yet, usually because pipeline was canceled before running all steps.
 		log.Trace().Err(err).Msgf("unable to delete service %s", svcName)

--- a/pipeline/backend/kubernetes/volume_test.go
+++ b/pipeline/backend/kubernetes/volume_test.go
@@ -42,6 +42,7 @@ func TestPvcMount(t *testing.T) {
 }
 
 func TestPersistentVolumeClaim(t *testing.T) {
+	namespace := "someNamespace"
 	expectedRwx := `
 	{
 	  "metadata": {
@@ -85,11 +86,11 @@ func TestPersistentVolumeClaim(t *testing.T) {
 	}`
 
 	pvc, err := mkPersistentVolumeClaim(&config{
-		Namespace:    "someNamespace",
+		Namespace:    namespace,
 		StorageClass: "local-storage",
 		VolumeSize:   "1Gi",
 		StorageRwx:   true,
-	}, "somename")
+	}, "somename", namespace)
 	assert.NoError(t, err)
 
 	j, err := json.Marshal(pvc)
@@ -97,11 +98,11 @@ func TestPersistentVolumeClaim(t *testing.T) {
 	assert.JSONEq(t, expectedRwx, string(j))
 
 	pvc, err = mkPersistentVolumeClaim(&config{
-		Namespace:    "someNamespace",
+		Namespace:    namespace,
 		StorageClass: "local-storage",
 		VolumeSize:   "1Gi",
 		StorageRwx:   false,
-	}, "somename")
+	}, "somename", namespace)
 	assert.NoError(t, err)
 
 	j, err = json.Marshal(pvc)
@@ -109,10 +110,10 @@ func TestPersistentVolumeClaim(t *testing.T) {
 	assert.JSONEq(t, expectedRwo, string(j))
 
 	_, err = mkPersistentVolumeClaim(&config{
-		Namespace:    "someNamespace",
+		Namespace:    namespace,
 		StorageClass: "local-storage",
 		VolumeSize:   "1Gi",
 		StorageRwx:   false,
-	}, "some0..INVALID3name")
+	}, "some0..INVALID3name", namespace)
 	assert.Error(t, err)
 }

--- a/pipeline/backend/types/step.go
+++ b/pipeline/backend/types/step.go
@@ -17,6 +17,7 @@ package types
 // Step defines a container process.
 type Step struct {
 	Name           string            `json:"name"`
+	Owner          string            `json:"owner,omitempty"`
 	UUID           string            `json:"uuid"`
 	Type           StepType          `json:"type,omitempty"`
 	Image          string            `json:"image,omitempty"`

--- a/server/pipeline/stepbuilder/stepBuilder.go
+++ b/server/pipeline/stepbuilder/stepBuilder.go
@@ -216,6 +216,7 @@ func (b *StepBuilder) genItemForWorkflow(workflow *model.Workflow, axis matrix.A
 	for stageI := range item.Config.Stages {
 		for stepI := range item.Config.Stages[stageI].Steps {
 			item.Config.Stages[stageI].Steps[stepI].WorkflowLabels = item.Labels
+			item.Config.Stages[stageI].Steps[stepI].Owner = b.Repo.Owner
 		}
 	}
 


### PR DESCRIPTION
# Problem
Our organization requires the ability to isolate different teams (organizations in Woodpecker CI) into separate Kubernetes namespaces within our CI cluster. This enables better hardening for additional features that we're supplementing Woodpecker CI with for our teams, providing stronger security boundaries between team workloads.

# Solution
This PR introduces optional Kubernetes namespace isolation functionality behind a feature flag. Once enabled, each teams CI workloads will be deployed to their dedicated namespace, providing:

- **Enhanced Security**: Stronger isolation between team workloads
- **Better Hardening**: Improved security posture for supplemental features we're adding to Woodpecker CI
- **Resource Management**: Better control over resource allocation per team
- **Compliance**: Meets organizational security requirements for multi-tenant environments

# Implementation Details
- Feature is disabled by default to maintain backward compatibility
- Existing behavior remains unchanged when feature flag is not enabled

# Status
This is currently a **proposal/RFC** to gather feedback from maintainers on the approach and feasibility of this feature. The feature has been successfully tested once `woodpecker-agent` ServiceAccount is given the following additional permissions


<details>
  <summary>Additional Kubernetes permissions</summary>
  
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: woodpecker-agent
rules:
- apiGroups:
  - ""
  resources:
  - persistentvolumeclaims
  - services
  - secrets
  verbs:
  - create
  - delete
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - watch
  - create
  - delete
  - get
  - list
- apiGroups:
  - ""
  resources:
  - pods/log
  verbs:
  - get
- apiGroups:
  - ""
  resources:
  - namespaces
  verbs:
  - get
  - list
  - create
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: woodpecker-agent
subjects:
- kind: ServiceAccount
  name: woodpecker-agent
  namespace: woodpecker
roleRef:
  kind: ClusterRole
  name: woodpecker-agent
  apiGroup: rbac.authorization.k8s.io
```
  
</details>

# Next Steps
If maintainers approve this direction, we will:
1. Create a corresponding PR for the Woodpecker CI Helm Chart repo to support this feature flag
2. Add documentation and tests

We're happy to iterate on this based on your feedback.