### PR TITLE
Create GitHub forge via WebUI fails to be loaded

### DIFF
--- a/server/forge/setup/setup.go
+++ b/server/forge/setup/setup.go
@@ -127,15 +127,9 @@ func setupGitLab(forge *model.Forge) (forge.Forge, error) {
 }
 
 func setupGitHub(forge *model.Forge) (forge.Forge, error) {
-	mergeRef, ok := forge.AdditionalOptions["merge-ref"].(bool)
-	if !ok {
-		return nil, fmt.Errorf("missing merge-ref")
-	}
-
-	publicOnly, ok := forge.AdditionalOptions["public-only"].(bool)
-	if !ok {
-		return nil, fmt.Errorf("missing public-only")
-	}
+	// get additional config and be false by default
+	mergeRef, _ := forge.AdditionalOptions["merge-ref"].(bool)
+	publicOnly, _ := forge.AdditionalOptions["public-only"].(bool)
 
 	opts := github.Opts{
 		URL:               forge.URL,


### PR DESCRIPTION
if you dont checked the optional checkboxes in the database `null` is stored.
this will let the github forge fail till you enabled and disabled both optinal options.

this pull fixes it by make use the default (false) if option could not be found