### PR TITLE
fix: prevent race condition in pipeline number calculation

### DIFF
--- a/server/store/datastore/engine.go
+++ b/server/store/datastore/engine.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"context"
+	"sync"
 
 	"github.com/rs/zerolog"
 	"xorm.io/xorm"
@@ -26,7 +27,8 @@ import (
 )
 
 type storage struct {
-	engine *xorm.Engine
+	engine          *xorm.Engine
+	pipelineMutexes sync.Map
 }
 
 const perPage = 50

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -15,6 +15,7 @@
 package datastore
 
 import (
+	"sync"
 	"time"
 
 	"xorm.io/builder"
@@ -128,6 +129,11 @@ func (s storage) GetPipelineCount() (int64, error) {
 }
 
 func (s storage) CreatePipeline(pipeline *model.Pipeline, stepList ...*model.Step) error {
+	mutexInterface, _ := s.pipelineMutexes.LoadOrStore(pipeline.RepoID, &sync.Mutex{})
+	repoMutex := mutexInterface.(*sync.Mutex)
+
+	repoMutex.Lock()
+	defer repoMutex.Unlock()
 	sess := s.engine.NewSession()
 	defer sess.Close()
 	if err := sess.Begin(); err != nil {


### PR DESCRIPTION
Fixes https://github.com/woodpecker-ci/woodpecker/issues/3884

## Problem

We've observed intermittent pipeline creation failures when our forge (Bitbucket Datacenter) sends concurrent webhook calls to `POST /api/hook` (e.g., "refs changed" and "pull request changed" events arriving simultaneously). This results in the following error:

```
pq: duplicate key value violates unique constraint "UQE_pipelines_s"
```

## Root Cause

The issue is caused by a race condition where both concurrent API calls calculate the same pipeline number from the logic at https://github.com/woodpecker-ci/woodpecker/blob/ac9101cf891e8fef9ac76f128cefeffc07c5dcf1/server/store/datastore/pipeline.go#L146-L154

Both requests execute this sequence simultaneously:
1. Query `MAX(number)` for the repository → both get the same value
2. Set `pipeline.Number = maxNumber + 1` → both set the same number  
3. Insert pipeline → duplicate key constraint violation

## Solution

After investigating database-level locking approaches (see [original discussion](https://github.com/woodpecker-ci/woodpecker/issues/3884#issuecomment-3219704030)), we determined that XORM's `ForUpdate()` support varies across databases and wouldn't provide a universal solution.

This PR implements **repository-specific application-level mutexes** to serialize pipeline creation per repository while maintaining concurrency between different repositories.