### PR TITLE
[Bugfix] Get ChangedFiles via API for github

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
-	github.com/google/go-github/v74 v74.0.0
+	github.com/google/go-github/v75 v75.0.0
 	github.com/google/tink/go v1.7.0
 	github.com/gorilla/securecookie v1.1.2
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v74 v74.0.0 h1:yZcddTUn8DPbj11GxnMrNiAnXH14gNs559AsUpNpPgM=
-github.com/google/go-github/v74 v74.0.0/go.mod h1:ubn/YdyftV80VPSI26nSJvaEsTOnsjrxG3o9kJhcyak=
+github.com/google/go-github/v75 v75.0.0 h1:k7q8Bvg+W5KxRl9Tjq16a9XEgVY1pwuiG5sIL7435Ic=
+github.com/google/go-github/v75 v75.0.0/go.mod h1:H3LUJEA1TCrzuUqtdAQniBNwuKiQIqdGKgBo1/M/uqI=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/server/forge/github/convert.go
+++ b/server/forge/github/convert.go
@@ -18,7 +18,7 @@ package github
 import (
 	"fmt"
 
-	"github.com/google/go-github/v74/github"
+	"github.com/google/go-github/v75/github"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 )

--- a/server/forge/github/convert_test.go
+++ b/server/forge/github/convert_test.go
@@ -239,7 +239,9 @@ func Test_parsePushHook(t *testing.T) {
 		from.HeadCommit.ID = github.Ptr("f72fc19")
 		from.Ref = github.Ptr("refs/heads/main")
 
-		_, pipeline := parsePushHook(from)
+		_, pipeline, before, now := parsePushHook(from)
+		assert.Equal(t, "before", before)
+		assert.Equal(t, "now", now)
 		assert.Equal(t, model.EventPush, pipeline.Event)
 		assert.Equal(t, "main", pipeline.Branch)
 		assert.Equal(t, "refs/heads/main", pipeline.Ref)
@@ -255,7 +257,9 @@ func Test_parsePushHook(t *testing.T) {
 		from := &github.PushEvent{}
 		from.Ref = github.Ptr("refs/tags/v1.0.0")
 
-		_, pipeline := parsePushHook(from)
+		_, pipeline, before, now := parsePushHook(from)
+		assert.Equal(t, "before", before)
+		assert.Equal(t, "now", now)
 		assert.Equal(t, model.EventTag, pipeline.Event)
 		assert.Equal(t, "refs/tags/v1.0.0", pipeline.Ref)
 	})
@@ -265,7 +269,9 @@ func Test_parsePushHook(t *testing.T) {
 		from.Ref = github.Ptr("refs/tags/v1.0.0")
 		from.BaseRef = github.Ptr("refs/heads/main")
 
-		_, pipeline := parsePushHook(from)
+		_, pipeline, before, now := parsePushHook(from)
+		assert.Equal(t, "before", before)
+		assert.Equal(t, "now", now)
 		assert.Equal(t, model.EventTag, pipeline.Event)
 		assert.Equal(t, "main", pipeline.Branch)
 	})
@@ -275,7 +281,9 @@ func Test_parsePushHook(t *testing.T) {
 		from.Ref = github.Ptr("refs/tags/v1.0.0")
 		from.BaseRef = github.Ptr("refs/refs/main")
 
-		_, pipeline := parsePushHook(from)
+		_, pipeline, before, now := parsePushHook(from)
+		assert.Equal(t, "before", before)
+		assert.Equal(t, "now", now)
 		assert.Equal(t, model.EventTag, pipeline.Event)
 		assert.Equal(t, "refs/tags/v1.0.0", pipeline.Branch)
 	})

