### PR TITLE
Remove fixed badge width in UI

### DIFF
--- a/web/src/views/repo/RepoWrapper.vue
+++ b/web/src/views/repo/RepoWrapper.vue
@@ -12,7 +12,7 @@
     </template>
     <template #headerActions>
       <a v-if="badgeUrl" :href="badgeUrl" target="_blank">
-        <img class="w-28" :src="badgeUrl" />
+        <img :src="badgeUrl" />
       </a>
       <IconButton :href="repo.forge_url" :title="$t('repo.open_in_forge')" :icon="forgeIcon" class="forge h-8 w-8" />
       <IconButton


### PR DESCRIPTION
fix the badge looking distorted and too big in the repo wrapper.

before:
<img width="236" height="73" alt="Screenshot 2026-02-24 at 10-17-10 Aktivitäten · woodpecker-ci_woodpecker · Woodpecker" src="https://github.com/user-attachments/assets/da8b084a-c6b4-403a-8116-4a68db63f354" />
after:
<img width="217" height="63" alt="Screenshot 2026-02-24 at 10-17-24 Aktivitäten · woodpecker-ci_woodpecker · Woodpecker" src="https://github.com/user-attachments/assets/ec4fa133-1b86-4258-a6e7-723894bc2f78" />
