### PR TITLE
Document how to ignore failure on services

### DIFF
--- a/.woodpecker/securityscan.yaml
+++ b/.woodpecker/securityscan.yaml
@@ -34,6 +34,7 @@ steps:
 services:
   server:
     image: *trivy_plugin
+    failure: ignore # as we don't care about the exit code
     settings:
       service: true
       db-repository: mirror.gcr.io/aquasec/trivy-db:2

--- a/docs/docs/20-usage/60-services.md
+++ b/docs/docs/20-usage/60-services.md
@@ -37,6 +37,20 @@ services:
       - 51820/udp
 ```
 
+## Stopping
+
+Services once not needed anymore get **SIGTERM** signal. If they don't honor it they will just get killed via **SIGKILL**.
+If you have services that don't gracefully stop and it does not matter, just ignore the failure:
+
+```diff
+ services:
+   - name: database
+     image: mysql
++    failure: ignore # we don't care how mysql exits
+     ports:
+       - 3306
+```
+
 ## Configuration
 
 Service containers generally expose environment variables to customize service startup such as default usernames, passwords and ports. Please see the official image documentation to learn more.

--- a/docs/docs/20-usage/60-services.md
+++ b/docs/docs/20-usage/60-services.md
@@ -39,8 +39,8 @@ services:
 
 ## Stopping
 
-Services once not needed anymore get **SIGTERM** signal. If they don't honor it they will just get killed via **SIGKILL**.
-If you have services that don't gracefully stop and it does not matter, just ignore the failure:
+Services that are no longer needed receive a **SIGTERM** signal. If they don't respond to it, they will be forcibly terminated with **SIGKILL**.
+If you have services that don't shut down gracefully and it doesn't matter, you can simply ignore the failure:
 
 ```diff
  services:

--- a/docs/docs/20-usage/60-services.md
+++ b/docs/docs/20-usage/60-services.md
@@ -39,8 +39,8 @@ services:
 
 ## Stopping
 
-Services that are no longer needed receive a **SIGTERM** signal. If they don't respond to it, they will be forcibly terminated with **SIGKILL**.
-If you have services that don't shut down gracefully and it doesn't matter, you can simply ignore the failure:
+Services that are no longer needed receive a **SIGTERM** signal. If they do not respond, they are forcibly terminated with **SIGKILL**.
+If there are services that do not shut down properly and this doesn't matter, you can simply ignore the error:
 
 ```diff
  services:

--- a/pipeline/frontend/yaml/linter/schema/.woodpecker/test-service.yaml
+++ b/pipeline/frontend/yaml/linter/schema/.woodpecker/test-service.yaml
@@ -16,6 +16,7 @@ services:
 
   cache:
     image: redis
+    failure: ignore
     directory: /tmp/
     ports:
       - '6379'

--- a/pipeline/frontend/yaml/linter/schema/schema.json
+++ b/pipeline/frontend/yaml/linter/schema/schema.json
@@ -879,6 +879,12 @@
         "volumes": {
           "$ref": "#/definitions/step_volumes"
         },
+        "failure": {
+          "description": "How to handle the failure of this step. Read more: https://woodpecker-ci.org/docs/usage/services#stopping",
+          "type": "string",
+          "enum": ["fail", "ignore"],
+          "default": "fail"
+        },
         "backend_options": {
           "$ref": "#/definitions/step_backend_options"
         },


### PR DESCRIPTION
and make it an official setting for services

as https://github.com/woodpecker-ci/woodpecker/pull/6039 made services report status back now...

> ... detached steps and services should let a pipeline fail. ...

fix: https://ci.woodpecker-ci.org/repos/3780/pipeline/31546/10