### PR TITLE
Improve error message when agent fails to connect

### DIFF
--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -140,7 +140,7 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 	authClient := agent_rpc.NewAuthGrpcClient(authConn, agentToken, agentConfig.AgentID)
 	authInterceptor, err := agent_rpc.NewAuthInterceptor(grpcClientCtx, authClient, authInterceptorRefreshInterval) //nolint:contextcheck
 	if err != nil {
-		return fmt.Errorf("could not create new auth interceptor: %w", err)
+		return fmt.Errorf("agent could not auth: %w", err)
 	}
 
 	conn, err := grpc.NewClient(
@@ -331,9 +331,9 @@ func runWithRetry(backendEngines []types.Backend) func(ctx context.Context, c *c
 		retryCount := c.Int("connect-retry-count")
 		retryDelay := c.Duration("connect-retry-delay")
 		var err error
-		for i := 0; i < retryCount; i++ {
+		for range retryCount {
 			if err = run(ctx, c, backendEngines); status.Code(err) == codes.Unavailable {
-				log.Warn().Err(err).Msg(fmt.Sprintf("cannot connect to server, retrying in %v", retryDelay))
+				log.Warn().Err(err).Msg(fmt.Sprintf("cannot connect to %s, retrying in %v", c.String("server"), retryDelay))
 				time.Sleep(retryDelay)
 			} else {
 				break


### PR DESCRIPTION
Auth Interceptor isn't really a concept to the user when they are trying to connect their agent to a woodpecker server. Also include the server name they are trying to connect to and modernize a for loop.

ref https://github.com/woodpecker-ci/woodpecker/discussions/4949

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
