### PR TITLE
Fix so agents don't need to specify a required label twice

### DIFF
--- a/server/grpc/filter.go
+++ b/server/grpc/filter.go
@@ -50,7 +50,11 @@ func createFilterFunc(agentFilter rpc.Filter) queue.FilterFn {
 			// all task labels are required to be present for an agent to match
 			agentLabelValue, ok := agentFilter.Labels[taskLabel]
 			if !ok {
-				return false, 0
+				// Check for required label
+				agentLabelValue, ok = agentFilter.Labels["!"+taskLabel]
+				if !ok {
+					return false, 0
+				}
 			}
 
 			switch agentLabelValue {

--- a/server/grpc/filter_test.go
+++ b/server/grpc/filter_test.go
@@ -119,6 +119,17 @@ func TestCreateFilterFunc(t *testing.T) {
 			wantMatched: true,
 			wantScore:   2,
 		},
+		{
+			name: "Required label matches without shebang",
+			agentFilter: rpc.Filter{
+				Labels: map[string]string{"!org-id": "123", "platform": "linux", "extra": "value"},
+			},
+			task: &model.Task{
+				Labels: map[string]string{"org-id": "123", "platform": "linux", "empty": ""},
+			},
+			wantMatched: true,
+			wantScore:   20,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
My initial implementation of this was a bit suboptimal, as the agent would need to specify a required label like `!foo=req,foo=req`. This fixes so `!foo=req` is enough to be picked up by the agent.

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
