### PR TITLE
Cleanup columns in forges table

### DIFF
--- a/server/model/forge.go
+++ b/server/model/forge.go
@@ -30,8 +30,8 @@ type Forge struct {
 	ID                int64          `json:"id"                           xorm:"pk autoincr 'id'"`
 	Type              ForgeType      `json:"type"                         xorm:"VARCHAR(250)"`
 	URL               string         `json:"url"                          xorm:"VARCHAR(500) 'url'"`
-	OAuthClientID     string         `json:"client,omitempty"             xorm:"VARCHAR(250)"`
-	OAuthClientSecret string         `json:"-"                            xorm:"VARCHAR(250)"` // do not expose client secret
+	OAuthClientID     string         `json:"client,omitempty"             xorm:"VARCHAR(250) 'oauth_client_id'"`
+	OAuthClientSecret string         `json:"-"                            xorm:"VARCHAR(250) 'oauth_client_secret'"` // do not expose client secret
 	SkipVerify        bool           `json:"skip_verify,omitempty"        xorm:"bool"`
 	OAuthHost         string         `json:"oauth_host,omitempty"         xorm:"VARCHAR(250) 'oauth_host'"` // public url for oauth if different from url
 	AdditionalOptions map[string]any `json:"additional_options,omitempty" xorm:"json"`

--- a/server/store/datastore/migration/027_fix_forge_columns.go
+++ b/server/store/datastore/migration/027_fix_forge_columns.go
@@ -1,0 +1,25 @@
+package migration
+
+import (
+	"src.techknowlogick.com/xormigrate"
+	"xorm.io/xorm"
+)
+
+var fixForgeColumns = xormigrate.Migration{
+	ID: "fix-forge-columns",
+	MigrateSession: func(sess *xorm.Session) (err error) {
+		if err := renameColumn(sess, "forges", "o_auth_client_i_d", "oauth_client_id"); err != nil {
+			return err
+		}
+		if err := renameColumn(sess, "forges", "o_auth_client_secret", "oauth_client_secret"); err != nil {
+			return err
+		}
+
+		// Drop client and client_secret columns if they still exist
+		if err := dropTableColumns(sess, "forges", "client", "client_secret"); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/server/store/datastore/migration/migration.go
+++ b/server/store/datastore/migration/migration.go
@@ -54,6 +54,7 @@ var migrationTasks = []*xormigrate.Migration{
 	&removeRepoScm,
 	&unsanitizeOrgAndUserNames,
 	&replaceZeroForgeIDsInOrgs,
+	&fixForgeColumns,
 }
 
 var allBeans = []any{


### PR DESCRIPTION
Stumbled across this while looking into https://github.com/woodpecker-ci/woodpecker/issues/5471. Would like to get the cleanup done first before working on this issue.

Changes:
- fix oauth column names
- drop old client and client_sectret columns

Before:

```
❯ docker exec -it woodpecker-db psql -U postgres -d woodpecker_server -c "\d+ forges"
                                                                      Table "public.forges"
        Column        |          Type          | Collation | Nullable |              Default               | Storage  | Compression | Stats target | Description
----------------------+------------------------+-----------+----------+------------------------------------+----------+-------------+--------------+-------------
 id                   | bigint                 |           | not null | nextval('forges_id_seq'::regclass) | plain    |             |              |
 type                 | character varying(250) |           |          |                                    | extended |             |              |
 url                  | character varying(500) |           |          |                                    | extended |             |              |
 client               | character varying(250) |           |          |                                    | extended |             |              |
 client_secret        | character varying(250) |           |          |                                    | extended |             |              |
 skip_verify          | boolean                |           |          |                                    | plain    |             |              |
 oauth_host           | character varying(250) |           |          |                                    | extended |             |              |
 additional_options   | json                   |           |          |                                    | extended |             |              |
 o_auth_client_i_d    | character varying(250) |           |          |                                    | extended |             |              |
 o_auth_client_secret | character varying(250) |           |          |                                    | extended |             |              |
Indexes:
    "forges_pkey" PRIMARY KEY, btree (id)
Access method: heap
```

After:

```
❯ docker exec -it woodpecker-db psql -U postgres -d woodpecker_server -c "\d+ forges"
                                                                     Table "public.forges"
       Column        |          Type          | Collation | Nullable |              Default               | Storage  | Compression | Stats target | Description
---------------------+------------------------+-----------+----------+------------------------------------+----------+-------------+--------------+-------------
 id                  | bigint                 |           | not null | nextval('forges_id_seq'::regclass) | plain    |             |              |
 type                | character varying(250) |           |          |                                    | extended |             |              |
 url                 | character varying(500) |           |          |                                    | extended |             |              |
 skip_verify         | boolean                |           |          |                                    | plain    |             |              |
 oauth_host          | character varying(250) |           |          |                                    | extended |             |              |
 additional_options  | json                   |           |          |                                    | extended |             |              |
 oauth_client_id     | character varying(250) |           |          |                                    | extended |             |              |
 oauth_client_secret | character varying(250) |           |          |                                    | extended |             |              |
Indexes:
    "forges_pkey" PRIMARY KEY, btree (id)
Access method: heap
```

The values that exist in the old columns `client` and `client_secret` were already present in the related `oauth_*` so I just dropped the old ones.

```
❯ docker exec -it woodpecker-db psql -U postgres -d woodpecker_server -c "select * from forges"
 id |     type     |             url              | skip_verify | oauth_host | additional_options |           oauth_client_id            |                   oauth_client_secret
----+--------------+------------------------------+-------------+------------+--------------------+--------------------------------------+----------------------------------------------------------
  3 | bitbucket-dc | https://myurl                | f           |            | null               | asasas                               |
  1 | gitea        | http://woodpecker-gitea:3000 | f           |            | {}                 | bc5fe614-***                         | gto_***
(2 rows)

```