### PR TITLE
fix: secrets-file flag

### DIFF
--- a/cli/exec/flags.go
+++ b/cli/exec/flags.go
@@ -80,7 +80,7 @@ var flags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_SECRETS_FILE"),
-		Name:    "secrets",
+		Name:    "secrets-file",
 		Usage:   "path to yaml file with secrets map",
 	},
 


### PR DESCRIPTION
there was a typo in #5509, cause secrets-file not loading, 


See comments at https://github.com/woodpecker-ci/woodpecker/pull/5509/changes/BASE..03934826281dd0783e656bfafd3284f32453d2df#r2651885873