### PR TITLE
Disable CGO for swag fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ generate: install-tools generate-openapi ## Run all code generations
 	CGO_ENABLED=0 go generate ./...
 
 generate-openapi: install-tools ## Run openapi code generation and format it
-	go run github.com/swaggo/swag/cmd/swag fmt --exclude pipeline/rpc/proto
+	CGO_ENABLED=0 go run github.com/swaggo/swag/cmd/swag fmt --exclude pipeline/rpc/proto
 	CGO_ENABLED=0 go generate cmd/server/openapi.go
 
 generate-license-header: install-tools


### PR DESCRIPTION
I'm seeing this when doing make build on nixos without CGO_ENABLED=0:

```sh
go run github.com/swaggo/swag/cmd/swag fmt --exclude pipeline/rpc/proto

# github.com/swaggo/swag/cmd/swag

net(.text): relocation target \_\_errno_location not defined
net(.text): relocation target getaddrinfo not defined
net(.text): relocation target free not defined
net(.text): relocation target freeaddrinfo not defined
net(.text): relocation target gai_strerror not defined
```

Works fine with CGO_ENABLED=0.
