### PR TITLE
docs: add SonarQube to plugins list

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -284,6 +284,11 @@
       "name": "ASCII JUnit Test Report",
       "docs": "https://raw.githubusercontent.com/wgroeneveld/woodpecker-ascii-junit/refs/heads/main/README.md",
       "verified": false
+    },
+    {
+      "name": "SonarQube",
+      "docs": "https://raw.githubusercontent.com/j04n-f/woodpecker-sonar-plugin/refs/heads/main/docs.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
## Description

Add SonarQube plugin to the plugins list.

## Background

New Woodpecker CI plugin to execute SonarQube analysis: https://github.com/j04n-f/woodpecker-sonar-plugin

The plugin features multiple images to facilitate scanning for Java, Node, Go, and Flutter projects. It works for Pull Request (Requires SonarQube Developer edition or Community Branch plugin).

It's my first plugin, feedback and guidance welcome 😊
