### PR TITLE
Fix badge label padding

### DIFF
--- a/web/src/components/atomic/Badge.vue
+++ b/web/src/components/atomic/Badge.vue
@@ -2,7 +2,7 @@
   <span class="inline-flex items-center text-xs font-medium">
     <span
       v-if="label"
-      class="border-wp-state-neutral-100 bg-wp-state-neutral-100 rounded-l-full border-1 py-0.5 pl-2 pr-1 whitespace-nowrap text-white"
+      class="border-wp-state-neutral-100 bg-wp-state-neutral-100 rounded-l-full border-1 py-0.5 pr-1 pl-2 whitespace-nowrap text-white"
       :class="{
         'rounded-r-full pr-2': !value,
       }"


### PR DESCRIPTION
just a mini UI issue.

before:
<img width="137" height="22" alt="Screenshot 2025-11-06 at 16-48-53 Agenten · Einstellungen · Woodpecker" src="https://github.com/user-attachments/assets/197c0a29-9745-4bde-acdb-4d2661f79e5b" />

after:
<img width="141" height="22" alt="Screenshot 2025-11-06 at 16-48-43 Agenten · Einstellungen · Woodpecker" src="https://github.com/user-attachments/assets/6815f99f-58f5-410d-9f8a-a1c5d6486043" />
