### PR TITLE
Dont apply background to service status icons

### DIFF
--- a/web/src/components/repo/pipeline/PipelineStatusIcon.vue
+++ b/web/src/components/repo/pipeline/PipelineStatusIcon.vue
@@ -5,7 +5,7 @@
   >
     <Icon
       :name="service ? 'settings' : `status-${status}`"
-      :bg-circle="['blocked', 'declined', 'error', 'failure', 'killed', 'skipped', 'success'].includes(status)"
+      :bg-circle="shouldShowBgCircle"
       size="1.5rem"
       :class="{
         'text-wp-error-100': pipelineStatusColors[status] === 'red',
@@ -20,6 +20,7 @@
 </template>
 
 <script lang="ts" setup>
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import Icon from '~/components/atomic/Icon.vue';
@@ -27,7 +28,7 @@ import type { PipelineStatus } from '~/lib/api/types';
 
 import { pipelineStatusColors } from './pipeline-status';
 
-defineProps<{
+const { status, service } = defineProps<{
   status: PipelineStatus;
   service?: boolean;
 }>();
@@ -49,4 +50,8 @@ const statusDescriptions = {
   // eslint-disable-next-line no-unused-vars
   [_ in PipelineStatus]: string;
 };
+
+const shouldShowBgCircle = computed(() => {
+  return service ? false : ['blocked', 'declined', 'error', 'failure', 'killed', 'skipped', 'success'].includes(status);
+});
 </script>


### PR DESCRIPTION
Follow-up: https://github.com/woodpecker-ci/woodpecker/pull/5958 Fixes: https://github.com/woodpecker-ci/woodpecker/issues/5948
Don't apply background to status icons for services/detached steps. 

<img width="876" height="586" alt="image" src="https://github.com/user-attachments/assets/719bcb71-2c1a-4ec9-a0f5-236b2bf99498" />
<img width="876" height="586" alt="image" src="https://github.com/user-attachments/assets/dc64d994-05b9-413a-ae69-d900c2b8f486" />
