### PR TITLE
Clarify envvars documentation

### DIFF
--- a/docs/docs/20-usage/90-advanced-usage.md
+++ b/docs/docs/20-usage/90-advanced-usage.md
@@ -114,7 +114,7 @@ steps:
   - name: debug
     image: bash
     commands:
-      - source envvars
+      - source ./envvars
       - echo $FOO
 ```
 

--- a/docs/versioned_docs/version-2.8/20-usage/90-advanced-usage.md
+++ b/docs/versioned_docs/version-2.8/20-usage/90-advanced-usage.md
@@ -114,7 +114,7 @@ steps:
   - name: debug
     image: bash
     commands:
-      - source envvars
+      - source ./envvars
       - echo $FOO
 ```
 

--- a/docs/versioned_docs/version-3.10/20-usage/90-advanced-usage.md
+++ b/docs/versioned_docs/version-3.10/20-usage/90-advanced-usage.md
@@ -114,7 +114,7 @@ steps:
   - name: debug
     image: bash
     commands:
-      - source envvars
+      - source ./envvars
       - echo $FOO
 ```
 

--- a/docs/versioned_docs/version-3.11/20-usage/90-advanced-usage.md
+++ b/docs/versioned_docs/version-3.11/20-usage/90-advanced-usage.md
@@ -114,7 +114,7 @@ steps:
   - name: debug
     image: bash
     commands:
-      - source envvars
+      - source ./envvars
       - echo $FOO
 ```
 

--- a/docs/versioned_docs/version-3.12/20-usage/90-advanced-usage.md
+++ b/docs/versioned_docs/version-3.12/20-usage/90-advanced-usage.md
@@ -114,7 +114,7 @@ steps:
   - name: debug
     image: bash
     commands:
-      - source envvars
+      - source ./envvars
       - echo $FOO
 ```
 


### PR DESCRIPTION
Not all shells will load a file from the local path if they're not prefixed with `./` to make it explicit. In those cases, the shell will report that the file doesn't exist, while loading it without issue if the `./` is prepended.

I experienced this issue with `quay.io/containers/buildah:v1.42.1-immutable`:

```text
sh-5.3# sh --version
GNU bash, version 5.3.0(1)-release (x86_64-redhat-linux-gnu)
Copyright (C) 2025 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

sh-5.3# cat /etc/os-release
NAME="Fedora Linux"
VERSION="43 (Container Image)"
RELEASE_TYPE=stable
ID=fedora
VERSION_ID=43
VERSION_CODENAME=""
PRETTY_NAME="Fedora Linux 43 (Container Image)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:43"
DEFAULT_HOSTNAME="fedora"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f43/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=43
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=43
SUPPORT_END=2026-12-02
VARIANT="Container Image"
VARIANT_ID=container
```

How to reproduce:

```
docker run --rm --user build -it quay.io/containers/buildah:v1.42.1-immutable sh
sh-5.3$ echo "FOO=bar" >> envvars
sh-5.3$ cat envvars
FOO=bar
sh-5.3$ source envvars
sh: source: envvars: file not found
sh-5.3$ source ./envvars
sh-5.3$ echo $FOO
bar
```