### PR TITLE
Add deployment target suggestions from pipeline configuration

### DIFF
--- a/web/src/components/layout/popups/DeployPipelinePopup.vue
+++ b/web/src/components/layout/popups/DeployPipelinePopup.vue
@@ -40,9 +40,9 @@
 </template>
 
 <script lang="ts" setup>
+import { decode } from 'js-base64';
 import { computed, onMounted, ref, toRef } from 'vue';
 import { useRouter } from 'vue-router';
-import { decode } from 'js-base64';
 
 import Button from '~/components/atomic/Button.vue';
 import InputField from '~/components/form/InputField.vue';
@@ -68,24 +68,25 @@ const router = useRouter();
 
 const pipelineConfigs = requiredInject('pipeline-configs');
 
-const decodedConfigs = computed(() =>
-  pipelineConfigs.value?.map((config) => ({
-    ...config,
-    data: decode(config.data), // Decode base64 to readable YAML
-  })) ?? []
+const decodedConfigs = computed(
+  () =>
+    pipelineConfigs.value?.map((config) => ({
+      ...config,
+      data: decode(config.data), // Decode base64 to readable YAML
+    })) ?? [],
 );
 
 // Extract CI_PIPELINE_DEPLOY_TARGET values
 const deployTargetsFromConfigs = computed(() => {
   const targets = new Set<string>();
 
-  decodedConfigs.value.forEach(config => {
+  decodedConfigs.value.forEach((config) => {
     const yamlContent = config.data;
     // Look for evaluate: CI_PIPELINE_DEPLOY_TARGET == "somevalue" patterns
     const targetMatches = yamlContent.match(/CI_PIPELINE_DEPLOY_TARGET\s*==\s*["']([^"']+)["']/g);
 
     if (targetMatches) {
-      targetMatches.forEach(match => {
+      targetMatches.forEach((match) => {
         // Extract the value between quotes
         const valueMatch = match.match(/["']([^"']+)["']/);
         if (valueMatch && valueMatch[1]) {
@@ -99,9 +100,9 @@ const deployTargetsFromConfigs = computed(() => {
 });
 
 const deployTargetOptions = computed(() => {
-  return deployTargetsFromConfigs.value.map(target => ({
+  return deployTargetsFromConfigs.value.map((target) => ({
     value: target,
-    text: target
+    text: target,
   }));
 });
 


### PR DESCRIPTION
### Add deployment target suggestions from pipeline configurations
This PR enhances the deploy pipeline popup by extracting deployment targets from pipeline 
configurations and presenting them as suggestions to users.

### Changes

- Auto-discovery: Parses pipeline YAML files to find CI_PIPELINE_DEPLOY_TARGET values used in conditional expressions

- Smart input: TextField now supports both typing custom values and selecting from discovered targets via HTML datalist

- Better UX: Users can see available deployment targets without having to remember or check pipeline configs manually

### Technical Details

- Extracts targets from patterns like CI_PIPELINE_DEPLOY_TARGET == "production"

- Base64 decodes pipeline configs to parse YAML content

<img width="657" height="403" alt="Skærmbillede 2025-10-08 kl  19 12 40" src="https://github.com/user-attachments/assets/e90b5055-ce45-4bd1-9e02-dfc91ca1c4fa" />
<img width="657" height="403" alt="Skærmbillede 2025-10-08 kl  19 21 47" src="https://github.com/user-attachments/assets/e51dbec7-b367-435e-bfe8-bca4709ecb18" />
