### PR TITLE
Use correct error when config fetching fails

### DIFF
--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -88,7 +88,7 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		return nil, ErrFiltered
 	} else if configFetchErr != nil {
 		log.Error().Str("repo", repo.FullName).Err(configFetchErr).Msgf("error while fetching config '%s' in '%s' with user: '%s'", repo.Config, pipeline.Ref, repoUser.Login)
-		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge: %s", err.Error()))
+		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge (%w): %s", err, err.Error()))
 	}
 
 	pipelineItems, parseErr := parsePipeline(_forge, _store, pipeline, repoUser, repo, forgeYamlConfigs, nil)

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -88,7 +88,7 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		return nil, ErrFiltered
 	} else if configFetchErr != nil {
 		log.Error().Str("repo", repo.FullName).Err(configFetchErr).Msgf("error while fetching config '%s' in '%s' with user: '%s'", repo.Config, pipeline.Ref, repoUser.Login)
-		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge (%w): %s", err, err.Error()))
+		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge: %w", configFetchErr))
 	}
 
 	pipelineItems, parseErr := parsePipeline(_forge, _store, pipeline, repoUser, repo, forgeYamlConfigs, nil)


### PR DESCRIPTION
https://github.com/woodpecker-ci/woodpecker/pull/5501/files#r2351742200


normally %w should be equal %s but allow to get the error back if needed or assert if it is the underlaying.
it it does not format nicely this is the better way to do to not lose that bit of information