### PR TITLE
Prevent body jump when scrollbar appears

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -58,6 +58,10 @@ watch(
   -moz-osx-font-smoothing: grayscale;
 }
 
+#scroll-component {
+  scrollbar-gutter: stable;
+}
+
 .slide-right-enter-active,
 .slide-right-leave-active {
   transition: all 0.3s ease;


### PR DESCRIPTION
Persists the space for the scrollbar and therefore prevents the body from jumping as soon as content is loaded or the list is getting longer as of infinite scrolling.