### PR TITLE
docs: add BunnyCDN Cache Purge Plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -299,6 +299,11 @@
       "name": "Github Comment",
       "docs": "https://raw.githubusercontent.com/yyewolf/woodpecker-plugins/refs/heads/main/github-comment/docs.md",
       "verified": false
+    },
+    {
+      "name": "BunnyCDN Cache Purge",
+      "docs": "https://codeberg.org/bentasker/woodpecker-ci-bunnycdn-cache-flush/raw/branch/main/docs.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
One of the things that I use Woodpecker for is building and deploying static sites.

Most of those live behind BunnyCDN, so I made a plugin to flush the CDNs cache