### PR TITLE
Also create image preview on label change only

### DIFF
--- a/.woodpecker/docker.yaml
+++ b/.woodpecker/docker.yaml
@@ -307,15 +307,15 @@ steps:
   # C L I #
   #########
 
-  build-cli-preview:
+  build-cli-alpine-preview:
     depends_on:
       - vendor
     image: *buildx_plugin
     settings:
       repo: woodpeckerci/woodpecker-cli
-      dockerfile: docker/Dockerfile.cli.multiarch.rootless
+      dockerfile: docker/Dockerfile.cli.alpine.multiarch.rootless
       platforms: *platforms_preview
-      tag: pull_${CI_COMMIT_PULL_REQUEST}
+      tag: pull_${CI_COMMIT_PULL_REQUEST}-alpine
       build_args: *build_args
       logins: *publish_logins
     when: *when-preview


### PR DESCRIPTION
currently you have to push to a pull after you added the label to get a preview image.
this changes it by also create a preview on adding the preview label alone

example: https://ci.woodpecker-ci.org/repos/3780/pipeline/29226