### PR TITLE
Fix nil pointer dereference during GitHub Hook parsing

### DIFF
--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -633,7 +633,7 @@ func (c *client) Hook(ctx context.Context, r *http.Request) (*model.Repo, *model
 		if err != nil {
 			return nil, nil, err
 		}
-	} else if pipeline.Event == model.EventPush {
+	} else if pipeline != nil && pipeline.Event == model.EventPush {
 		// GitHub has removed commit summaries from Events API payloads from 7th October 2025 onwards.
 		pipeline, err = c.loadChangedFilesFromCommits(ctx, repo, pipeline, prevCommit, currCommit)
 		if err != nil {


### PR DESCRIPTION
close https://github.com/woodpecker-ci/woodpecker/issues/5680
regression of  #5618