### PR TITLE
Apply background only to required status icons

### DIFF
--- a/web/src/components/repo/pipeline/PipelineStatusIcon.vue
+++ b/web/src/components/repo/pipeline/PipelineStatusIcon.vue
@@ -5,7 +5,7 @@
   >
     <Icon
       :name="service ? 'settings' : `status-${status}`"
-      :bg-circle="true"
+      :bg-circle="['blocked', 'declined', 'error', 'failure', 'killed', 'skipped', 'success'].includes(status)"
       size="1.5rem"
       :class="{
         'text-wp-error-100': pipelineStatusColors[status] === 'red',


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/5948 introduced in https://github.com/woodpecker-ci/woodpecker/pull/5880

Only apply background to status icons that benefit from it. Other status icons that work well without it, as well as service icons, are ignored now.

<img width="876" height="586" alt="image" src="https://github.com/user-attachments/assets/944a15bb-5a9d-46d3-a204-587478b1b02f" />
