### PR TITLE
Add ASCII JUnit Test Report plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -279,6 +279,11 @@
       "name": "Peckify",
       "docs": "https://codeberg.org/woodpecker-community/peckify/raw/branch/main/docs.md",
       "verified": false
-    }
+    },
+    {
+      "name": "ASCII JUnit Test Report",
+      "docs": "https://raw.githubusercontent.com/wgroeneveld/woodpecker-ascii-junit/refs/heads/main/README.md",
+      "verified": false
+    }    
   ]
 }

--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -284,6 +284,6 @@
       "name": "ASCII JUnit Test Report",
       "docs": "https://raw.githubusercontent.com/wgroeneveld/woodpecker-ascii-junit/refs/heads/main/README.md",
       "verified": false
-    }    
+    }
   ]
 }


### PR DESCRIPTION
This is a plugin for folks on the JVM (or similar that output JUnit-compatible XML reports) that want a summary of test results printed out in ASCII without having to download them. We https://github.com/jobrunr/ use this daily to help with build failure inspections!

