### PR TITLE
Revert repos pagination for GH and BB

### DIFF
--- a/server/forge/bitbucket/bitbucket.go
+++ b/server/forge/bitbucket/bitbucket.go
@@ -181,6 +181,12 @@ func (c *config) Repo(ctx context.Context, u *model.User, remoteID model.ForgeRe
 // Repos returns a list of all repositories for Bitbucket account, including
 // organization repositories.
 func (c *config) Repos(ctx context.Context, u *model.User, p *model.ListOptions) ([]*model.Repo, error) {
+	// we paginate internally (https://github.com/woodpecker-ci/woodpecker/issues/5667)
+	// we merge data from different sources
+	if p.Page != 1 {
+		return nil, nil
+	}
+
 	setListOptions(p)
 
 	client := c.newClient(ctx, u)

--- a/server/forge/bitbucket/parse.go
+++ b/server/forge/bitbucket/parse.go
@@ -31,7 +31,6 @@ const (
 	hookPullUpdated  = "pullrequest:updated"
 	hookPullMerged   = "pullrequest:fulfilled"
 	hookPullDeclined = "pullrequest:rejected"
-	stateOpen        = "OPEN"
 	stateClosed      = "MERGED"
 	stateDeclined    = "DECLINED"
 )

--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -199,10 +199,7 @@ func (g *GitLab) Teams(ctx context.Context, user *model.User, p *model.ListOptio
 		return nil, err
 	}
 
-	perPage := p.PerPage
-	if perPage > defaultPerPage {
-		perPage = defaultPerPage
-	}
+	perPage := min(p.PerPage, defaultPerPage)
 
 	groups, _, err := client.Groups.ListGroups(&gitlab.ListGroupsOptions{
 		ListOptions: gitlab.ListOptions{
@@ -294,10 +291,7 @@ func (g *GitLab) Repos(ctx context.Context, user *model.User, p *model.ListOptio
 		return nil, err
 	}
 
-	perPage := p.PerPage
-	if perPage > defaultPerPage {
-		perPage = defaultPerPage
-	}
+	perPage := min(p.PerPage, defaultPerPage)
 
 	opts := &gitlab.ListProjectsOptions{
 		ListOptions: gitlab.ListOptions{


### PR DESCRIPTION
just like https://github.com/woodpecker-ci/woodpecker/pull/5679 but for github and bitbucket.
BB DC has this already, and for gitlab it's not necessary as nothing is filtered there.

Also added some simple code modernizations.

replaces https://github.com/woodpecker-ci/woodpecker/pull/5890
closes https://github.com/woodpecker-ci/woodpecker/issues/5902