### PR TITLE
Fix language selector by only using the language part to get the display name

### DIFF
--- a/web/src/views/user/UserGeneral.vue
+++ b/web/src/views/user/UserGeneral.vue
@@ -49,10 +49,13 @@ const { locale, t } = useI18n();
 const { storeTheme } = useTheme();
 
 const localeOptions = computed(() =>
-  SUPPORTED_LOCALES.map((supportedLocale) => ({
-    value: supportedLocale,
-    text: new Intl.DisplayNames(supportedLocale, { type: 'language' }).of(supportedLocale) || supportedLocale,
-  })),
+  SUPPORTED_LOCALES.map((supportedLocale) => {
+    const language = supportedLocale.split('_')[0];
+    return {
+      value: supportedLocale,
+      text: new Intl.DisplayNames(language, { type: 'language' }).of(language) || supportedLocale,
+    };
+  }),
 );
 
 const storedLocale = useStorage('woodpecker:locale', locale.value);


### PR DESCRIPTION
Adding nb_NO here broke the selector as Intl.DisplayNames does not understand it

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
