### PR TITLE
feature: enhancement of the log stream operation

### DIFF
--- a/pipeline/log/utils_test.go
+++ b/pipeline/log/utils_test.go
@@ -71,7 +71,7 @@ func TestCopyLineByLine(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Wait until no writes have occurred (should be immediate)
+	// wait until no writes have occurred (should be immediate)
 	assert.Eventually(t, func() bool {
 		return len(testWriter.GetWrites()) == 0
 	}, time.Second, 5*time.Millisecond, "expected 0 writes after first write")
@@ -81,7 +81,7 @@ func TestCopyLineByLine(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Wait until two writes have occurred
+	// wait until two writes have occurred
 	assert.Eventually(t, func() bool {
 		return len(testWriter.GetWrites()) == 2
 	}, time.Second, 5*time.Millisecond, "expected 2 writes after second write")
@@ -93,7 +93,7 @@ func TestCopyLineByLine(t *testing.T) {
 	// closing the writer should flush the remaining data
 	w.Close()
 
-	// Wait for the goroutine to finish
+	// wait for the goroutine to finish
 	select {
 	case <-done:
 	case <-time.After(time.Second):


### PR DESCRIPTION
issue: #5646 

read the log stream from cache while it has '\n' in the stream byte.

For the most of log byte less than 1024 in a row, directly write into, otherwise chunk writing. (slightly enhancement in reducing the function calling)

I was try to use the condition combination:
1. max_size variable 
2. reach '\n' character
to define whether it should be write to dist.
the following code would be the trying.

```go
func CopyLineByLine(dst io.Writer, src io.Reader, maxSize int) error {
	r := bufio.NewReaderSize(src, maxSize)
	buf := make([]byte, maxSize)

	for {
		// read up to maxSize bytes or until newline, whichever comes first
		n, err := readUntilNewlineOrMax(r, buf)

		if n > 0 {
			if err := writeChunks(dst, buf[:n], maxSize); err != nil {
				return err
			}
		}

		if errors.Is(err, io.EOF) {
			break
		} else if err != nil {
			return err
		}
	}
	return nil
}

// readUntilNewlineOrMax reads data from the reader up to maxSize bytes or until
// a newline is encountered, whichever comes first. This allows for more responsive
// log streaming by not blocking indefinitely waiting for newlines.
//
// The strategy is:
// 1. if a newline is found in buffered data, read up to and including it
// 2. if line is longer than maxSize, read maxSize bytes
// 3. if no newline and buffer is empty, block to read at least one byte
// 4. after blocking read, check if more data arrived and look for newline
func readUntilNewlineOrMax(r *bufio.Reader, buf []byte) (int, error) {
	maxSize := len(buf)

	// peek at all buffered data to check for newline
	buffered := r.Buffered()
	if buffered > maxSize {
		buffered = maxSize
	}

	// having data
	if buffered > 0 {
		peek, err := r.Peek(buffered)
		if err != nil && !errors.Is(err, bufio.ErrBufferFull) {
			// non buffer full error, return error
			if !errors.Is(err, io.EOF) {
				return 0, err
			}
		}

		// look for newline in peeked data
		for i := 0; i < len(peek); i++ {
			if peek[i] == '\n' {
				// Found newline - read up to and including it
				return r.Read(buf[:i+1])
			}
		}

		// no newline found - check if we should read anyway
		// only read if: buffer is full (maxSize reached) or we hit EOF
		if len(peek) >= maxSize {
			// Line is too long, read maxSize bytes
			return r.Read(buf[:maxSize])
		}

		// no newline and haven't hit maxSize - don't read yet,
		// wait for more data (might get a newline)
		// fall through to blocking read
	}

	// no buffered data or waiting for more data - do a blocking read
	return blockUntilNewData(r, buf)
}

func blockUntilNewData(r *bufio.Reader, buf []byte) (int, error) {
	maxSize := len(buf)
	// no buffered data and then do a blocking read to wait for new data and to get at least one byte
	b, err := r.ReadByte()
	if err != nil {
		return 0, err
	}
	buf[0] = b

	// if we got a newline, return immediately
	if b == '\n' {
		return 1, nil
	}

	// else, try to read more data if available (non-blocking check)
	bytesRead := 1
	buffered := r.Buffered()
	// more data is available, read it
	if buffered > 0 {
		toRead := buffered
		if bytesRead+toRead > maxSize {
			toRead = maxSize - bytesRead
		}

		peek, err := r.Peek(toRead)
		if err != nil && !errors.Is(err, bufio.ErrBufferFull) && !errors.Is(err, io.EOF) {
			return bytesRead, err
		}

		// check for newline in the additional data
		for i := 0; i < len(peek) && i < toRead; i++ {
			if peek[i] == '\n' {
				n, err := r.Read(buf[bytesRead : bytesRead+i+1])
				return bytesRead + n, err
			}
		}

		// no newline, read all available data
		// n, err := r.Read(buf[bytesRead : bytesRead+toRead])
		// return bytesRead + n, err
	}

	return bytesRead, nil
}
```

the frustrated thing would be I realize if it not reach the '\n' character, the function would be a infinite loop and burn the CPU.

if we do uncomment these row of code,

```go
// no newline, read all available data
n, err := r.Read(buf[bytesRead : bytesRead+toRead])
return bytesRead + n, err
```

it would be fine because each time of iteration would write something into the dist and if no data the .ReadByte() function will block the function to prevent the infinite loop in calling function by the infinite loop operation happening in the OS kernel level.

But in this way, it has highly chance that would be byte to byte to write into the dist if the cache are having value so fast. 

My tentatively thinking would be maybe we can try to replace the code in 

```go
// no newline, read all available data
n, err := r.Read(buf[bytesRead : bytesRead+toRead])
return bytesRead + n, err
```

by temporally save into the application level cache, so that we have system level cache and application level cache, the application level cache can be the buffer. And then conditional judgement can happen in the buffer.  How do you think so?



