### PR TITLE
Replace header bg with border

### DIFF
--- a/web/src/components/layout/scaffold/Header.vue
+++ b/web/src/components/layout/scaffold/Header.vue
@@ -1,9 +1,6 @@
 <template>
-  <header
-    class="border-wp-background-400 bg-wp-background-100 text-wp-text-100 dark:border-wp-background-100 dark:bg-wp-background-300 border-b"
-    :class="{ 'md:px-4': fullWidth }"
-  >
-    <Container :full-width="fullWidth" class="py-0!">
+  <header class="border-wp-background-400 text-wp-text-100" :class="{ 'md:px-4': fullWidth }">
+    <Container :full-width="fullWidth" class="relative py-0!">
       <div class="flex w-full flex-col gap-2 py-3 md:flex-row md:items-center md:justify-between md:gap-10">
         <div
           class="flex min-h-10 content-start items-center"
@@ -47,6 +44,8 @@
           <slot name="tabActions" />
         </div>
       </div>
+
+      <div class="bg-wp-background-400 -mt-px h-px w-full rounded-md" />
     </Container>
   </header>
 </template>


### PR DESCRIPTION
Instead of having two "headers"  with backgrounds (the app bar with the woodpecker logo and the scaffold pages header with tabs etc), this PR smoothes the scaffold / tabs header into the page by using a subtle border instead.

<img width="2256" height="775" alt="Screenshot from 2025-07-31 13-58-03" src="https://github.com/user-attachments/assets/83564113-a37c-445f-b916-49e7a042f9bc" />
<img width="2256" height="775" alt="Screenshot from 2025-07-31 13-57-57" src="https://github.com/user-attachments/assets/33c47310-1084-4e62-b705-7110f8094fa4" />
<img width="2256" height="775" alt="Screenshot from 2025-07-31 13-57-43" src="https://github.com/user-attachments/assets/d6046279-1de6-4285-bd14-a3dc6c653d1a" />
<img width="2256" height="775" alt="Screenshot from 2025-07-31 13-57-36" src="https://github.com/user-attachments/assets/106cc73c-60fa-477b-acdc-c6a873530959" />
