### PR TITLE
Add MCP tool to awesome docs

### DIFF
--- a/docs/src/pages/awesome.md
+++ b/docs/src/pages/awesome.md
@@ -30,6 +30,7 @@ If you want to add a new entry, open a [pull-request](https://github.com/woodpec
 - [woodpecker-lint](https://git.schmidl.dev/schtobia/woodpecker-lint) - A repository for linting a Woodpecker config file via pre-commit hook
 - [Grafana Dashboard](https://github.com/Janik-Haag/woodpecker-grafana-dashboard) - A dashboard visualizing information exposed by the Woodpecker prometheus endpoint.
 - [woodpecker-autoscaler](https://github.com/Lerentis/woodpecker-autoscaler) - Yet another Woodpecker autoscaler currently targeting [Hetzner cloud](https://www.hetzner.com/cloud) that works in parallel to other autoscaler implementations.
+- [Woodpecker MCP](https://github.com/j04n-f/woodpecker-mcp) - A Model Context Protocol (MCP) server that connects AI assistants to Woodpecker CI. Debug pipeline failures, analyze build logs, and troubleshoot CI/CD configurations with AI assistance.
 
 ## Configuration Services
 


### PR DESCRIPTION
## Description

I want to share with the community the MPC server for Woodpecker: https://github.com/j04n-f/woodpecker-mcp. It's useful while developing to ask the AI assistant to solve a pipeline error, retrieve a pipeline configuration as context or analyze the performance of your pipelines.

This PR add the link to the awesome tools page.
