### PR TITLE
fix example docker compose file

### DIFF
--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -27,7 +27,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      - WOODPECKER_SERVER=woodpecker-server:9000
+      - WOODPECKER_SERVER=woodpecker-server:8000
       - WOODPECKER_AGENT_SECRET=${WOODPECKER_AGENT_SECRET}
       - WOODPECKER_MAX_WORKFLOWS=2
 


### PR DESCRIPTION
Server is started at port 800. I saw at least one issue created due to this mismatched, so the example file should be corrected.

Reference: https://github.com/woodpecker-ci/woodpecker/issues/3949