### PR TITLE
fix(bitbucketdatacenter): prevent adding new repos with empty branch

### DIFF
--- a/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
@@ -16,6 +16,7 @@ package bitbucketdatacenter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -200,6 +201,10 @@ func (c *client) Repo(ctx context.Context, u *model.User, rID model.ForgeRemoteI
 	b, _, err := bc.Projects.GetDefaultBranch(ctx, repo.Project.Key, repo.Slug)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch default branch: %w", err)
+	}
+
+	if b.DisplayID == "" {
+		return nil, errors.New("default branch setting does not exist")
 	}
 
 	perms := &model.Perm{Pull: true, Push: true}


### PR DESCRIPTION
# Problem

We encountered a scenario where users created a Woodpecker CI repository when the corresponding Bitbucket repository was empty (no commits, no branches). This causes Woodpecker to persist an empty branch name for the repo, as Bitbucket returns an empty default branch for repositories with no commits, and Woodpecker never updates this value later.

Once users start adding content to their Bitbucket repository and attempt to run Woodpecker CI builds, the builds fail with a cryptic error: *"name is not a valid kubernetes DNS name"*. After debugging, we discovered this was caused by Woodpecker attempting to attach the `woodpecker-ci.org/branch` label with an empty string value to Kubernetes pods, which violates Kubernetes naming constraints and is not supported.

This creates a difficult debugging experience for users, as the error message doesn't clearly indicate the root cause is an empty branch name persisted during initial repository setup.

# Solution

This pull request adds a simple validation check in the Bitbucket Data Center forge implementation:

```go
if b.DisplayID == "" {
    return nil, errors.New("default branch setting does not exist")
}
```

When the default branch (`DisplayID`) is empty, the repository creation fails early with a clear error message instead of persisting invalid data. This prevents the downstream Kubernetes pod creation issues and provides users with a more understandable error that indicates the repository needs to have at least one branch before it can be added to Woodpecker CI.