### PR TITLE
Use native slice

### DIFF
--- a/pipeline/frontend/yaml/types/container_test.go
+++ b/pipeline/frontend/yaml/types/container_test.go
@@ -17,7 +17,6 @@ package types
 import (
 	"testing"
 
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 
@@ -273,15 +272,15 @@ func stringsToInterface(val ...string) []any {
 func TestIsPlugin(t *testing.T) {
 	assert.True(t, (&Container{}).IsPlugin())
 	assert.True(t, (&Container{
-		Commands: base.StringOrSlice(strslice.StrSlice{}),
+		Commands: base.StringOrSlice([]string{}),
 	}).IsPlugin())
 	assert.False(t, (&Container{
-		Commands: base.StringOrSlice(strslice.StrSlice{"echo 'this is not a plugin'"}),
+		Commands: base.StringOrSlice([]string{"echo 'this is not a plugin'"}),
 	}).IsPlugin())
 	assert.True(t, (&Container{
-		Entrypoint: base.StringOrSlice(strslice.StrSlice{}),
+		Entrypoint: base.StringOrSlice([]string{}),
 	}).IsPlugin())
 	assert.False(t, (&Container{
-		Entrypoint: base.StringOrSlice(strslice.StrSlice{"echo 'this is not a plugin'"}),
+		Entrypoint: base.StringOrSlice([]string{"echo 'this is not a plugin'"}),
 	}).IsPlugin())
 }


### PR DESCRIPTION
Discovered that when I checked https://github.com/woodpecker-ci/woodpecker/discussions/6154. There's no reason to not use a simple native slice there I think…