### PR TITLE
Fix version string in log

### DIFF
--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -65,7 +65,7 @@ var (
 )
 
 func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
-	log.Info().Str("version", version.Version).Msg("Starting Woodpecker agent")
+	log.Info().Str("version", version.String()).Msg("Starting Woodpecker agent")
 
 	agentCtx, ctxCancel := context.WithCancelCause(ctx)
 	stopAgentFunc = func(err error) {


### PR DESCRIPTION
regression of #5724. Forgot that we have to use `version.String()` to correctly work with dev versions.