### PR TITLE
Fix forge oauth columns migration (3)

### DIFF
--- a/server/store/datastore/migration/026_fix_forge_columns.go
+++ b/server/store/datastore/migration/026_fix_forge_columns.go
@@ -23,6 +23,7 @@ var fixForgeColumns = xormigrate.Migration{
 	ID: "fix-forge-columns",
 	MigrateSession: func(sess *xorm.Session) (err error) {
 		type forges struct {
+			ID                int64  `xorm:"pk autoincr 'id'"`
 			Client            string `xorm:"VARCHAR(250) 'client'"`
 			ClientSecret      string `xorm:"VARCHAR(250) 'client_secret'"`
 			OAuthClientID     string `xorm:"VARCHAR(250) 'o_auth_client_i_d'"`


### PR DESCRIPTION
On SQLite, it's not possible to add a primary key to an existing table. That means on a fresh setup with SQLite, the server won't start:

```
failed to setup store: could not migrate datastore: msg: sync error '*model.Forge': Cannot add a PRIMARY KEY column
```

We need to ensure all primary key fields are already synced during migrations