--- a/server/forge/github/convert_test.go
+++ b/server/forge/github/convert_test.go
@@ -18,7 +18,7 @@ package github
 import (
 	"testing"
 
-	"github.com/google/go-github/v74/github"
+	"github.com/google/go-github/v75/github"
 	"github.com/stretchr/testify/assert"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"

--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v74/github"
+	"github.com/google/go-github/v75/github"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
 

--- a/server/forge/github/parse.go
+++ b/server/forge/github/parse.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v74/github"
+	"github.com/google/go-github/v75/github"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/common"
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/types"

--- a/server/forge/github/parse.go
+++ b/server/forge/github/parse.go
@@ -27,7 +27,6 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/common"
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
-	"go.woodpecker-ci.org/woodpecker/v3/shared/utils"
 )
 
 const (
@@ -56,7 +55,7 @@ const (
 
 // parseHook parses a GitHub hook from an http.Request request and returns
 // Repo and Pipeline detail. If a hook type is unsupported nil values are returned.
-func parseHook(r *http.Request, merge bool) (*github.PullRequest, *model.Repo, *model.Pipeline, error) {
+func parseHook(r *http.Request, merge bool) (_ *github.PullRequest, _ *model.Repo, _ *model.Pipeline, commitBefore, commitNow string, _ error) {
 	var reader io.Reader = r.Body
 
 	if payload := r.FormValue(hookField); payload != "" {
@@ -65,51 +64,52 @@ func parseHook(r *http.Request, merge bool) (*github.PullRequest, *model.Repo, *
 
 	raw, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, "", "", err
 	}
 
 	payload, err := github.ParseWebHook(github.WebHookType(r), raw)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, "", "", err
 	}
 
 	switch hook := payload.(type) {
 	case *github.PushEvent:
-		repo, pipeline := parsePushHook(hook)
-		return nil, repo, pipeline, nil
+		repo, pipeline, before, now := parsePushHook(hook)
+		return nil, repo, pipeline, before, now, nil
 	case *github.DeploymentEvent:
 		repo, pipeline := parseDeployHook(hook)
-		return nil, repo, pipeline, nil
+		return nil, repo, pipeline, "", "", nil
 	case *github.PullRequestEvent:
-		return parsePullHook(hook, merge)
+		pr, repo, pipeline, err := parsePullHook(hook, merge)
+		return pr, repo, pipeline, "", "", err
 	case *github.ReleaseEvent:
 		repo, pipeline := parseReleaseHook(hook)
-		return nil, repo, pipeline, nil
+		return nil, repo, pipeline, "", "", nil
 	default:
-		return nil, nil, nil, &types.ErrIgnoreEvent{Event: github.Stringify(hook)}
+		return nil, nil, nil, "", "", &types.ErrIgnoreEvent{Event: github.Stringify(hook)}
 	}
 }
 
 // parsePushHook parses a push hook and returns the Repo and Pipeline details.
 // If the commit type is unsupported nil values are returned.
-func parsePushHook(hook *github.PushEvent) (*model.Repo, *model.Pipeline) {
+func parsePushHook(hook *github.PushEvent) (_ *model.Repo, _ *model.Pipeline, before, now string) {
 	if hook.Deleted != nil && *hook.Deleted {
-		return nil, nil
+		return nil, nil, "", ""
 	}
 
 	pipeline := &model.Pipeline{
-		Event:        model.EventPush,
-		Commit:       hook.GetHeadCommit().GetID(),
-		Ref:          hook.GetRef(),
-		ForgeURL:     hook.GetHeadCommit().GetURL(),
-		Branch:       strings.ReplaceAll(hook.GetRef(), "refs/heads/", ""),
-		Message:      hook.GetHeadCommit().GetMessage(),
-		Email:        hook.GetHeadCommit().GetAuthor().GetEmail(),
-		Avatar:       hook.GetSender().GetAvatarURL(),
-		Author:       hook.GetSender().GetLogin(),
-		Sender:       hook.GetSender().GetLogin(),
-		ChangedFiles: getChangedFilesFromCommits(hook.Commits),
+		Event:    model.EventPush,
+		Commit:   hook.GetHeadCommit().GetID(),
+		Ref:      hook.GetRef(),
+		ForgeURL: hook.GetHeadCommit().GetURL(),
+		Branch:   strings.ReplaceAll(hook.GetRef(), "refs/heads/", ""),
+		Message:  hook.GetHeadCommit().GetMessage(),
+		Email:    hook.GetHeadCommit().GetAuthor().GetEmail(),
+		Avatar:   hook.GetSender().GetAvatarURL(),
+		Author:   hook.GetSender().GetLogin(),
+		Sender:   hook.GetSender().GetLogin(),
 	}
+	repo := convertRepoHook(hook.GetRepo())
 
 	if len(pipeline.Author) == 0 {
 		pipeline.Author = hook.GetHeadCommit().GetAuthor().GetLogin()
@@ -118,15 +118,15 @@ func parsePushHook(hook *github.PushEvent) (*model.Repo, *model.Pipeline) {
 		// just kidding, this is actually a tag event. Why did this come as a push
 		// event we'll never know!
 		pipeline.Event = model.EventTag
-		pipeline.ChangedFiles = nil
 		// For tags, if the base_ref (tag's base branch) is set, we're using it
 		// as pipeline's branch so that we can filter events base on it
 		if strings.HasPrefix(hook.GetBaseRef(), "refs/heads/") {
 			pipeline.Branch = strings.ReplaceAll(hook.GetBaseRef(), "refs/heads/", "")
 		}
+		return repo, pipeline, "", ""
 	}
 
-	return convertRepoHook(hook.GetRepo()), pipeline
+	return repo, pipeline, hook.GetBefore(), hook.GetHeadCommit().GetID()
 }
 
 // parseDeployHook parses a deployment and returns the Repo and Pipeline details.
@@ -253,15 +253,4 @@ func parseReleaseHook(hook *github.ReleaseEvent) (*model.Repo, *model.Pipeline) 
 	}
 
 	return convertRepo(hook.GetRepo()), pipeline
-}
-
-func getChangedFilesFromCommits(commits []*github.HeadCommit) []string {
-	// assume a capacity of 4 changed files per commit
-	files := make([]string, 0, len(commits)*4)
-	for _, cm := range commits {
-		files = append(files, cm.Added...)
-		files = append(files, cm.Removed...)
-		files = append(files, cm.Modified...)
-	}
-	return utils.DeduplicateStrings(files)
 }

--- a/server/forge/github/parse_test.go
+++ b/server/forge/github/parse_test.go
@@ -48,7 +48,9 @@ func testHookRequest(payload []byte, event string) *http.Request {
 func Test_parseHook(t *testing.T) {
 	t.Run("ignore unsupported hook events", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequest), "issues")
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.Nil(t, r)
 		assert.Nil(t, b)
 		assert.Nil(t, p)
@@ -57,7 +59,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("skip skip push hook when action is deleted", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPushDeleted), hookPush)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.Nil(t, r)
 		assert.Nil(t, b)
 		assert.NoError(t, err)
@@ -65,7 +69,9 @@ func Test_parseHook(t *testing.T) {
 	})
 	t.Run("push hook", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPush), hookPush)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.Nil(t, p)
 		assert.NotNil(t, r)
@@ -77,7 +83,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("PR hook", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequest), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -86,7 +94,9 @@ func Test_parseHook(t *testing.T) {
 	})
 	t.Run("PR closed hook", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestClosed), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -96,7 +106,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("reopen a pull", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestReopened), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -106,7 +118,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("PR merged hook", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestMerged), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -116,7 +130,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("PR edited hook", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestEdited), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -127,7 +143,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("deploy hook", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookDeploy), hookDeploy)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -139,7 +157,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("release hook", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookRelease), hookRelease)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -151,7 +171,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("pull review requested", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestReviewRequested), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.ErrorIs(t, err, &types.ErrIgnoreEvent{})
 		assert.Nil(t, r)
 		assert.Nil(t, b)
@@ -160,7 +182,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("pull milestoned", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestMilestoneAdded), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -207,7 +231,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("pull request demilestoned", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestMilestoneRemoved), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -242,7 +268,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("pull request labele added", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestLabelAdded), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -292,7 +320,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("pull request got label removed", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestLabelRemoved), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -326,7 +356,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("pull request got all label removed", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestLabelsCleared), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -355,7 +387,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("pull request assigned", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestAssigneeAdded), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)
@@ -398,7 +432,9 @@ func Test_parseHook(t *testing.T) {
 
 	t.Run("pull request unassigned", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestAssigneeRemoved), hookPull)
-		p, r, b, err := parseHook(req, false)
+		p, r, b, cb, ca, err := parseHook(req, false)
+		assert.Equal(t, "commit before TODO", cb)
+		assert.Equal(t, "commit after TODO", ca)
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.NotNil(t, b)


### PR DESCRIPTION
as:
```
// GitHub has removed commit summaries from Events API payloads from 7th October 2025 onwards.
```

we need to query

# WIP because:
not tested just coded and documentation read