### PR TITLE
eslint ignore html-indent in vue, we use prettier

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -87,6 +87,7 @@ export default antfu(
           math: 'always',
         },
       ],
+      'vue/html-indent': 'off',
       'vue/block-order': [
         'error',
         {


### PR DESCRIPTION
as per https://github.com/woodpecker-ci/woodpecker/pull/5214#discussion_r2297391010