### PR TITLE
feat: include CI_COMMIT_TAG env in deployment events

### DIFF
--- a/pipeline/frontend/metadata/environment.go
+++ b/pipeline/frontend/metadata/environment.go
@@ -97,7 +97,7 @@ func (m *Metadata) Environ() map[string]string {
 	setNonEmptyEnvVar(params, "CI_COMMIT_AUTHOR", commit.Author.Name)
 	setNonEmptyEnvVar(params, "CI_COMMIT_AUTHOR_EMAIL", commit.Author.Email)
 	setNonEmptyEnvVar(params, "CI_COMMIT_AUTHOR_AVATAR", commit.Author.Avatar)
-	if pipeline.Event == EventTag || pipeline.Event == EventRelease || strings.HasPrefix(pipeline.Commit.Ref, "refs/tags/") {
+	if pipeline.Event == EventTag || pipeline.Event == EventRelease || pipeline.Event == EventDeploy || strings.HasPrefix(pipeline.Commit.Ref, "refs/tags/") {
 		setNonEmptyEnvVar(params, "CI_COMMIT_TAG", strings.TrimPrefix(pipeline.Commit.Ref, "refs/tags/"))
 	}
 	if pipeline.Event == EventRelease {


### PR DESCRIPTION
# Problem

Bitbucket Data Center does not support [`release` events](https://woodpecker-ci.org/docs/next/administration/configuration/forges/overview), forcing workflows to rely on `deployment` events instead. Currently, the `CI_COMMIT_TAG` environment variable is not populated for deployment events, which prevents our teams using Woodpecker CI from successfully running tag-based deployment pipelines.

# Solution

Updated the logic to apply for `deployment` as well to ensure that `CI_COMMIT_TAG` is correctly populated when the pipeline is triggered by a `deployment` event for tags, enabling tag-based deployments for Bitbucket Data Center forge users.