### PR TITLE
Make TestCopyLineByLine less flaky

### DIFF
--- a/pipeline/log/utils_test.go
+++ b/pipeline/log/utils_test.go
@@ -64,7 +64,7 @@ func TestCopyLineByLine(t *testing.T) {
 	}()
 
 	// wait for the goroutine to start
-	time.Sleep(time.Millisecond)
+	time.Sleep(time.Second / 10)
 
 	// write 4 bytes without newline
 	if _, err := w.Write([]byte("1234")); err != nil {


### PR DESCRIPTION
Happens way to often on heavy used agents

<img width="1720" height="718" alt="image" src="https://github.com/user-attachments/assets/056a2f62-3861-4eb0-bd74-b36ccb09dc40" />

example: https://ci.woodpecker-ci.org/repos/3780/pipeline/28719/30