### PR TITLE
fix: Reintroduce stop all pods on workflow

### DIFF
--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -455,6 +455,15 @@ func (e *kube) DestroyStep(ctx context.Context, step *types.Step, taskUUID strin
 func (e *kube) DestroyWorkflow(ctx context.Context, conf *types.Config, taskUUID string) error {
 	log.Trace().Str("taskUUID", taskUUID).Msg("deleting Kubernetes primitives")
 
+	for _, stage := range conf.Stages {
+		for _, step := range stage.Steps {
+			err := stopPod(ctx, e, step, defaultDeleteOptions)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	namespace := e.config.GetNamespace(conf.Stages[0].Steps[0].OrgID)
 
 	log.Trace().Str("taskUUID", taskUUID).Msgf("deleting workflow headless service")


### PR DESCRIPTION
As part of the headless services #5764 I removed a few to many lines when destroying the workflow, so all running pods is no longer stopped when halting the workflow, I reintroduce the required lines in the PR.