### PR TITLE
fifo test cleanup changed value

### DIFF
--- a/server/queue/fifo_test.go
+++ b/server/queue/fifo_test.go
@@ -580,6 +580,9 @@ func TestFifoLeaseManagement(t *testing.T) {
 
 	t.Run("lease expiration", func(t *testing.T) {
 		q.extension = 0
+		t.Cleanup(func() {
+			q.extension = 50 * time.Millisecond
+		})
 		dummyTask := &model.Task{ID: "lease-exp-1"}
 		assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{dummyTask}))
 


### PR DESCRIPTION
i hope to not see https://ci.woodpecker-ci.org/repos/3780/pipeline/31058/32 errors again with this

```
--- FAIL: TestFifoLeaseManagement (1.99s)
    --- FAIL: TestFifoLeaseManagement/wait_operations (0.96s)
        fifo_test.go:693: 
            	Error Trace:	/woodpecker/src/github.com/woodpecker-ci/woodpecker/server/queue/fifo_test.go:693
            	Error:      	Received unexpected error:
            	            	queue: task expired
            	Test:       	TestFifoLeaseManagement/wait_operations
```

regression of https://github.com/woodpecker-ci/woodpecker/pull/6017 in test