### PR TITLE
GitHub: count reopening an pull as opening an pull

### DIFF
--- a/server/forge/github/parse.go
+++ b/server/forge/github/parse.go
@@ -33,6 +33,7 @@ const (
 	hookField = "payload"
 
 	actionOpen     = "opened"
+	actionReopen   = "reopened"
 	actionClose    = "closed"
 	actionSync     = "synchronize"
 	actionReleased = "released"
@@ -148,7 +149,10 @@ func parseDeployHook(hook *github.DeploymentEvent) (*model.Repo, *model.Pipeline
 // parsePullHook parses a pull request hook and returns the Repo and Pipeline
 // details.
 func parsePullHook(hook *github.PullRequestEvent, merge bool) (*github.PullRequest, *model.Repo, *model.Pipeline, error) {
-	if hook.GetAction() != actionOpen && hook.GetAction() != actionSync && hook.GetAction() != actionClose {
+	if hook.GetAction() != actionOpen &&
+		hook.GetAction() != actionSync &&
+		hook.GetAction() != actionClose &&
+		hook.GetAction() != actionReopen {
 		return nil, nil, nil, nil
 	}
 


### PR DESCRIPTION
currently if you open a new pull it will trigger a pull event,
also if you close the pull it will trigger an pull_close event,
but if you reopen it again nothing is triggered.

this make it so that reopening is counted as if you would normally open a new one.