### PR TITLE
Allow untrusted repo to still drop network for steps

### DIFF
--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -87,16 +87,6 @@ steps:
     <<: *base-step
     image: golang:latest
 `,
-	}, {
-		Title: "allow network mode none", Data: `
-when:
-  event: push
-steps:
-  ping:
-    image: bash
-    commands: ping example.com
-    network_mode: none
-`,
 	}}
 
 	for _, testd := range testdatas {


### PR DESCRIPTION
as it is an undocumented feature this might change / move into a more generalized backend network option at some point ...

but i think we could at least support it as proposed in this patch meanwhile