### PR TITLE
fix: allow spaces in `WOODPECKER_PLUGINS_PRIVILEGED`

### DIFF
--- a/cli/admin/secret/secret_add.go
+++ b/cli/admin/secret/secret_add.go
@@ -41,10 +41,16 @@ var secretCreateCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "event",
 			Usage: "secret limited to these events",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
 			Usage: "secret limited to these images",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	},
 }

--- a/cli/admin/secret/secret_set.go
+++ b/cli/admin/secret/secret_set.go
@@ -41,10 +41,16 @@ var secretUpdateCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "event",
 			Usage: "secret limited to these events",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
 			Usage: "secret limited to these images",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	},
 }

--- a/cli/exec/flags.go
+++ b/cli/exec/flags.go
@@ -47,11 +47,17 @@ var flags = []cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_VOLUMES"),
 		Name:    "volumes",
 		Usage:   "pipeline volumes",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_NETWORKS"),
 		Name:    "network",
 		Usage:   "external networks",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_PLUGINS_PRIVILEGED"),
@@ -292,6 +298,9 @@ var flags = []cli.Flag{
 		Sources: cli.EnvVars("CI_COMMIT_PULL_REQUEST_LABELS"),
 		Name:    "commit-pull-labels",
 		Usage:   "Set the metadata environment variable \"CI_COMMIT_PULL_REQUEST_LABELS\".",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("CI_COMMIT_PULL_REQUEST_MILESTONE"),
@@ -402,6 +411,9 @@ var flags = []cli.Flag{
 		Sources: cli.EnvVars("CI_ENV"),
 		Name:    "env",
 		Usage:   "Set the metadata environment variable \"CI_ENV\".",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("CI_FORGE_TYPE"),

--- a/cli/exec/flags.go
+++ b/cli/exec/flags.go
@@ -57,6 +57,9 @@ var flags = []cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_PLUGINS_PRIVILEGED"),
 		Name:    "plugins-privileged",
 		Usage:   "Allow plugins to run in privileged mode, if environment variable is defined but empty there will be none",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND"),

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -41,6 +41,9 @@ var Command = &cli.Command{
 			Sources: cli.EnvVars("WOODPECKER_PLUGINS_PRIVILEGED"),
 			Name:    "plugins-privileged",
 			Usage:   "allow plugins to run in privileged mode, if set empty, there is no",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.StringSliceFlag{
 			Sources: cli.EnvVars("WOODPECKER_PLUGINS_TRUSTED_CLONE"),

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -50,6 +50,9 @@ var Command = &cli.Command{
 			Name:    "plugins-trusted-clone",
 			Usage:   "plugins that are trusted to handle Git credentials in cloning steps",
 			Value:   constant.TrustedClonePlugins,
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.BoolFlag{
 			Sources: cli.EnvVars("WOODPECKER_LINT_STRICT"),

--- a/cli/org/secret/secret_add.go
+++ b/cli/org/secret/secret_add.go
@@ -44,10 +44,16 @@ var secretCreateCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "event",
 			Usage: "secret limited to these events",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
 			Usage: "secret limited to these images",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	},
 }

--- a/cli/org/secret/secret_set.go
+++ b/cli/org/secret/secret_set.go
@@ -44,10 +44,16 @@ var secretUpdateCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "event",
 			Usage: "limit secret to these event",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
 			Usage: "limit secret to these image",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	},
 }

--- a/cli/pipeline/create.go
+++ b/cli/pipeline/create.go
@@ -39,6 +39,9 @@ var pipelineCreateCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "var",
 			Usage: "key=value",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	}...),
 }

--- a/cli/pipeline/deploy/deploy.go
+++ b/cli/pipeline/deploy/deploy.go
@@ -54,6 +54,9 @@ var Command = &cli.Command{
 			Name:    "param",
 			Aliases: []string{"p"},
 			Usage:   "custom parameters to inject into the step environment. Format: KEY=value",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	},
 }

--- a/cli/pipeline/start.go
+++ b/cli/pipeline/start.go
@@ -36,6 +36,9 @@ var pipelineStartCmd = &cli.Command{
 			Name:    "param",
 			Aliases: []string{"p"},
 			Usage:   "custom parameters to inject into the step environment. Format: KEY=value",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	},
 }

