### PR TITLE
woodpecker-go/types: fix time-related struct field tags

### DIFF
--- a/woodpecker-go/woodpecker/types.go
+++ b/woodpecker-go/woodpecker/types.go
@@ -102,10 +102,10 @@ type (
 		Event     string           `json:"event"`
 		Status    string           `json:"status"`
 		Errors    []*PipelineError `json:"errors"`
-		Created   int64            `json:"created_at"`
-		Updated   int64            `json:"updated_at"`
-		Started   int64            `json:"started_at"`
-		Finished  int64            `json:"finished_at"`
+		Created   int64            `json:"created"`
+		Updated   int64            `json:"updated"`
+		Started   int64            `json:"started"`
+		Finished  int64            `json:"finished"`
 		Deploy    string           `json:"deploy_to"`
 		Commit    string           `json:"commit"`
 		Branch    string           `json:"branch"`
@@ -120,7 +120,7 @@ type (
 		Email     string           `json:"author_email"`
 		ForgeURL  string           `json:"forge_url"`
 		Reviewer  string           `json:"reviewed_by"`
-		Reviewed  int64            `json:"reviewed_at"`
+		Reviewed  int64            `json:"reviewed"`
 		Workflows []*Workflow      `json:"workflows,omitempty"`
 	}
 
@@ -131,8 +131,8 @@ type (
 		Name     string            `json:"name"`
 		State    string            `json:"state"`
 		Error    string            `json:"error,omitempty"`
-		Started  int64             `json:"start_time,omitempty"`
-		Stopped  int64             `json:"end_time,omitempty"`
+		Started  int64             `json:"started,omitempty"`
+		Stopped  int64             `json:"finished,omitempty"`
 		AgentID  int64             `json:"agent_id,omitempty"`
 		Platform string            `json:"platform,omitempty"`
 		Environ  map[string]string `json:"environ,omitempty"`
@@ -148,8 +148,8 @@ type (
 		State    string   `json:"state"`
 		Error    string   `json:"error,omitempty"`
 		ExitCode int      `json:"exit_code"`
-		Started  int64    `json:"start_time,omitempty"`
-		Stopped  int64    `json:"end_time,omitempty"`
+		Started  int64    `json:"started,omitempty"`
+		Stopped  int64    `json:"finished,omitempty"`
 		Type     StepType `json:"type,omitempty"`
 	}
 


### PR DESCRIPTION
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
Changes the JSON struct tags in the woodpecker-go API client to match the new field names merged in #3968 and released in v3. Quoting [docs/src/pages/migrations.md](docs/src/pages/migrations.md) and the current [migrations page](https://woodpecker-ci.org/migrations):

> - The SDK fields `start_time`, `end_time`, `created_at`, `started_at`, `finished_at` and `reviewed_at` have been renamed to `started`, `finished`, `created`, `started`, `finished`, `reviewed` ([#3968](https://github.com/woodpecker-ci/woodpecker/pull/3968))

The original PR changed the field names in some structs, but not all.
Please let me know if tests are needed (the existing ones of course still pass), and thank you for your time.