### PR TITLE
Allow disabling isolated home directory for local agents

### DIFF
--- a/pipeline/backend/local/clone.go
+++ b/pipeline/backend/local/clone.go
@@ -124,6 +124,11 @@ func (e *local) writeNetRC(step *types.Step, state *workflowState) (string, erro
 		return "", nil
 	}
 
+	if !e.isolatedHome {
+		log.Trace().Msg("writing .netrc skipped due to disabled isolated home")
+		return "", nil
+	}
+
 	file := filepath.Join(state.homeDir, ".netrc")
 	rmCmd := fmt.Sprintf("rm \"%s\"", file)
 	if e.os == "windows" {

--- a/pipeline/backend/local/flags.go
+++ b/pipeline/backend/local/flags.go
@@ -31,7 +31,7 @@ var Flags = []cli.Flag{
 	&cli.BoolFlag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_LOCAL_ISOLATED_HOME"),
 		Name:    "backend-local-isolated-home",
-		Usage:   "set HOME, USERPROFILE and other variables to an isolated directory",
+		Usage:   "set HOME, USERPROFILE and other variables to an isolated directory, if false we ignore netrc",
 		Value:   true,
 	},
 }

--- a/pipeline/backend/local/flags.go
+++ b/pipeline/backend/local/flags.go
@@ -28,4 +28,10 @@ var Flags = []cli.Flag{
 		DefaultText: "system temporary directory",
 		Value:       os.TempDir(),
 	},
+	&cli.BoolFlag{
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_LOCAL_ISOLATED_HOME"),
+		Name:    "backend-local-isolated-home",
+		Usage:   "set HOME, USERPROFILE and other variables to an isolated directory",
+		Value:   true,
+	},
 }

--- a/pipeline/backend/local/local.go
+++ b/pipeline/backend/local/local.go
@@ -47,6 +47,7 @@ type stepState struct {
 
 type local struct {
 	tempDir         string
+	isolatedHome    bool
 	workflows       sync.Map
 	pluginGitBinary string
 	os, arch        string
@@ -84,6 +85,7 @@ func (e *local) Load(ctx context.Context) (*types.BackendInfo, error) {
 	c, ok := ctx.Value(types.CliCommand).(*cli.Command)
 	if ok {
 		e.tempDir = c.String("backend-local-temp-dir")
+		e.isolatedHome = c.Bool("backend-local-isolated-home")
 	}
 
 	e.loadClone()
@@ -154,9 +156,11 @@ func (e *local) StartStep(ctx context.Context, step *types.Step, taskUUID string
 		}
 	}
 
-	// Set HOME and CI_WORKSPACE
-	env = append(env, "HOME="+state.homeDir)
-	env = append(env, "USERPROFILE="+state.homeDir)
+	if e.isolatedHome {
+		env = append(env, "HOME="+state.homeDir)
+		env = append(env, "USERPROFILE="+state.homeDir)
+	}
+
 	env = append(env, "CI_WORKSPACE="+state.workspaceDir)
 
 	switch step.Type {

--- a/pipeline/backend/local/local_test.go
+++ b/pipeline/backend/local/local_test.go
@@ -190,6 +190,7 @@ func TestRunStep(t *testing.T) {
 
 	backend, _ := New().(*local)
 	backend.tempDir = t.TempDir()
+	backend.isolatedHome = true
 	ctx := t.Context()
 	taskUUID := "test-run-tasks"
 


### PR DESCRIPTION
Make it possible to disable the isolated home created by the local agent. To do so an environment variable `WOODPECKER_BACKEND_LOCAL_ISOLATED_HOME` is introduced. Set it to `false` to make the local agent not set the environment variables `HOME` and `USERPROFILE`.

This is needed for a Windows local agent. For a Windows environment these two variables are far from being enough, there are multiple other variables, also there is the registry and other stuff. Also for me, the whole point of a local agent is to use the local environment, what ever it is.