### PR TITLE
Add server config for maximum log lines shown in web UI

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -345,6 +345,12 @@ var flags = append([]cli.Flag{
 		Usage:   "Disable version check in admin web ui.",
 		Name:    "skip-version-check",
 	},
+	&cli.UintFlag{
+		Sources: cli.EnvVars("WOODPECKER_MAX_PIPELINE_LOG_LINE_COUNT"),
+		Usage:   "Maximum number of lines to show in a pipeline log, defaults to 5000.",
+		Name:    "max-pipeline-log-line-count",
+		Value:   5000,
+	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_LOG_STORE"),
 		Name:    "log-store",

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -258,6 +258,7 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 	server.Config.Pipeline.Volumes = c.StringSlice("volume")
 	server.Config.WebUI.EnableSwagger = c.Bool("enable-swagger")
 	server.Config.WebUI.SkipVersionCheck = c.Bool("skip-version-check")
+	server.Config.WebUI.MaxPipelineLogLineCount = c.Uint("max-pipeline-log-line-count")
 	server.Config.Pipeline.PrivilegedPlugins = c.StringSlice("plugins-privileged")
 
 	// prometheus

--- a/server/config.go
+++ b/server/config.go
@@ -58,8 +58,9 @@ var Config = struct {
 		DisableUserRegisteredAgentRegistration bool
 	}
 	WebUI struct {
-		EnableSwagger    bool
-		SkipVersionCheck bool
+		EnableSwagger           bool
+		SkipVersionCheck        bool
+		MaxPipelineLogLineCount uint
 	}
 	Prometheus struct {
 		AuthToken string

--- a/server/web/config.go
+++ b/server/web/config.go
@@ -40,13 +40,14 @@ func Config(c *gin.Context) {
 	}
 
 	configData := map[string]any{
-		"user":                   user,
-		"csrf":                   csrf,
-		"version":                version.String(),
-		"skip_version_check":     server.Config.WebUI.SkipVersionCheck,
-		"root_path":              server.Config.Server.RootPath,
-		"enable_swagger":         server.Config.WebUI.EnableSwagger,
-		"user_registered_agents": !server.Config.Agent.DisableUserRegisteredAgentRegistration,
+		"user":                        user,
+		"csrf":                        csrf,
+		"version":                     version.String(),
+		"skip_version_check":          server.Config.WebUI.SkipVersionCheck,
+		"root_path":                   server.Config.Server.RootPath,
+		"enable_swagger":              server.Config.WebUI.EnableSwagger,
+		"user_registered_agents":      !server.Config.Agent.DisableUserRegisteredAgentRegistration,
+		"max_pipeline_log_line_count": server.Config.WebUI.MaxPipelineLogLineCount,
 	}
 
 	// default func map with json parser.
@@ -81,4 +82,5 @@ window.WOODPECKER_ROOT_PATH = "{{ .root_path }}";
 window.WOODPECKER_ENABLE_SWAGGER = {{ .enable_swagger }};
 window.WOODPECKER_SKIP_VERSION_CHECK = {{ .skip_version_check }}
 window.WOODPECKER_USER_REGISTERED_AGENTS = {{ .user_registered_agents }}
+window.WOODPECKER_MAX_PIPELINE_LOG_LINE_COUNT = {{ .max_pipeline_log_line_count }}
 `

--- a/web/src/components/repo/pipeline/PipelineLog.vue
+++ b/web/src/components/repo/pipeline/PipelineLog.vue
@@ -133,6 +133,7 @@ import { useRoute } from 'vue-router';
 import IconButton from '~/components/atomic/IconButton.vue';
 import PipelineStatusIcon from '~/components/repo/pipeline/PipelineStatusIcon.vue';
 import useApiClient from '~/compositions/useApiClient';
+import useConfig from '~/compositions/useConfig';
 import { requiredInject } from '~/compositions/useInjectProvide';
 import useNotifications from '~/compositions/useNotifications';
 import type { Pipeline, PipelineStep, PipelineWorkflow } from '~/lib/api/types';
@@ -184,7 +185,9 @@ const ansiUp = ref(new AnsiUp());
 ansiUp.value.use_classes = true;
 const logBuffer = ref<LogLine[]>([]);
 
-const maxLineCount = 5000; // TODO(2653): set back to 500 and implement lazy-loading support
+const config = useConfig();
+
+const maxLineCount = config.maxPipelineLogLineCount; // TODO(2653): implement lazy-loading support
 const hasPushPermission = computed(() => repoPermissions?.value?.push);
 
 const urlRegex = /https?:\/\/\S+/g;

--- a/web/src/compositions/useConfig.ts
+++ b/web/src/compositions/useConfig.ts
@@ -9,6 +9,7 @@ declare global {
     WOODPECKER_ROOT_PATH: string | undefined;
     WOODPECKER_ENABLE_SWAGGER: boolean | undefined;
     WOODPECKER_USER_REGISTERED_AGENTS: boolean | undefined;
+    WOODPECKER_MAX_PIPELINE_LOG_LINE_COUNT: number | undefined;
   }
 }
 
@@ -20,4 +21,5 @@ export default () => ({
   rootPath: window.WOODPECKER_ROOT_PATH ?? '',
   enableSwagger: window.WOODPECKER_ENABLE_SWAGGER === true || false,
   userRegisteredAgents: window.WOODPECKER_USER_REGISTERED_AGENTS || false,
+  maxPipelineLogLineCount: window.WOODPECKER_MAX_PIPELINE_LOG_LINE_COUNT || 5000,
 });

--- a/web/src/compositions/useConfig.ts
+++ b/web/src/compositions/useConfig.ts
@@ -21,5 +21,5 @@ export default () => ({
   rootPath: window.WOODPECKER_ROOT_PATH ?? '',
   enableSwagger: window.WOODPECKER_ENABLE_SWAGGER === true || false,
   userRegisteredAgents: window.WOODPECKER_USER_REGISTERED_AGENTS || false,
-  maxPipelineLogLineCount: window.WOODPECKER_MAX_PIPELINE_LOG_LINE_COUNT || 5000,
+  maxPipelineLogLineCount: window.WOODPECKER_MAX_PIPELINE_LOG_LINE_COUNT ?? 5000,
 });


### PR DESCRIPTION
I frequently find it annoying to not be able to see the whole pipeline log. I know that there is already an issue which requests to implement lazy loading for the log, #2653. That would be indeed the best solution. However that might takes a while.

This PR instead makes it possible to configure the maximum number of lines to show in a pipeline log. This allows to tweak the lines to show to whatever fits best for any individual instance.