### PR TITLE
Fix docusaurus md link deprecation

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -321,7 +321,7 @@ const config = {
     hooks: {
       onBrokenMarkdownLinks: 'throw',
       onBrokenMarkdownImages: 'throw',
-    }
+    },
   },
   future: {
     experimental_faster: true,


### PR DESCRIPTION
deprecation in docusaurus 3.9: https://docusaurus.io/blog/releases/3.9#other-changes