### PR TITLE
Don't split language if not required

### DIFF
--- a/web/src/compositions/useI18n.ts
+++ b/web/src/compositions/useI18n.ts
@@ -1,11 +1,15 @@
 import { useStorage } from '@vueuse/core';
+import { SUPPORTED_LOCALES } from 'virtual:vue-i18n-supported-locales';
 import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
 
 import { useDate } from './useDate';
 
 export function getUserLanguage(): string {
-  const browserLocale = navigator.language.split('-')[0];
+  let browserLocale = navigator.language;
+  if (!SUPPORTED_LOCALES.includes(browserLocale)) {
+    browserLocale = browserLocale.split('-')[0];
+  }
   const selectedLocale = useStorage('woodpecker:locale', browserLocale).value;
 
   return selectedLocale;


### PR DESCRIPTION
Since we now have `nb-NO` we cannot just split it. With `nb-NO` as system language this is converted to `nb` only and vue-i18n doesn't recognize it. So you have to manually change the language.