### PR TITLE
feat: expose listing available organizations via woodpecker-go / CLI

### DIFF
--- a/cli/org/org.go
+++ b/cli/org/org.go
@@ -28,5 +28,6 @@ var Command = &cli.Command{
 	Commands: []*cli.Command{
 		registry.Command,
 		secret.Command,
+		orgListCmd,
 	},
 }

--- a/cli/org/org_list.go
+++ b/cli/org/org_list.go
@@ -1,0 +1,65 @@
+package org
+
+import (
+	"context"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/urfave/cli/v3"
+	"go.woodpecker-ci.org/woodpecker/v3/cli/common"
+	"go.woodpecker-ci.org/woodpecker/v3/cli/internal"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+var orgListCmd = &cli.Command{
+	Name:      "ls",
+	Usage:     "list organizations",
+	ArgsUsage: "",
+	Action:    orgList,
+	Flags: []cli.Flag{
+		common.FormatFlag(tmplOrgList, true),
+	},
+}
+
+func orgList(ctx context.Context, c *cli.Command) error {
+	format := c.String("format") + "\n"
+
+	client, err := internal.NewClient(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	opt := woodpecker.ListOptions{}
+
+	list, err := client.OrgList(opt)
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("_").Funcs(orgFuncMap).Parse(format)
+	if err != nil {
+		return err
+	}
+
+	for _, org := range list {
+		if err := tmpl.Execute(os.Stdout, org); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Template for org list items.
+var tmplOrgList = "\x1b[33m{{ .Name }} \x1b[0m" + `
+Organization ID: {{ .ID }}
+{{- if .IsUser }}
+Is user: {{ .IsUser }}
+{{- end }}
+`
+
+var orgFuncMap = template.FuncMap{
+	"list": func(s []string) string {
+		return strings.Join(s, ", ")
+	},
+}

--- a/woodpecker-go/woodpecker/interface.go
+++ b/woodpecker-go/woodpecker/interface.go
@@ -186,6 +186,9 @@ type Client interface {
 	// OrgLookup returns an organization id by name.
 	OrgLookup(orgName string) (*Org, error)
 
+	// OrgList returns a list of all organizations.
+	OrgList(opt ListOptions) ([]*Org, error)
+
 	// OrgSecret returns an organization secret by name.
 	OrgSecret(orgID int64, secret string) (*Secret, error)
 

--- a/woodpecker-go/woodpecker/org.go
+++ b/woodpecker-go/woodpecker/org.go
@@ -8,6 +8,7 @@ import (
 const (
 	pathOrg           = "%s/api/orgs/%d"
 	pathOrgLookup     = "%s/api/orgs/lookup/%s"
+	pathOrgList       = "%s/api/orgs"
 	pathOrgSecrets    = "%s/api/orgs/%d/secrets"
 	pathOrgSecret     = "%s/api/orgs/%d/secrets/%s"
 	pathOrgRegistries = "%s/api/orgs/%d/registries"
@@ -27,6 +28,14 @@ func (c *client) OrgLookup(name string) (*Org, error) {
 	out := new(Org)
 	uri := fmt.Sprintf(pathOrgLookup, c.addr, name)
 	err := c.get(uri, out)
+	return out, err
+}
+
+func (c *client) OrgList(opt ListOptions) ([]*Org, error) {
+	var out []*Org
+	uri, _ := url.Parse(fmt.Sprintf(pathOrgList, c.addr))
+	uri.RawQuery = opt.getURLQuery().Encode()
+	err := c.get(uri.String(), &out)
 	return out, err
 }
 


### PR DESCRIPTION
Currently neither the woodpecker cli nor woodpecker-go don't expose functionality to expose listing Organizations while it's available on the HTTP API.

Mentioned in #3386

