### PR TITLE
Show cancellation reason in pipeline details

### DIFF
--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -4678,6 +4678,20 @@ const docTemplate = `{
                 }
             }
         },
+        "CancelInfo": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "reason": {
+                    "$ref": "#/definitions/model.CancelReason"
+                }
+            }
+        },
         "Config": {
             "type": "object",
             "properties": {
@@ -4982,8 +4996,8 @@ const docTemplate = `{
                 "branch": {
                     "type": "string"
                 },
-                "cancel_reason": {
-                    "type": "string"
+                "cancel_info": {
+                    "$ref": "#/definitions/CancelInfo"
                 },
                 "changed_files": {
                     "type": "array",
@@ -5995,6 +6009,17 @@ const docTemplate = `{
                 "RequireApprovalForks",
                 "RequireApprovalPullRequests",
                 "RequireApprovalAllEvents"
+            ]
+        },
+        "model.CancelReason": {
+            "type": "string",
+            "enum": [
+                "user_cancel",
+                "superseded"
+            ],
+            "x-enum-varnames": [
+                "CancelReasonUserCancel",
+                "CancelReasonSuperseded"
             ]
         },
         "model.ForgeType": {

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -4982,6 +4982,9 @@ const docTemplate = `{
                 "branch": {
                     "type": "string"
                 },
+                "cancel_reason": {
+                    "type": "string"
+                },
                 "changed_files": {
                     "type": "array",
                     "items": {

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -4681,7 +4681,7 @@ const docTemplate = `{
         "CancelInfo": {
             "type": "object",
             "properties": {
-                "cancel_by_user": {
+                "canceled_by_user": {
                     "type": "string"
                 },
                 "superseded_by": {

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -4681,14 +4681,11 @@ const docTemplate = `{
         "CancelInfo": {
             "type": "object",
             "properties": {
-                "data": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "cancel_by_user": {
+                    "type": "string"
                 },
-                "reason": {
-                    "$ref": "#/definitions/model.CancelReason"
+                "superseded_by": {
+                    "type": "integer"
                 }
             }
         },
@@ -6009,17 +6006,6 @@ const docTemplate = `{
                 "RequireApprovalForks",
                 "RequireApprovalPullRequests",
                 "RequireApprovalAllEvents"
-            ]
-        },
-        "model.CancelReason": {
-            "type": "string",
-            "enum": [
-                "user_cancel",
-                "superseded_by"
-            ],
-            "x-enum-varnames": [
-                "CancelReasonUserCancel",
-                "CancelReasonSuperseded"
             ]
         },
         "model.ForgeType": {

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -6015,7 +6015,7 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "user_cancel",
-                "superseded"
+                "superseded_by"
             ],
             "x-enum-varnames": [
                 "CancelReasonUserCancel",

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -494,7 +494,7 @@ func CancelPipeline(c *gin.Context) {
 	}
 
 	if err := pipeline.Cancel(c, _forge, _store, repo, user, pl, &model.CancelInfo{
-		CancelByUser: user.Login,
+		CanceledByUser: user.Login,
 	}); err != nil {
 		handlePipelineErr(c, err)
 	} else {

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -494,10 +494,7 @@ func CancelPipeline(c *gin.Context) {
 	}
 
 	if err := pipeline.Cancel(c, _forge, _store, repo, user, pl, &model.CancelInfo{
-		Reason: model.CancelReasonUserCancel,
-		Data: map[string]string{
-			"user": user.Login,
-		},
+		CancelByUser: user.Login,
 	}); err != nil {
 		handlePipelineErr(c, err)
 	} else {

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -493,7 +493,7 @@ func CancelPipeline(c *gin.Context) {
 		return
 	}
 
-	if err := pipeline.Cancel(c, _forge, _store, repo, user, pl); err != nil {
+	if err := pipeline.Cancel(c, _forge, _store, repo, user, pl, fmt.Sprintf("Canceled by user %s", user.Login)); err != nil {
 		handlePipelineErr(c, err)
 	} else {
 		c.Status(http.StatusNoContent)

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -493,7 +493,12 @@ func CancelPipeline(c *gin.Context) {
 		return
 	}
 
-	if err := pipeline.Cancel(c, _forge, _store, repo, user, pl, fmt.Sprintf("Canceled by user %s", user.Login)); err != nil {
+	if err := pipeline.Cancel(c, _forge, _store, repo, user, pl, &model.CancelInfo{
+		Reason: model.CancelReasonUserCancel,
+		Data: map[string]string{
+			"user": user.Login,
+		},
+	}); err != nil {
 		handlePipelineErr(c, err)
 	} else {
 		c.Status(http.StatusNoContent)

--- a/server/api/pipeline_test.go
+++ b/server/api/pipeline_test.go
@@ -28,6 +28,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	forge_mocks "go.woodpecker-ci.org/woodpecker/v3/server/forge/mocks"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/pubsub"
 	manager_mocks "go.woodpecker-ci.org/woodpecker/v3/server/services/mocks"
 	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
 	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
@@ -231,5 +232,42 @@ func TestGetPipelineMetadata(t *testing.T) {
 
 			assert.Equal(t, http.StatusNotFound, w.Code)
 		})
+	})
+}
+
+func TestCancelPipeline(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("should cancel running pipeline", func(t *testing.T) {
+		runningPipeline := &model.Pipeline{
+			ID:     2,
+			Number: 2,
+			Status: model.StatusRunning,
+		}
+
+		fakeRepo := &model.Repo{ID: 1}
+		fakeUser := &model.User{Login: "testuser"}
+
+		mockForge := forge_mocks.NewMockForge(t)
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("GetPipelineNumber", fakeRepo, int64(2)).Return(runningPipeline, nil)
+		mockStore.On("WorkflowGetTree", mock.Anything).Return([]*model.Workflow{}, nil)
+		mockStore.On("UpdatePipeline", mock.Anything).Return(nil)
+
+		mockManager := manager_mocks.NewMockManager(t)
+		mockManager.On("ForgeFromRepo", fakeRepo).Return(mockForge, nil)
+		server.Config.Services.Manager = mockManager
+		server.Config.Services.Pubsub = pubsub.New()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Set("store", mockStore)
+		c.Set("repo", fakeRepo)
+		c.Set("user", fakeUser)
+		c.Params = gin.Params{{Key: "number", Value: "2"}}
+
+		CancelPipeline(c)
+
+		assert.Equal(t, http.StatusNoContent, c.Writer.Status())
 	})
 }

--- a/server/model/pipeline.go
+++ b/server/model/pipeline.go
@@ -48,7 +48,7 @@ type Pipeline struct {
 	ForgeURL             string                 `json:"forge_url"               xorm:"forge_url"`
 	Reviewer             string                 `json:"reviewed_by"             xorm:"reviewer"`
 	Reviewed             int64                  `json:"reviewed"                xorm:"reviewed"`
-	CancelReason         string                 `json:"cancel_reason,omitempty" xorm:"cancel_reason"`
+	CancelInfo           *CancelInfo            `json:"cancel_info,omitempty"   xorm:"json 'cancel_info'"`
 	Workflows            []*Workflow            `json:"workflows,omitempty"     xorm:"-"`
 	ChangedFiles         []string               `json:"changed_files,omitempty" xorm:"LONGTEXT 'changed_files'"`
 	AdditionalVariables  map[string]string      `json:"variables,omitempty"     xorm:"json 'additional_variables'"`
@@ -86,3 +86,15 @@ type PipelineOptions struct {
 	Branch    string            `json:"branch"`
 	Variables map[string]string `json:"variables"`
 } //	@name	PipelineOptions
+
+type CancelReason string
+
+const (
+	CancelReasonUserCancel CancelReason = "user_cancel"
+	CancelReasonSuperseded CancelReason = "superseded_by"
+)
+
+type CancelInfo struct {
+	Reason CancelReason      `json:"reason"`
+	Data   map[string]string `json:"data,omitempty"`
+} //	@name	CancelInfo

--- a/server/model/pipeline.go
+++ b/server/model/pipeline.go
@@ -88,6 +88,6 @@ type PipelineOptions struct {
 } //	@name	PipelineOptions
 
 type CancelInfo struct {
-	CancelByUser string `json:"cancel_by_user,omitempty"`
+	CanceledByUser string `json:"canceled_by_user,omitempty"`
 	SupersededBy int64  `json:"superseded_by,omitempty"`
 } //	@name	CancelInfo

--- a/server/model/pipeline.go
+++ b/server/model/pipeline.go
@@ -87,14 +87,7 @@ type PipelineOptions struct {
 	Variables map[string]string `json:"variables"`
 } //	@name	PipelineOptions
 
-type CancelReason string
-
-const (
-	CancelReasonUserCancel CancelReason = "user_cancel"
-	CancelReasonSuperseded CancelReason = "superseded_by"
-)
-
 type CancelInfo struct {
-	Reason CancelReason      `json:"reason"`
-	Data   map[string]string `json:"data,omitempty"`
+	CancelByUser string `json:"cancel_by_user,omitempty"`
+	SupersededBy int64  `json:"superseded_by,omitempty"`
 } //	@name	CancelInfo

--- a/server/model/pipeline.go
+++ b/server/model/pipeline.go
@@ -48,6 +48,7 @@ type Pipeline struct {
 	ForgeURL             string                 `json:"forge_url"               xorm:"forge_url"`
 	Reviewer             string                 `json:"reviewed_by"             xorm:"reviewer"`
 	Reviewed             int64                  `json:"reviewed"                xorm:"reviewed"`
+	CancelReason         string                 `json:"cancel_reason,omitempty" xorm:"cancel_reason"`
 	Workflows            []*Workflow            `json:"workflows,omitempty"     xorm:"-"`
 	ChangedFiles         []string               `json:"changed_files,omitempty" xorm:"LONGTEXT 'changed_files'"`
 	AdditionalVariables  map[string]string      `json:"variables,omitempty"     xorm:"json 'additional_variables'"`

--- a/server/model/pipeline.go
+++ b/server/model/pipeline.go
@@ -89,5 +89,5 @@ type PipelineOptions struct {
 
 type CancelInfo struct {
 	CanceledByUser string `json:"canceled_by_user,omitempty"`
-	SupersededBy int64  `json:"superseded_by,omitempty"`
+	SupersededBy   int64  `json:"superseded_by,omitempty"`
 } //	@name	CancelInfo

--- a/server/pipeline/cancel.go
+++ b/server/pipeline/cancel.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Cancel the pipeline and returns the status.
-func Cancel(ctx context.Context, _forge forge.Forge, store store.Store, repo *model.Repo, user *model.User, pipeline *model.Pipeline, cancelReason string) error {
+func Cancel(ctx context.Context, _forge forge.Forge, store store.Store, repo *model.Repo, user *model.User, pipeline *model.Pipeline, cancelInfo *model.CancelInfo) error {
 	if pipeline.Status != model.StatusRunning && pipeline.Status != model.StatusPending && pipeline.Status != model.StatusBlocked {
 		return &ErrBadRequest{Msg: "Cannot cancel a non-running or non-pending or non-blocked pipeline"}
 	}
@@ -70,7 +70,7 @@ func Cancel(ctx context.Context, _forge forge.Forge, store store.Store, repo *mo
 		}
 	}
 
-	killedPipeline, err := UpdateToStatusKilled(store, *pipeline, cancelReason)
+	killedPipeline, err := UpdateToStatusKilled(store, *pipeline, cancelInfo)
 	if err != nil {
 		log.Error().Err(err).Msgf("UpdateToStatusKilled: %v", pipeline)
 		return err
@@ -133,7 +133,12 @@ func cancelPreviousPipelines(
 			continue
 		}
 
-		if err = Cancel(ctx, _forge, _store, repo, user, active, fmt.Sprintf("Superseded by pipeline #%d", pipeline.Number)); err != nil {
+		if err = Cancel(ctx, _forge, _store, repo, user, active, &model.CancelInfo{
+			Reason: model.CancelReasonSuperseded,
+			Data: map[string]string{
+				"pipeline_number": fmt.Sprint(pipeline.Number),
+			},
+		}); err != nil {
 			log.Error().
 				Err(err).
 				Str("ref", active.Ref).

--- a/server/pipeline/cancel.go
+++ b/server/pipeline/cancel.go
@@ -134,10 +134,7 @@ func cancelPreviousPipelines(
 		}
 
 		if err = Cancel(ctx, _forge, _store, repo, user, active, &model.CancelInfo{
-			Reason: model.CancelReasonSuperseded,
-			Data: map[string]string{
-				"pipeline_number": fmt.Sprint(pipeline.Number),
-			},
+			SupersededBy: pipeline.Number,
 		}); err != nil {
 			log.Error().
 				Err(err).

--- a/server/pipeline/pipeline_status.go
+++ b/server/pipeline/pipeline_status.go
@@ -59,9 +59,9 @@ func UpdateToStatusError(store store.Store, pipeline model.Pipeline, err error) 
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }
 
-func UpdateToStatusKilled(store store.Store, pipeline model.Pipeline, cancelReason string) (*model.Pipeline, error) {
+func UpdateToStatusKilled(store store.Store, pipeline model.Pipeline, cancelInfo *model.CancelInfo) (*model.Pipeline, error) {
 	pipeline.Status = model.StatusKilled
 	pipeline.Finished = time.Now().Unix()
-	pipeline.CancelReason = cancelReason
+	pipeline.CancelInfo = cancelInfo
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }

--- a/server/pipeline/pipeline_status.go
+++ b/server/pipeline/pipeline_status.go
@@ -59,8 +59,9 @@ func UpdateToStatusError(store store.Store, pipeline model.Pipeline, err error) 
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }
 
-func UpdateToStatusKilled(store store.Store, pipeline model.Pipeline) (*model.Pipeline, error) {
+func UpdateToStatusKilled(store store.Store, pipeline model.Pipeline, cancelReason string) (*model.Pipeline, error) {
 	pipeline.Status = model.StatusKilled
 	pipeline.Finished = time.Now().Unix()
+	pipeline.CancelReason = cancelReason
 	return &pipeline, store.UpdatePipeline(&pipeline)
 }

--- a/server/pipeline/pipeline_status_test.go
+++ b/server/pipeline/pipeline_status_test.go
@@ -95,13 +95,13 @@ func TestUpdateToStatusKilled(t *testing.T) {
 
 	now := time.Now().Unix()
 	cancelInfo := &model.CancelInfo{
-		Reason: "Unit tests status",
+		SupersededBy: 2,
 	}
 
 	pipeline, _ := UpdateToStatusKilled(mockStorePipeline(t), model.Pipeline{}, cancelInfo)
 
 	assert.Equal(t, model.StatusKilled, pipeline.Status)
 	assert.NotNil(t, pipeline.CancelInfo)
-	assert.Equal(t, "Unit tests status", pipeline.CancelInfo.Reason)
+	assert.EqualValues(t, 2, pipeline.CancelInfo.SupersededBy)
 	assert.LessOrEqual(t, now, pipeline.Finished)
 }

--- a/server/pipeline/pipeline_status_test.go
+++ b/server/pipeline/pipeline_status_test.go
@@ -94,11 +94,14 @@ func TestUpdateToStatusKilled(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().Unix()
-	message := "Unit tests status"
+	cancelInfo := &model.CancelInfo{
+		Reason: "Unit tests status",
+	}
 
-	pipeline, _ := UpdateToStatusKilled(mockStorePipeline(t), model.Pipeline{}, message)
+	pipeline, _ := UpdateToStatusKilled(mockStorePipeline(t), model.Pipeline{}, cancelInfo)
 
 	assert.Equal(t, model.StatusKilled, pipeline.Status)
-	assert.Equal(t, message, pipeline.CancelReason)
+	assert.NotNil(t, pipeline.CancelInfo)
+	assert.Equal(t, "Unit tests status", pipeline.CancelInfo.Reason)
 	assert.LessOrEqual(t, now, pipeline.Finished)
 }

--- a/server/pipeline/pipeline_status_test.go
+++ b/server/pipeline/pipeline_status_test.go
@@ -94,9 +94,11 @@ func TestUpdateToStatusKilled(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().Unix()
+	message := "Unit tests status"
 
-	pipeline, _ := UpdateToStatusKilled(mockStorePipeline(t), model.Pipeline{})
+	pipeline, _ := UpdateToStatusKilled(mockStorePipeline(t), model.Pipeline{}, message)
 
 	assert.Equal(t, model.StatusKilled, pipeline.Status)
+	assert.Equal(t, message, pipeline.CancelReason)
 	assert.LessOrEqual(t, now, pipeline.Finished)
 }

--- a/server/pipeline/workflow_status_test.go
+++ b/server/pipeline/workflow_status_test.go
@@ -1,0 +1,145 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"go.woodpecker-ci.org/woodpecker/v3/rpc"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+func TestUpdateWorkflowStatusToRunning(t *testing.T) {
+	t.Run("should update workflow to running status", func(t *testing.T) {
+		workflow := model.Workflow{
+			ID:    1,
+			State: model.StatusPending,
+		}
+		state := rpc.WorkflowState{
+			Started: 1234567890,
+		}
+
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("WorkflowUpdate", mock.MatchedBy(func(w *model.Workflow) bool {
+			return w.ID == 1 && w.State == model.StatusRunning && w.Started == 1234567890
+		})).Return(nil)
+
+		result, err := UpdateWorkflowStatusToRunning(mockStore, workflow, state)
+
+		assert.NoError(t, err)
+		assert.Equal(t, model.StatusRunning, result.State)
+		assert.Equal(t, int64(1234567890), result.Started)
+		mockStore.AssertCalled(t, "WorkflowUpdate", mock.Anything)
+	})
+}
+
+func TestUpdateWorkflowToStatusSkipped(t *testing.T) {
+	t.Run("should update workflow to skipped status", func(t *testing.T) {
+		workflow := model.Workflow{
+			ID:    2,
+			State: model.StatusPending,
+		}
+
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("WorkflowUpdate", mock.MatchedBy(func(w *model.Workflow) bool {
+			return w.ID == 2 && w.State == model.StatusSkipped
+		})).Return(nil)
+
+		result, err := UpdateWorkflowToStatusSkipped(mockStore, workflow)
+
+		assert.NoError(t, err)
+		assert.Equal(t, model.StatusSkipped, result.State)
+		mockStore.AssertCalled(t, "WorkflowUpdate", mock.Anything)
+	})
+}
+
+func TestUpdateWorkflowStatusToDone(t *testing.T) {
+	t.Run("should mark as skipped when not started", func(t *testing.T) {
+		workflow := model.Workflow{
+			ID:       3,
+			State:    model.StatusRunning,
+			Children: []*model.Step{},
+		}
+		state := rpc.WorkflowState{
+			Started:  0, // Not started
+			Finished: 1234567900,
+			Error:    "",
+		}
+
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("WorkflowUpdate", mock.MatchedBy(func(w *model.Workflow) bool {
+			return w.State == model.StatusSkipped && w.Finished == 1234567900
+		})).Return(nil)
+
+		result, err := UpdateWorkflowStatusToDone(mockStore, workflow, state)
+
+		assert.NoError(t, err)
+		assert.Equal(t, model.StatusSkipped, result.State)
+		assert.Equal(t, int64(1234567900), result.Finished)
+	})
+
+	t.Run("should mark as failure when error exists", func(t *testing.T) {
+		workflow := model.Workflow{
+			ID:       5,
+			State:    model.StatusRunning,
+			Children: []*model.Step{},
+		}
+		state := rpc.WorkflowState{
+			Started:  1234567800,
+			Finished: 1234567900,
+			Error:    "some error occurred",
+		}
+
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("WorkflowUpdate", mock.MatchedBy(func(w *model.Workflow) bool {
+			return w.State == model.StatusFailure
+		})).Return(nil)
+
+		result, err := UpdateWorkflowStatusToDone(mockStore, workflow, state)
+
+		assert.NoError(t, err)
+		assert.Equal(t, model.StatusFailure, result.State)
+		assert.Equal(t, "some error occurred", result.Error)
+	})
+
+	t.Run("should mark as success when all children are successful", func(t *testing.T) {
+		successStep := &model.Step{
+			ID:    1,
+			State: model.StatusSuccess,
+		}
+		workflow := model.Workflow{
+			ID:       6,
+			State:    model.StatusRunning,
+			Children: []*model.Step{successStep},
+		}
+		state := rpc.WorkflowState{
+			Started:  1234567800,
+			Finished: 1234567900,
+			Error:    "",
+		}
+
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("WorkflowUpdate", mock.Anything).Return(nil)
+
+		result, err := UpdateWorkflowStatusToDone(mockStore, workflow, state)
+
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1234567900), result.Finished)
+	})
+}

--- a/server/pipeline/workflow_status_test.go
+++ b/server/pipeline/workflow_status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Woodpecker Authors
+// Copyright 2026 Woodpecker Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -271,7 +271,7 @@
       "created": "Created: {created}",
       "cancel_info": {
         "superseded_by": "Superseded by pipeline #{pipelineId}",
-        "cancel_by_user": "Canceled by {user}"
+        "canceled_by_user": "Canceled by {user}"
       },
       "debug": {
         "title": "Debug",

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -270,7 +270,7 @@
       "duration": "Pipeline duration: {duration}",
       "created": "Created: {created}",
       "cancel_info": {
-        "superseded_by": "Superseded by pipeline #{pipeline_number}",
+        "superseded_by": "Superseded by pipeline #{pipelineId}",
         "cancel_by_user": "Canceled by {user}"
       },
       "debug": {

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -271,7 +271,7 @@
       "created": "Created: {created}",
       "cancel_info": {
         "superseded_by": "Superseded by pipeline #{pipeline_number}",
-        "user_cancel": "Canceled by {user}"
+        "cancel_by_user": "Canceled by {user}"
       },
       "debug": {
         "title": "Debug",

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -269,6 +269,10 @@
       "we_got_some_errors": "Oh no, an error occurred!",
       "duration": "Pipeline duration: {duration}",
       "created": "Created: {created}",
+      "cancel_info": {
+        "superseded_by": "Superseded by pipeline #{pipeline_number}",
+        "user_cancel": "Canceled by {user}"
+      },
       "debug": {
         "title": "Debug",
         "download_metadata": "Download metadata",

--- a/web/src/lib/api/types/pipeline.ts
+++ b/web/src/lib/api/types/pipeline.ts
@@ -8,8 +8,8 @@ export interface PipelineError<D = unknown> {
 }
 
 export interface CancelInfo {
-  reason: string;
-  data?: Record<string, string>;
+  canceled_by_user: string;
+  superseded_by: number
 }
 
 // A pipeline for a repository.
@@ -86,8 +86,6 @@ export interface Pipeline {
   reviewed_by: string;
 
   reviewed: number;
-
-  cancel_info?: CancelInfo;
 
   // The steps associated with this pipeline.
   // A pipeline will have multiple steps if a matrix pipeline was used or if a rebuild was requested.

--- a/web/src/lib/api/types/pipeline.ts
+++ b/web/src/lib/api/types/pipeline.ts
@@ -92,6 +92,8 @@ export interface Pipeline {
   workflows?: PipelineWorkflow[];
 
   changed_files?: string[];
+
+  cancel_info: CancelInfo;
 }
 
 export type PipelineStatus =

--- a/web/src/lib/api/types/pipeline.ts
+++ b/web/src/lib/api/types/pipeline.ts
@@ -9,7 +9,7 @@ export interface PipelineError<D = unknown> {
 
 export interface CancelInfo {
   canceled_by_user: string;
-  superseded_by: number
+  superseded_by: number;
 }
 
 // A pipeline for a repository.

--- a/web/src/lib/api/types/pipeline.ts
+++ b/web/src/lib/api/types/pipeline.ts
@@ -7,6 +7,11 @@ export interface PipelineError<D = unknown> {
   is_warning: boolean;
 }
 
+export interface CancelInfo {
+  reason: string;
+  data?: Record<string, string>;
+}
+
 // A pipeline for a repository.
 export interface Pipeline {
   id: number;
@@ -81,6 +86,8 @@ export interface Pipeline {
   reviewed_by: string;
 
   reviewed: number;
+
+  cancel_info?: CancelInfo;
 
   // The steps associated with this pipeline.
   // A pipeline will have multiple steps if a matrix pipeline was used or if a rebuild was requested.

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -81,18 +81,14 @@
         <div v-if="pipeline.status === 'killed' && pipeline.cancel_info" class="flex shrink-0 items-center gap-2">
           <Icon name="status-killed" />
           <span class="truncate">
-            <template v-if="pipeline.cancel_info.reason === 'superseded_by'">
+            <template v-if="pipeline.cancel_info.superseded_by">
               <router-link
-                :to="{ name: 'repo-pipeline', params: { pipelineId: pipeline.cancel_info.data.pipeline_number } }"
+                :to="{ name: 'repo-pipeline', params: { pipelineId: pipeline.cancel_info.superseded_by } }"
                 class="hover:underline"
-                >{{ $t('repo.pipeline.cancel_info.superseded_by', pipeline.cancel_info.data) }}</router-link
-              >
+                >{{ $t('repo.pipeline.cancel_info.superseded_by', pipeline.cancel_info.superseded_by) }}</router-link>
             </template>
-            <template v-else-if="pipeline.cancel_info.reason === 'user_cancel'">
-              {{ $t('repo.pipeline.cancel_info.user_cancel', pipeline.cancel_info.data) }}
-            </template>
-            <template v-else>
-              {{ pipeline.cancel_info.reason }}
+            <template v-else-if="pipeline.cancel_info.cancel_by_user">
+              {{ $t('repo.pipeline.cancel_info.cancel_by_user', pipeline.cancel_info.cancel_by_user) }}
             </template>
           </span>
         </div>

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -78,6 +78,10 @@
           <Icon name="duration" />
           <span>{{ duration }}</span>
         </div>
+        <div v-if="pipeline.status === 'killed' && pipeline.cancel_reason" class="flex shrink-0 items-center gap-2">
+          <Icon name="status-killed" />
+          <span class="truncate" :title="pipeline.cancel_reason">{{ pipeline.cancel_reason }}</span>
+        </div>
       </div>
     </template>
 

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -90,8 +90,8 @@
                 }}</router-link
               >
             </template>
-            <template v-else-if="pipeline.cancel_info.cancel_by_user">
-              {{ $t('repo.pipeline.cancel_info.cancel_by_user', { user: pipeline.cancel_info.cancel_by_user }) }}
+            <template v-else-if="pipeline.cancel_info.canceled_by_user">
+              {{ $t('repo.pipeline.cancel_info.canceled_by_user', { user: pipeline.cancel_info.canceled_by_user }) }}
             </template>
           </span>
         </div>

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -85,10 +85,10 @@
               <router-link
                 :to="{ name: 'repo-pipeline', params: { pipelineId: pipeline.cancel_info.superseded_by } }"
                 class="hover:underline"
-                >{{ $t('repo.pipeline.cancel_info.superseded_by', pipeline.cancel_info.superseded_by) }}</router-link>
+                >{{ $t('repo.pipeline.cancel_info.superseded_by', { pipelineId: pipeline.cancel_info.superseded_by }) }}</router-link>
             </template>
             <template v-else-if="pipeline.cancel_info.cancel_by_user">
-              {{ $t('repo.pipeline.cancel_info.cancel_by_user', pipeline.cancel_info.cancel_by_user) }}
+              {{ $t('repo.pipeline.cancel_info.cancel_by_user', { user: pipeline.cancel_info.cancel_by_user }) }}
             </template>
           </span>
         </div>

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -78,9 +78,22 @@
           <Icon name="duration" />
           <span>{{ duration }}</span>
         </div>
-        <div v-if="pipeline.status === 'killed' && pipeline.cancel_reason" class="flex shrink-0 items-center gap-2">
+        <div v-if="pipeline.status === 'killed' && pipeline.cancel_info" class="flex shrink-0 items-center gap-2">
           <Icon name="status-killed" />
-          <span class="truncate" :title="pipeline.cancel_reason">{{ pipeline.cancel_reason }}</span>
+          <span class="truncate">
+            <template v-if="pipeline.cancel_info.reason === 'superseded_by'">
+              <router-link
+                :to="{ name: 'repo-pipeline', params: { pipelineId: pipeline.cancel_info.data.pipeline_number } }"
+                class="hover:underline"
+                >{{ $t('repo.pipeline.cancel_info.superseded_by', pipeline.cancel_info.data ) }}</router-link>
+            </template>
+            <template v-else-if="pipeline.cancel_info.reason === 'user_cancel'">
+              {{ $t('repo.pipeline.cancel_info.user_cancel', pipeline.cancel_info.data ) }}
+            </template>
+            <template v-else>
+              {{ pipeline.cancel_info.reason }}
+            </template>
+          </span>
         </div>
       </div>
     </template>

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -85,7 +85,10 @@
               <router-link
                 :to="{ name: 'repo-pipeline', params: { pipelineId: pipeline.cancel_info.superseded_by } }"
                 class="hover:underline"
-                >{{ $t('repo.pipeline.cancel_info.superseded_by', { pipelineId: pipeline.cancel_info.superseded_by }) }}</router-link>
+                >{{
+                  $t('repo.pipeline.cancel_info.superseded_by', { pipelineId: pipeline.cancel_info.superseded_by })
+                }}</router-link
+              >
             </template>
             <template v-else-if="pipeline.cancel_info.cancel_by_user">
               {{ $t('repo.pipeline.cancel_info.cancel_by_user', { user: pipeline.cancel_info.cancel_by_user }) }}

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -81,14 +81,13 @@
         <div v-if="pipeline.status === 'killed' && pipeline.cancel_info" class="flex shrink-0 items-center gap-2">
           <Icon name="status-killed" />
           <span class="truncate">
-            <template v-if="pipeline.cancel_info.superseded_by">
-              <router-link
-                :to="{ name: 'repo-pipeline', params: { pipelineId: pipeline.cancel_info.superseded_by } }"
-                class="hover:underline"
-                >{{
-                  $t('repo.pipeline.cancel_info.superseded_by', { pipelineId: pipeline.cancel_info.superseded_by })
-                }}</router-link>
-            </template>
+            <router-link
+              v-if="pipeline.cancel_info.superseded_by"
+              :to="{ name: 'repo-pipeline', params: { pipelineId: pipeline.cancel_info.superseded_by } }"
+              class="hover:underline"
+            >
+              {{ $t('repo.pipeline.cancel_info.superseded_by', { pipelineId: pipeline.cancel_info.superseded_by }) }}
+            </router-link>
             <template v-else-if="pipeline.cancel_info.canceled_by_user">
               {{ $t('repo.pipeline.cancel_info.canceled_by_user', { user: pipeline.cancel_info.canceled_by_user }) }}
             </template>

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -85,10 +85,11 @@
               <router-link
                 :to="{ name: 'repo-pipeline', params: { pipelineId: pipeline.cancel_info.data.pipeline_number } }"
                 class="hover:underline"
-                >{{ $t('repo.pipeline.cancel_info.superseded_by', pipeline.cancel_info.data ) }}</router-link>
+                >{{ $t('repo.pipeline.cancel_info.superseded_by', pipeline.cancel_info.data) }}</router-link
+              >
             </template>
             <template v-else-if="pipeline.cancel_info.reason === 'user_cancel'">
-              {{ $t('repo.pipeline.cancel_info.user_cancel', pipeline.cancel_info.data ) }}
+              {{ $t('repo.pipeline.cancel_info.user_cancel', pipeline.cancel_info.data) }}
             </template>
             <template v-else>
               {{ pipeline.cancel_info.reason }}

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -87,8 +87,7 @@
                 class="hover:underline"
                 >{{
                   $t('repo.pipeline.cancel_info.superseded_by', { pipelineId: pipeline.cancel_info.superseded_by })
-                }}</router-link
-              >
+                }}</router-link>
             </template>
             <template v-else-if="pipeline.cancel_info.canceled_by_user">
               {{ $t('repo.pipeline.cancel_info.canceled_by_user', { user: pipeline.cancel_info.canceled_by_user }) }}


### PR DESCRIPTION
This PR adds cancel info, so one can see why it was cancelled.
- It can set the status to cancel by user with the name of the user
- It can set the status to superceded by pipeline, which holds the reference and link to said pipeline
- Uses I18n to support translation in the UI

As well as a few tests I had added as part of the old proposed fix.

<img width="1187" height="566" alt="image" src="https://github.com/user-attachments/assets/fb55e564-c3c5-4822-9c66-f13fb470ed6b" />