### PR TITLE
feat(agent): log agent version on startup

### DIFF
--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -65,7 +65,7 @@ var (
 )
 
 func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
-	log.Info().Msgf("Starting Woodpecker agent version: %s", version.Version)
+	log.Info().Str("version", version.Version).Msg("Starting Woodpecker agent")
 
 	agentCtx, ctxCancel := context.WithCancelCause(ctx)
 	stopAgentFunc = func(err error) {


### PR DESCRIPTION
Logs the agent version at startup using zerolog for better traceability and debugging.

Only modifies `cmd/agent/core/agent.go` as requested. No changes to other files.

Let me know if you'd like to adjust the log level, format, or placement.