### PR TITLE
Make disabled checkboxes match overall style

### DIFF
--- a/web/src/components/atomic/Button.vue
+++ b/web/src/components/atomic/Button.vue
@@ -2,9 +2,9 @@
   <component
     :is="to === undefined ? 'button' : httpLink ? 'a' : 'router-link'"
     v-bind="btnAttrs"
-    class="border-wp-background-400 dark:border-wp-background-100 relative flex shrink-0 cursor-pointer items-center overflow-hidden rounded-md border px-2 py-1 whitespace-nowrap transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-50"
+    class="border-wp-control-neutral-200 relative flex shrink-0 cursor-pointer items-center overflow-hidden rounded-md border px-2 py-1 whitespace-nowrap transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-50"
     :class="{
-      'border-wp-control-neutral-300 dark:border-wp-background-100 bg-wp-control-neutral-100 text-wp-text-100 hover:bg-wp-control-neutral-200':
+      'border-wp-control-neutral-200 bg-wp-control-neutral-100 text-wp-text-100 hover:bg-wp-control-neutral-200':
         color === 'gray',
       'border-wp-control-ok-300 bg-wp-control-ok-100 hover:bg-wp-control-ok-200 text-white': color === 'green',
       'border-wp-control-info-300 bg-wp-control-info-100 hover:bg-wp-control-info-200 text-white': color === 'blue',

--- a/web/src/components/form/Checkbox.vue
+++ b/web/src/components/form/Checkbox.vue
@@ -3,7 +3,7 @@
     <input
       :id="`checkbox-${id}`"
       type="checkbox"
-      class="checkbox border-wp-control-neutral-200 dark:border-wp-control-neutral-300 disabled:border-wp-control-neutral-200 dark:disabled:border-wp-control-neutral-300 disabled:bg-wp-control-neutral-100 dark:disabled:bg-wp-control-neutral-200 checked:border-wp-control-ok-200 checked:bg-wp-control-ok-200 focus-visible:border-wp-control-neutral-300 checked:focus-visible:border-wp-control-ok-300 relative h-5 w-5 shrink-0 cursor-pointer rounded-md border transition-colors duration-150"
+      class="checkbox border-wp-control-neutral-200 disabled:border-wp-control-neutral-200 disabled:bg-wp-control-neutral-100 dark:disabled:bg-wp-control-neutral-200 checked:border-wp-control-ok-200 checked:bg-wp-control-ok-200 focus-visible:border-wp-control-neutral-300 checked:focus-visible:border-wp-control-ok-300 relative h-5 w-5 shrink-0 cursor-pointer rounded-md border transition-colors duration-150"
       :checked="innerValue"
       :disabled="disabled || false"
       @click="innerValue = !innerValue"

--- a/web/src/components/form/RadioField.vue
+++ b/web/src/components/form/RadioField.vue
@@ -3,7 +3,7 @@
     <input
       :id="`radio-${id}-${option.value}`"
       type="radio"
-      class="radio border-wp-control-neutral-200 dark:border-wp-control-neutral-300 disabled:border-wp-control-neutral-200 dark:disabled:border-wp-control-neutral-300 disabled:bg-wp-control-neutral-100 dark:disabled:bg-wp-control-neutral-200 checked:border-wp-control-ok-200 checked:bg-wp-control-ok-200 focus-visible:border-wp-control-neutral-300 checked:focus-visible:border-wp-control-ok-300 relative h-5 w-5 shrink-0 cursor-pointer rounded-full border"
+      class="radio border-wp-control-neutral-200 disabled:border-wp-control-neutral-200 disabled:bg-wp-control-neutral-100 dark:disabled:bg-wp-control-neutral-200 checked:border-wp-control-ok-200 checked:bg-wp-control-ok-200 focus-visible:border-wp-control-neutral-300 checked:focus-visible:border-wp-control-ok-300 relative h-5 w-5 shrink-0 cursor-pointer rounded-full border"
       :value="option.value"
       :checked="innerValue?.includes(option.value)"
       :disabled="disabled || false"
@@ -68,7 +68,7 @@ const id = (Math.random() + 1).toString(36).substring(7);
   opacity: 0;
 }
 
-.checkbox:disabled::before {
+.radio:disabled::before {
   border-color: var(--wp-text-alt-100);
 }
 


### PR DESCRIPTION
The color settings were a bit off, especially in dark mode where disabled checkboxes border color was different for the one that were not disabled. Also add disable support for radio buttons as well.


Before:
<img width="1556" height="414" alt="image" src="https://github.com/user-attachments/assets/426567e4-91cd-407c-8088-f20a114c49c2" />

<img width="1556" height="414" alt="image" src="https://github.com/user-attachments/assets/5719a6a1-0d5c-43c2-b7dc-017ef1478237" />

After:
<img width="1556" height="414" alt="image" src="https://github.com/user-attachments/assets/eba45d24-dcf0-4f0f-b237-7028282d5f3a" />

<img width="1556" height="414" alt="image" src="https://github.com/user-attachments/assets/c17240ba-0862-42f6-854a-56a4bd917c33" />