### PR TITLE
fix(datastore): fix pagination bug in workflowsDelete skipping records

### DIFF
--- a/server/store/datastore/workflow.go
+++ b/server/store/datastore/workflow.go
@@ -85,9 +85,9 @@ func (s storage) WorkflowsReplace(pipeline *model.Pipeline, workflows []*model.W
 
 func (s storage) workflowsDelete(sess *xorm.Session, pipelineID int64) error {
 	// delete related steps
-	for startSteps := 0; ; startSteps += perPage {
+	for {
 		stepIDs := make([]int64, 0, perPage)
-		if err := sess.Limit(perPage, startSteps).Table("steps").Cols("id").Where("pipeline_id = ?", pipelineID).Find(&stepIDs); err != nil {
+		if err := sess.Limit(perPage).Table("steps").Cols("id").Where("pipeline_id = ?", pipelineID).Find(&stepIDs); err != nil {
 			return err
 		}
 		if len(stepIDs) == 0 {


### PR DESCRIPTION
### Problem

The `POST /api/repos/{repo_id}/pipelines/{number}/approve` fails when the pipeline contains a large number of steps. This is caused by a logic error in the pagination of the `workflowsDelete` function, which is called via `WorkflowsReplace` during the approval process.

When a pipeline is approved, Woodpecker refreshes its workflow structure. To do this, it attempts to delete all existing steps and workflows associated with the pipeline before inserting the newly generated ones. However, the deletion loop was using an increasing offset while simultaneously removing rows from the database. 

As rows were deleted, the remaining rows "shifted up," but the next iteration of the loop would skip the new first page because it incremented its starting position. This left "ghost" steps in the database, causing the approve to fail with error

```
{"level":"error","error":"pq: duplicate key value violates unique constraint \"UQE_steps_s\"","repo":"<snip>","time":"2025-12-19T06:13:23Z","message":"error persisting new steps for <snip>#187 after approval"}
```

### Solution

This PR fixes the `workflowsDelete` function in `server/store/datastore/workflow.go` to ensure all steps are correctly purged regardless of their quantity.