### PR TITLE
plugin: ascii junit report: renamed gh username

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -282,7 +282,7 @@
     },
     {
       "name": "ASCII JUnit Test Report",
-      "docs": "https://raw.githubusercontent.com/wgroeneveld/woodpecker-ascii-junit/refs/heads/main/README.md",
+      "docs": "https://raw.githubusercontent.com/brainbaking/woodpecker-ascii-junit/refs/heads/main/README.md",
       "verified": false
     },
     {


### PR DESCRIPTION
I renamed my github username from wgroeneveld to brainbaking, breaking this raw githubusercontent link.
I originally opened a PR in june 2025 for adding that plugin. It's still maintained; the repo URL just moved.