### PR TITLE
Fix Kubernetes install docs to use OCI artifacts instead of deprecated helm chart

### DIFF
--- a/docs/versioned_docs/version-3.10/30-administration/05-installation/20-helm-chart.md
+++ b/docs/versioned_docs/version-3.10/30-administration/05-installation/20-helm-chart.md
@@ -3,11 +3,26 @@
 Woodpecker provides a [Helm chart](https://github.com/woodpecker-ci/helm) for Kubernetes environments:
 
 ```bash
-helm repo add woodpecker oci://ghcr.io/woodpecker-ci/helm
-helm install woodpecker woodpecker/woodpecker
+helm install woodpecker oci://ghcr.io/woodpecker-ci/helm/woodpecker
 ```
 
-## Metrics
+## Configuration
+
+To fetch all configurable options with detailed comments:
+
+```bash
+helm show values oci://ghcr.io/woodpecker-ci/helm/woodpecker > values.yaml
+```
+
+Install using custom values:
+
+```bash
+helm install woodpecker \
+  oci://ghcr.io/woodpecker-ci/helm/woodpecker \
+  -f values.yaml
+```
+
+### Metrics
 
 To enable metrics gathering, set the following in values.yml:
 

--- a/docs/versioned_docs/version-3.8/30-administration/05-installation/20-helm-chart.md
+++ b/docs/versioned_docs/version-3.8/30-administration/05-installation/20-helm-chart.md
@@ -3,11 +3,26 @@
 Woodpecker provides a [Helm chart](https://github.com/woodpecker-ci/helm) for Kubernetes environments:
 
 ```bash
-helm repo add woodpecker oci://ghcr.io/woodpecker-ci/helm
-helm install woodpecker woodpecker/woodpecker
+helm install woodpecker oci://ghcr.io/woodpecker-ci/helm/woodpecker
 ```
 
-## Metrics
+## Configuration
+
+To fetch all configurable options with detailed comments:
+
+```bash
+helm show values oci://ghcr.io/woodpecker-ci/helm/woodpecker > values.yaml
+```
+
+Install using custom values:
+
+```bash
+helm install woodpecker \
+  oci://ghcr.io/woodpecker-ci/helm/woodpecker \
+  -f values.yaml
+```
+
+### Metrics
 
 To enable metrics gathering, set the following in values.yml:
 

--- a/docs/versioned_docs/version-3.9/30-administration/05-installation/20-helm-chart.md
+++ b/docs/versioned_docs/version-3.9/30-administration/05-installation/20-helm-chart.md
@@ -3,11 +3,26 @@
 Woodpecker provides a [Helm chart](https://github.com/woodpecker-ci/helm) for Kubernetes environments:
 
 ```bash
-helm repo add woodpecker oci://ghcr.io/woodpecker-ci/helm
-helm install woodpecker woodpecker/woodpecker
+helm install woodpecker oci://ghcr.io/woodpecker-ci/helm/woodpecker
 ```
 
-## Metrics
+## Configuration
+
+To fetch all configurable options with detailed comments:
+
+```bash
+helm show values oci://ghcr.io/woodpecker-ci/helm/woodpecker > values.yaml
+```
+
+Install using custom values:
+
+```bash
+helm install woodpecker \
+  oci://ghcr.io/woodpecker-ci/helm/woodpecker \
+  -f values.yaml
+```
+
+### Metrics
 
 To enable metrics gathering, set the following in values.yml:
 


### PR DESCRIPTION
- Document Helm chart installation from GHCR as OCI artifacts, not a classic Helm repository
- Include configuration example with custom values.yaml file