### PR TITLE
Use `NoError` for error assertion

### DIFF
--- a/pipeline/frontend/yaml/types/base/slice_test.go
+++ b/pipeline/frontend/yaml/types/base/slice_test.go
@@ -36,7 +36,7 @@ func TestStringOrSliceYaml(t *testing.T) {
 		assert.Equal(t, StringOrSlice{"bar", "baz"}, s.Foo)
 
 		d, err := yaml.Marshal(&s)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		s2 := StructStringOrSlice{}
 		assert.NoError(t, yaml.Unmarshal(d, &s2))


### PR DESCRIPTION
found while reviewing https://github.com/woodpecker-ci/woodpecker/pull/5977