### PR TITLE
Bitbucket DC: resolve annotated tag SHA to commit SHA before posting build status

### DIFF
--- a/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
@@ -580,7 +580,7 @@ func (c *client) updatePipelineFromCommits(ctx context.Context, u *model.User, r
 		return nil, fmt.Errorf("unable to read commit: %w", err)
 	}
 
-	// Fix for https://github.com/woodpecker-ci/woodpecker/issues/6202:
+	// In Bitbucket Data Center, when using annotated tags, the webhook's ToHash is the tag object SHA, not the actual commit SHA.
 	// Update p.Commit so that build statuses are posted to the correct commit SHA.
 	if p.Event == model.EventTag && commit.ID != "" && commit.ID != p.Commit {
 		p.Commit = commit.ID

--- a/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/server/forge/bitbucketdatacenter/bitbucketdatacenter.go
@@ -579,6 +579,14 @@ func (c *client) updatePipelineFromCommits(ctx context.Context, u *model.User, r
 	if err != nil {
 		return nil, fmt.Errorf("unable to read commit: %w", err)
 	}
+
+	// Fix for https://github.com/woodpecker-ci/woodpecker/issues/6202:
+	// Update p.Commit so that build statuses are posted to the correct commit SHA.
+	if p.Event == model.EventTag && commit.ID != "" && commit.ID != p.Commit {
+		p.Commit = commit.ID
+		p.ForgeURL = fmt.Sprintf("%s/projects/%s/repos/%s/commits/%s", c.url, r.Owner, r.Name, commit.ID)
+	}
+
 	p.Message = commit.Message
 
 	opts := &bb.CompareChangesOptions{}


### PR DESCRIPTION
Fixes #6202 
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
