### PR TITLE
fix(db): replace lib/pq with pgx for connection pooler compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,11 +33,11 @@ require (
 	github.com/google/go-github/v84 v84.0.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
+	github.com/jackc/pgx/v5 v5.8.0
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12
 	github.com/kinbiko/jsonassert v1.2.0
-	github.com/lib/pq v1.11.2
 	github.com/mattn/go-sqlite3 v1.14.34
 	github.com/migueleliasweb/go-github-mock v1.5.0
 	github.com/moby/term v0.5.2
@@ -142,6 +142,9 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
@@ -157,6 +160,7 @@ require (
 	github.com/lestrrat-go/jwx/v3 v3.0.12 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
+	github.com/lib/pq v1.11.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,7 @@ github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bY
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgmock v0.0.0-20201204152224-4fe30f7445fd/go.mod h1:hrBW0Enj2AZTNpt/7Y5rr2xe/9Mn757Wtb2xeBzPv2c=
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65/go.mod h1:5R2h2EEX+qri8jOWMbJCtaPWkrrNc7OHwsp2TCqp7ak=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
@@ -314,6 +315,8 @@ github.com/jackc/pgproto3/v2 v2.1.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwX
 github.com/jackc/pgproto3/v2 v2.3.2/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgtype v0.0.0-20190421001408-4ed0de4755e0/go.mod h1:hdSHsc1V01CGwFsrv11mJRHWJ6aifDLfdV3aVjFF0zg=
 github.com/jackc/pgtype v0.0.0-20190824184912-ab885b375b90/go.mod h1:KcahbBH1nCMSo2DXpzsoWOAfFkdEtEJpPbVLq8eE+mc=
 github.com/jackc/pgtype v0.0.0-20190828014616-a8802b16cc59/go.mod h1:MWlu30kVJrUS8lot6TQqcg7mtthZ9T0EoIBFiJcmcyw=
@@ -324,10 +327,14 @@ github.com/jackc/pgx/v4 v4.0.0-20190421002000-1b8f0016e912/go.mod h1:no/Y67Jkk/9
 github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQnOEnf1dqHGpw7JmHqHc1NxDoalibchSk9/RWuDc=
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.18.0/go.mod h1:FydWkUyadDmdNH/mHnGob881GawxeEm7TcMCzkb+qQE=
+github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
+github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=

--- a/server/store/datastore/engine.go
+++ b/server/store/datastore/engine.go
@@ -32,7 +32,12 @@ type storage struct {
 const perPage = 50
 
 func NewEngine(opts *store.Opts) (store.Store, error) {
-	engine, err := xorm.NewEngine(opts.Driver, opts.Config)
+	driver := opts.Driver
+	if driver == "postgres" {
+		driver = "pgx"
+	}
+
+	engine, err := xorm.NewEngine(driver, opts.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/server/store/datastore/init.go
+++ b/server/store/datastore/init.go
@@ -18,7 +18,7 @@ package datastore
 
 import (
 	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 // Supported database drivers.

--- a/server/store/datastore/init_cgo.go
+++ b/server/store/datastore/init_cgo.go
@@ -19,7 +19,7 @@ package datastore
 import (
 	// Blank imports to register the sql drivers.
 	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/mattn/go-sqlite3"
 )
 

--- a/server/store/datastore/migration/migration_test.go
+++ b/server/store/datastore/migration/migration_test.go
@@ -23,7 +23,7 @@ import (
 
 	// Blank imports to register the sql drivers.
 	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,7 +87,7 @@ func testDB(t *testing.T, initNewDB bool) (engine *xorm.Engine, closeDB func()) 
 		if !initNewDB {
 			restorePostgresDump(t, config)
 		}
-		engine, err = xorm.NewEngine(driver, config)
+		engine, err = xorm.NewEngine("pgx", config)
 		require.NoError(t, err)
 		return engine, closeDB
 	default:
@@ -102,7 +102,7 @@ func restorePostgresDump(t *testing.T, config string) {
 	dump, err := os.ReadFile(postgresDump)
 	require.NoError(t, err)
 
-	db, err := sql.Open("postgres", config)
+	db, err := sql.Open("pgx", config)
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -134,7 +134,7 @@ func restorePostgresDump(t *testing.T, config string) {
 }
 
 func cleanPostgresDB(t *testing.T, config string) {
-	db, err := sql.Open("postgres", config)
+	db, err := sql.Open("pgx", config)
 	require.NoError(t, err)
 	defer db.Close()
 


### PR DESCRIPTION
## Summary

Fixes #6097

Replace `github.com/lib/pq` with `github.com/jackc/pgx/v5/stdlib` as the PostgreSQL driver.

`lib/pq` uses PostgreSQL's **extended query protocol** with unnamed prepared statements for all parameterized queries. This is incompatible with connection poolers (pgBouncer, pgcat) in **transaction pooling mode** — the pooler can route different clients' Parse/Bind messages to the same server connection, causing:

```
pq: bind message supplies 4 parameters, but prepared statement "" requires 1
```

`pgx` supports **simple query protocol** via the DSN parameter `default_query_exec_mode=simple_protocol`, which avoids prepared statements entirely and is fully compatible with transaction pooling.

## Changes

- **`server/store/datastore/init.go`** / **`init_cgo.go`** — Swap `lib/pq` import for `pgx/v5/stdlib`
- **`server/store/datastore/engine.go`** — Map `"postgres"` driver name to `"pgx"` (pgx/stdlib registers under `"pgx"`)
- **`server/store/datastore/migration/migration_test.go`** — Update imports and driver names
- **`go.mod`** / **`go.sum`** — Add `pgx/v5`, remove direct `lib/pq` dependency

## Why pgx

- Drop-in replacement via `pgx/stdlib` (implements `database/sql` interface — XORM works without changes)
- Supports `default_query_exec_mode=simple_protocol` to avoid prepared statements
- `lib/pq` is in maintenance mode; its author [recommends migrating to pgx](https://github.com/lib/pq#status)
- Other Go projects (Gitea, etc.) have made the same migration for the same reason

## Impact

- **Users connecting directly to PostgreSQL (no pooler):** no behavior change
- **Users with session pooling mode:** no behavior change
- **Users with transaction pooling mode (pgBouncer, pgcat):** append `?default_query_exec_mode=simple_protocol` to their `WOODPECKER_DATABASE_DATASOURCE` to resolve the error

## Performance note

Simple protocol sends parameters as text (not binary) and cannot reuse prepared statement query plans. For Woodpecker's workload (simple CRUD queries), the difference is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)