### PR TITLE
feat(k8s): k8s priority class name config

### DIFF
--- a/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
+++ b/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
@@ -404,3 +404,12 @@ Determines if containers must be required to run as non-root users.
 - Default: none
 
 Secret names to pull images from private repositories. See, how to [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+
+---
+
+### BACKEND_K8S_PRIORITY_CLASS
+
+- Name: `WOODPECKER_BACKEND_K8S_PRIORITY_CLASS`
+- Default: none, which will use the default priority class configured in Kubernetes
+
+Which [Kubernetes PriorityClass](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/priority-class-v1/) to assign to created job pods.

--- a/pipeline/backend/kubernetes/flags.go
+++ b/pipeline/backend/kubernetes/flags.go
@@ -95,4 +95,10 @@ var Flags = []cli.Flag{
 		Usage:   "whether to allow existing Kubernetes secrets to be referenced from steps",
 		Value:   false,
 	},
+	&cli.StringFlag{
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_PRIORITY_CLASS"),
+		Name:    "backend-k8s-priority-class",
+		Usage:   "which kubernetes priority class to assign to created job pods",
+		Value:   "",
+	},
 }

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -70,6 +70,7 @@ type config struct {
 	ImagePullSecretNames        []string
 	SecurityContext             SecurityContextConfig
 	NativeSecretsAllowFromStep  bool
+	PriorityClassName           string
 }
 
 func (c *config) GetNamespace(orgID int64) string {
@@ -103,6 +104,7 @@ func configFromCliContext(ctx context.Context) (*config, error) {
 				StorageClass:                c.String("backend-k8s-storage-class"),
 				VolumeSize:                  c.String("backend-k8s-volume-size"),
 				StorageRwx:                  c.Bool("backend-k8s-storage-rwx"),
+				PriorityClassName:           c.String("backend-k8s-priority-class"),
 				PodLabels:                   make(map[string]string), // just init empty map to prevent nil panic
 				PodLabelsAllowFromStep:      c.Bool("backend-k8s-pod-labels-allow-from-step"),
 				PodAnnotations:              make(map[string]string), // just init empty map to prevent nil panic

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -173,6 +173,7 @@ func podSpec(step *types.Step, config *config, options BackendOptions, nsp nativ
 		RestartPolicy:      v1.RestartPolicyNever,
 		RuntimeClassName:   options.RuntimeClassName,
 		ServiceAccountName: options.ServiceAccountName,
+		PriorityClassName:  config.PriorityClassName,
 		HostAliases:        hostAliases(step.ExtraHosts),
 		NodeSelector:       nodeSelector(options.NodeSelector, config.PodNodeSelector, step.Environment["CI_SYSTEM_PLATFORM"]),
 		Tolerations:        tolerations(options.Tolerations),


### PR DESCRIPTION
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->

This adds a new backend option to configure the `priorityClassName` of created pod objects. The benefits are described in #5229.

I have performed the following tests:
- If an administrator does not define the new option, Kubernetes' default priority class is used just like before this change.
- If an administrator defines a priority class name that does not exist in kubernetes, a user gets an appropriate error message in the WebUI when they try to run jobs.
- If a valid priority class name is configured, the change works as expected and assigns it to all created  pod objects.

Closes #5229 
