### PR TITLE
chore(deps): drop `github.com/gorilla/securecookie`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -173,7 +173,6 @@
     "Rydzewski",
     "seccomp",
     "secprofile",
-    "securecookie",
     "selfhosted",
     "sess",
     "shellescape",

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -159,7 +159,7 @@ linters:
         - time.*
         - strings.Split
         - callerName
-        - securecookie.GenerateRandomKey
+        - random.GetRandomBytes
     revive:
       rules:
         - name: var-naming

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/securecookie"
+	"github.com/google/tink/go/subtle/random"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v3"
 
@@ -136,7 +136,7 @@ func setupJWTSecret(_store store.Store) (string, error) {
 	jwtSecret, err := _store.ServerConfigGet(jwtSecretID)
 	if errors.Is(err, types.RecordNotExist) {
 		jwtSecret := base32.StdEncoding.EncodeToString(
-			securecookie.GenerateRandomKey(32),
+			random.GetRandomBytes(32),
 		)
 		err = _store.ServerConfigSet(jwtSecretID, jwtSecret)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/go-github/v74 v74.0.0
 	github.com/google/tink/go v1.7.0
-	github.com/gorilla/securecookie v1.1.2
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/jellydator/ttlcache/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,6 @@ github.com/google/go-github/v74 v74.0.0/go.mod h1:ubn/YdyftV80VPSI26nSJvaEsTOnsj
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
@@ -271,8 +269,6 @@ github.com/google/tink/go v1.7.0/go.mod h1:GAUOd+QE3pgj9q8VKIGTCP33c/B7eb4NhxLcg
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
-github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/server/api/login.go
+++ b/server/api/login.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/securecookie"
+	"github.com/google/tink/go/subtle/random"
 	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
@@ -168,7 +168,7 @@ func HandleAuth(c *gin.Context) {
 			Email:         userFromForge.Email,
 			Avatar:        userFromForge.Avatar,
 			Hash: base32.StdEncoding.EncodeToString(
-				securecookie.GenerateRandomKey(32),
+				random.GetRandomBytes(32),
 			),
 		}
 

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/securecookie"
+	"github.com/google/tink/go/subtle/random"
 	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
@@ -115,7 +115,7 @@ func PostRepo(c *gin.Context) {
 
 	if repo.Hash == "" {
 		repo.Hash = base32.StdEncoding.EncodeToString(
-			securecookie.GenerateRandomKey(32),
+			random.GetRandomBytes(32),
 		)
 	}
 

--- a/server/api/user.go
+++ b/server/api/user.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/securecookie"
+	"github.com/google/tink/go/subtle/random"
 	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
@@ -201,7 +201,7 @@ func DeleteToken(c *gin.Context) {
 
 	user := session.User(c)
 	user.Hash = base32.StdEncoding.EncodeToString(
-		securecookie.GenerateRandomKey(32),
+		random.GetRandomBytes(32),
 	)
 	if err := _store.UpdateUser(user); err != nil {
 		c.String(http.StatusInternalServerError, "Error revoking tokens. %s", err)

--- a/server/api/users.go
+++ b/server/api/users.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/securecookie"
+	"github.com/google/tink/go/subtle/random"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	"go.woodpecker-ci.org/woodpecker/v3/server/router/middleware/session"
@@ -130,7 +130,7 @@ func PostUser(c *gin.Context) {
 		Email:  in.Email,
 		Avatar: in.Avatar,
 		Hash: base32.StdEncoding.EncodeToString(
-			securecookie.GenerateRandomKey(32),
+			random.GetRandomBytes(32),
 		),
 		ForgeID:       1,                        // TODO: replace with forge id when multiple forges are supported
 		ForgeRemoteID: model.ForgeRemoteID("0"), // TODO: search for the user in the forge and get the remote id

--- a/server/model/agent.go
+++ b/server/model/agent.go
@@ -18,7 +18,7 @@ import (
 	"encoding/base32"
 	"fmt"
 
-	"github.com/gorilla/securecookie"
+	"github.com/google/tink/go/subtle/random"
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline"
 )
@@ -56,7 +56,7 @@ func (a *Agent) IsSystemAgent() bool {
 }
 
 func GenerateNewAgentToken() string {
-	return base32.StdEncoding.EncodeToString(securecookie.GenerateRandomKey(32))
+	return base32.StdEncoding.EncodeToString(random.GetRandomBytes(32))
 }
 
 func (a *Agent) GetServerLabels() (map[string]string, error) {


### PR DESCRIPTION
This dependency was only used to get random bytes, this utility is also provided by the tink library that is currently imported. No need for a separate dependency that is not being used for its main goal.
