### PR TITLE
fix(openapi-docs): LookupOrg router path

### DIFF
--- a/server/api/org.go
+++ b/server/api/org.go
@@ -109,7 +109,7 @@ func GetOrgPermissions(c *gin.Context) {
 // LookupOrg
 //
 //	@Summary	Lookup an organization by full name
-//	@Router		/org/lookup/{org_full_name} [get]
+//	@Router		/orgs/lookup/{org_full_name} [get]
 //	@Produce	json
 //	@Success	200	{object}	Org
 //	@Tags		Organizations


### PR DESCRIPTION
`GET /org/lookup/{org_full_name}` returns 404 while the actual path in the router is `GET /orgs/lookup/{org_full_name}`.

This pull request updates the OpenAPI documentation with the correct endpoint.