### PR TITLE
fix(agent): workflow runner use shutdown context

### DIFF
--- a/agent/runner.go
+++ b/agent/runner.go
@@ -178,8 +178,8 @@ func (r *Runner) Run(runnerCtx, shutdownCtx context.Context) error {
 	}
 
 	logger.Debug().
-		Bool("canceled", canceled.Load()).
 		Str("error", state.Error).
+		Bool("canceled", canceled.Load()).
 		Msg("workflow finished")
 
 	// Ensure all logs/traces are uploaded before finishing


### PR DESCRIPTION
## What was happening

When a workflow/run was canceled from the UI or API, the server correctly marked the run as Canceled, but the runner machines continued executing job steps.

Specifically:

- The cancel signal was received by the runner
- The workflow state was updated on the server
- Pipeline execution on the runner was not interrupted
- Tests and other long-running steps kept running and consuming runner capacity

This resulted in:

- Wasted compute time
- Runner capacity remaining blocked
- Confusing UX (UI shows Canceled, but jobs keep running)

## Related issue

Closes #5925

## Related PRs

This change complements previous cancellation-related fixes:

- #6018 — fixes container cleanup on step cancellation  
- #6020 — ensures DestroyStep runs on pipeline cancellation

While those PRs focus on step and backend cleanup, this PR ensures that workflow cancellation is properly propagated to the runner execution context.

## What this PR changes

This PR ensures that canceling a workflow immediately stops execution on the runner.

- Propagates server-side cancel events to the runner workflow context
- Cancels the workflow execution context as soon as a cancel signal is received
- Ensures pipeline execution and backend steps are interrupted
- Normalizes cancellation handling so the workflow consistently ends as Canceled

## Why this approach

In Woodpecker, the workflow context is the single source of truth for execution lifecycle.

Previously, receiving a cancel event did not reliably cancel the workflow execution context, allowing pipeline steps to continue running.
By explicitly canceling the workflow context when a cancel signal is received:

- The pipeline runtime receives context.Done()
- Backend implementations (Docker, Kubernetes, etc.) can terminate running steps
- Runner capacity is freed promptly

This aligns runner behavior with what the UI reports and avoids wasted resources.

## Implementation overview

```mermaid
sequenceDiagram
    participant UI as Web UI / API
    participant Server as Woodpecker Server
    participant Runner as Agent Runner
    participant Pipeline as Pipeline Runtime
    participant Backend as Backend Engine

    UI->>Server: Cancel workflow
    Server->>Runner: Cancel signal (Wait)
    Runner->>Runner: cancel workflow context
    Runner->>Pipeline: ctx.Done()
    Pipeline->>Backend: stop execution
    Backend-->>Pipeline: terminate running steps
    Pipeline-->>Runner: execution aborted
    Runner->>Server: report canceled state
```