### PR TITLE
Add back-off retry for pod log streaming to kubernetes backend

### DIFF
--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"
@@ -46,10 +47,7 @@ const (
 	EngineName = "kubernetes"
 	// TODO: 5 seconds is against best practice, k3s didn't work otherwise
 	defaultResyncDuration = 5 * time.Second
-	initialRetryDelay     = 1 * time.Second
-	maxRetryDelay         = 5 * time.Second
 	maxRetryDuration      = 1 * time.Minute
-	backoffMultiplier     = 2
 )
 
 var defaultDeleteOptions = newDefaultDeleteOptions()
@@ -408,36 +406,24 @@ func (e *kube) TailStep(ctx context.Context, step *types.Step, taskUUID string) 
 		Container: podName,
 	}
 
-	var logs io.ReadCloser
-	start := time.Now()
-	delay := initialRetryDelay
-	for {
-		logs, err = e.client.CoreV1().RESTClient().Get().
-			Namespace(e.config.GetNamespace(step.OrgID)).
-			Name(podName).
-			Resource("pods").
-			SubResource("log").
-			VersionedParams(opts, scheme.ParameterCodec).
-			Stream(ctx)
-		if err == nil {
-			break
-		}
-		// stop retrying if context is done
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		// enforce a maximum total wait time
-		if time.Since(start) >= maxRetryDuration {
-			return nil, err
-		}
-		log.Warn().Err(err).Str("pod", podName).Msg("failed to open pod log stream, retrying with backoff")
-		time.Sleep(delay)
-		if delay < maxRetryDelay {
-			delay *= backoffMultiplier
-			if delay > maxRetryDelay {
-				delay = maxRetryDelay
-			}
-		}
+	logs, err := backoff.Retry(ctx,
+		func() (io.ReadCloser, error) {
+			return e.client.CoreV1().RESTClient().Get().
+				Namespace(e.config.GetNamespace(step.OrgID)).
+				Name(podName).
+				Resource("pods").
+				SubResource("log").
+				VersionedParams(opts, scheme.ParameterCodec).
+				Stream(ctx)
+		},
+		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithMaxElapsedTime(maxRetryDuration),
+		backoff.WithNotify(func(err error, delay time.Duration) {
+			log.Warn().Err(err).Str("pod", podName).Dur("backoff", delay).Msg("failed to open pod log stream, retrying with backoff")
+		}),
+	)
+	if err != nil {
+		return nil, err
 	}
 	rc, wc := io.Pipe()
 


### PR DESCRIPTION
# Problem

Woodpecker CI fails with 

```
rpc error: code = Unknown desc = workflow finished with error Get "https://10.0.9.147:10250/containerLogs/...": remote error: tls: internal error
```

when trying to read container logs from newly provisioned Kubernetes worker nodes. This occurs because:

- New worker nodes require CSR (Certificate Signing Request) approval before kubelet can serve TLS requests
- Woodpecker attempts to read logs immediately
- Race condition: log collection happens faster than certificate provisioning

This can be reproduced by ensuring that the Woodpecker step causes creation of new Kubernetes worker node (we are using Karpenter that handles it), where from time to time it fails with the error.

https://repost.aws/questions/QUK8WLbLYlSs2lKw__7h-uOQ/eks-remote-error-tls-internal-error-when-running-kubectl-logs-command led to us to understand the issue better, and the fact that when provisioning a new worker node, the `kubectl get csr --watch` shows 15s period of time when the CSR is pending

```
csr-d5fmg   0s      kubernetes.io/kubelet-serving   system:node:<node>  <none>              Pending
csr-d5fmg   15s     kubernetes.io/kubelet-serving   system:node:<node>   <none>              Approved
csr-d5fmg   15s     kubernetes.io/kubelet-serving   system:node:<node>   <none>              Approved,Issued
```

```mermaid
sequenceDiagram
    participant WP as Woodpecker CI
    participant K8s as Kubernetes API
    participant Node as New Worker Node
    participant Kubelet as Kubelet
    
    WP->>K8s: Create build pod
    K8s->>Node: Schedule pod
    Node->>Kubelet: Start container
    Note over Node: CSR not yet approved
    WP->>Kubelet: GET /containerLogs (too early!)
    Kubelet-->>WP: TLS: internal error
    Note over Node: CSR gets approved later

```

# Solution

Added retry logic with exponential backoff to the `TailStep` function in the Kubernetes backend to improve resiliency when fetching log streams. This prevents Woodpecker from marking steps as failed due to temporary issues (such as our specific issue with newly provisioned nodes where kubelet certificates are not yet valid when Woodpecker is already trying to tail the logs).