### PR TITLE
Shorten superseded text

### DIFF
--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -270,7 +270,7 @@
       "duration": "Pipeline duration: {duration}",
       "created": "Created: {created}",
       "cancel_info": {
-        "superseded_by": "Superseded by pipeline #{pipelineId}",
+        "superseded_by": "Superseded by #{pipelineId}",
         "canceled_by_user": "Canceled by {user}"
       },
       "debug": {


### PR DESCRIPTION
from #6072 

The text with "pipeline" is quite long, I'd remove that word.

<img width="547" height="48" alt="grafik" src="https://github.com/user-attachments/assets/b9abbc92-e27a-463c-9d5c-245b83df8e6f" />
