### PR TITLE
Fix OAuth token refresh race condition with singleflight

### DIFF
--- a/server/forge/refresh.go
+++ b/server/forge/refresh.go
@@ -68,7 +68,7 @@ func Refresh(ctx context.Context, forge Forge, _store store.Store, user *model.U
 		}
 
 		key := fmt.Sprintf("refresh-%d", user.ID)
-		result, err, _ := refreshGroup.Do(key, func() (interface{}, error) {
+		result, err, _ := refreshGroup.Do(key, func() (any, error) {
 			userUpdated, err := refresher.Refresh(ctx, user)
 			if err != nil {
 				return nil, err

--- a/server/forge/refresh_test.go
+++ b/server/forge/refresh_test.go
@@ -81,7 +81,10 @@ func TestRefresh_ExpiredToken(t *testing.T) {
 	user := expiredUser(1)
 
 	mockRefresher.On("Refresh", mock.Anything, user).Return(true, nil).Run(func(args mock.Arguments) {
-		u := args.Get(1).(*model.User)
+		u, ok := args.Get(1).(*model.User)
+		if !ok {
+			return
+		}
 		u.AccessToken = "new-access-token"
 		u.RefreshToken = "new-refresh-token"
 		u.Expiry = time.Now().UTC().Unix() + 3600
@@ -127,7 +130,10 @@ func TestRefresh_ConcurrentRefreshSerialized(t *testing.T) {
 		refreshCount.Add(1)
 		// Simulate network latency so concurrent callers overlap
 		time.Sleep(50 * time.Millisecond)
-		u := args.Get(1).(*model.User)
+		u, ok := args.Get(1).(*model.User)
+		if !ok {
+			return
+		}
 		u.AccessToken = "new-access-token"
 		u.RefreshToken = "new-refresh-token"
 		u.Expiry = time.Now().UTC().Unix() + 3600


### PR DESCRIPTION
When a forge uses single-use refresh tokens (e.g. Forgejo with InvalidateRefreshTokens=true), concurrent API requests can trigger simultaneous token refreshes. The second refresh fails because the token was already consumed, permanently poisoning the stored token and requiring users to re-login.

Use golang.org/x/sync/singleflight to deduplicate concurrent refresh calls per user ID. Only one refresh executes at a time; concurrent callers wait for and receive the same result.

Fixes #5839

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
