### PR TITLE
fix: send correct argument to rpc call for name/url

### DIFF
--- a/server/forge/addon/client.go
+++ b/server/forge/addon/client.go
@@ -67,13 +67,13 @@ type RPC struct {
 
 func (g *RPC) Name() string {
 	var resp string
-	_ = g.client.Call("Plugin.Name", nil, &resp)
+	_ = g.client.Call("Plugin.Name", []byte{}, &resp)
 	return resp
 }
 
 func (g *RPC) URL() string {
 	var resp string
-	_ = g.client.Call("Plugin.URL", nil, &resp)
+	_ = g.client.Call("Plugin.URL", []byte{}, &resp)
 	return resp
 }
 


### PR DESCRIPTION
While working on an addon forge I eventually figured out that my plugin was crashing because gob choked on encoding `nil` rather than `[]byte{}` https://github.com/woodpecker-ci/woodpecker/blob/b65424967ac0d5d7e1bd3b08c96cf10a7b2979e8/server/forge/addon/server.go#L46

I've fixed it for both `Name` and `URL` and my plugin stopped crashing after applying this patch to a local test instance.

/cc @qwerty287 since it relates to addon forges 🙂 