### PR TITLE
Add create event to GitHub webhook subscription

### DIFF
--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -574,6 +574,7 @@ func (c *client) Activate(ctx context.Context, u *model.User, r *model.Repo, lin
 			"pull_request",
 			"pull_request_review",
 			"deployment",
+			"create",
 		},
 		Config: &github.HookConfig{
 			URL:         &link,


### PR DESCRIPTION
## Problem

Currently, when Woodpecker activates a GitHub repository, it only subscribes to the following webhook events:
- push
- pull_request
- pull_request_review
- deployment

This means that tag-based pipelines (configured with `when: event: tag`) do not trigger automatically when tags are pushed to the repository.

## Root Cause

GitHub sends two types of events for tags:
1. **create event** - Triggered when a branch or tag is created
2. **push event** - Triggered for commits (but may not reliably trigger for tags in all scenarios)

Tag-based pipelines in Woodpecker rely on the `create` event from GitHub, but Woodpecker doesn't subscribe to this event when creating webhooks.

## Solution

This PR adds the `create` event to the webhook subscription list in the GitHub forge implementation.

## Impact

- Tag-based pipelines will now trigger automatically when tags are pushed
- No breaking changes - this only adds an additional event subscription
- Users will no longer need to manually add the `create` event to their webhook configuration

## Testing

The change was tested by:
1. Creating a tag-based pipeline configuration
2. Pushing a tag to the repository
3. Verifying that the pipeline triggers automatically