--- a/cli/repo/secret/secret_add.go
+++ b/cli/repo/secret/secret_add.go
@@ -44,10 +44,16 @@ var secretCreateCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "event",
 			Usage: "limit secret to these events",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
 			Usage: "limit secret to these images",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	},
 }

--- a/cli/repo/secret/secret_set.go
+++ b/cli/repo/secret/secret_set.go
@@ -44,10 +44,16 @@ var secretUpdateCmd = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "event",
 			Usage: "limit secret to these events",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 		&cli.StringSliceFlag{
 			Name:  "image",
 			Usage: "limit secret to these images",
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
 		},
 	},
 }

--- a/cmd/agent/core/flags.go
+++ b/cmd/agent/core/flags.go
@@ -67,6 +67,9 @@ var flags = []cli.Flag{
 		Name:    "labels",
 		Aliases: []string{"filter"}, // remove in v4.x
 		Usage:   "List of labels to filter tasks on. An agent must be assigned every tag listed in a task to be selected.",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.IntFlag{
 		Sources: cli.EnvVars("WOODPECKER_MAX_WORKFLOWS", "WOODPECKER_MAX_PROCS"), // cspell:words PROCS

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -126,16 +126,25 @@ var flags = append([]cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_ADMIN"),
 		Name:    "admin",
 		Usage:   "list of admin users",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_ORGS"),
 		Name:    "orgs",
 		Usage:   "list of approved organizations",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_REPO_OWNERS"),
 		Name:    "repo-owners",
 		Usage:   "Repositories by those owners will be allowed to be used in woodpecker",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.BoolFlag{
 		Sources: cli.EnvVars("WOODPECKER_OPEN"),
@@ -164,6 +173,9 @@ var flags = append([]cli.Flag{
 		Name:    "default-cancel-previous-pipeline-events",
 		Usage:   "List of event names that will be canceled when a new pipeline for the same context (tag, branch) is created.",
 		Value:   []string{"push", "pull_request"},
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_DEFAULT_CLONE_PLUGIN", "WOODPECKER_DEFAULT_CLONE_IMAGE"),
@@ -188,6 +200,9 @@ var flags = append([]cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_DEFAULT_WORKFLOW_LABELS"),
 		Name:    "default-workflow-labels",
 		Usage:   "The default label filter to set for workflows that has no label filter set. By default workflows will be allowed to run on any agent, if not specified in the workflow.",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.DurationFlag{
 		Sources: cli.EnvVars("WOODPECKER_SESSION_EXPIRES"),
@@ -208,10 +223,16 @@ var flags = append([]cli.Flag{
 		Name:    "plugins-trusted-clone",
 		Usage:   "Plugins which are trusted to handle Git credentials in clone steps",
 		Value:   constant.TrustedClonePlugins,
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_VOLUME"),
 		Name:    "volume",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_DOCKER_CONFIG"),
@@ -220,10 +241,16 @@ var flags = append([]cli.Flag{
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_ENVIRONMENT"),
 		Name:    "environment",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_NETWORK"),
 		Name:    "network",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringFlag{
 		Sources: cli.NewValueSourceChain(

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -199,6 +199,9 @@ var flags = append([]cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_PLUGINS_PRIVILEGED"),
 		Name:    "plugins-privileged",
 		Usage:   "Allow plugins to run in privileged mode, if environment variable is defined but empty there will be none",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_PLUGINS_TRUSTED_CLONE"),

--- a/pipeline/backend/kubernetes/flags.go
+++ b/pipeline/backend/kubernetes/flags.go
@@ -100,6 +100,9 @@ var Flags = []cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_PULL_SECRET_NAMES"),
 		Name:    "backend-k8s-pod-image-pull-secret-names",
 		Usage:   "backend k8s pull secret names for private registries",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
 	},
 	&cli.BoolFlag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_ALLOW_NATIVE_SECRETS"),


### PR DESCRIPTION
In v3.8.0 the following was parsed correctly:
```
WOODPECKER_PLUGINS_PRIVILEGED="docker.io/woodpeckerci/plugin-docker-buildx:latest, docker.io/woodpeckerci/plugin-docker-buildx:6.0.2"
```

But in v3.9.0 this would not be parsed correctly and results in the following linter error:
```
The formerly privileged plugin `woodpeckerci/plugin-docker-buildx:6.0.2` is no longer privileged by default, if required, add it to `WOODPECKER_PLUGINS_PRIVILEGED`
```

Regression of 59a855c7b9529a64d66461be100617b70d9d0d3e