### PR TITLE
eslint: disable vue/html-indent

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -94,6 +94,7 @@ export default antfu(
         },
       ],
       'vue/singleline-html-element-content-newline': ['off'],
+      'vue/html-indent': ['off'],
     },
   },
 


### PR DESCRIPTION
was an unrelated change in https://github.com/woodpecker-ci/woodpecker/pull/5155 ... and cleaned away from https://github.com/woodpecker-ci/woodpecker/pull/5214 


@qwerty287 would be nice to provide context why it was done :)