### PR TITLE
Sort glossary items alphabetically

### DIFF
--- a/docs/docs/20-usage/15-terminology/index.md
+++ b/docs/docs/20-usage/15-terminology/index.md
@@ -2,29 +2,29 @@
 
 ## Glossary
 
-- **Woodpecker CI**: The project name around Woodpecker.
-- **Woodpecker**: An open-source tool that executes [pipelines][Pipeline] on your code.
-- **Server**: The component of Woodpecker that handles webhooks from forges, orchestrates agents, and sends status back. It also serves the API and web UI for administration and configuration.
 - **Agent**: A component of Woodpecker that executes [pipelines][Pipeline] (specifically one or more [workflows][Workflow]) with a specific backend (e.g. [Docker][], Kubernetes, [local][Local]). It connects to the server via GRPC.
 - **CLI**: The Woodpecker command-line interface (CLI) is a terminal tool used to administer the server, to execute pipelines locally for debugging / testing purposes, and to perform tasks like linting pipelines.
-- **[Pipeline][Pipeline]**: A sequence of [workflows][Workflow] that are executed on the code. Pipelines are triggered by events.
-- **[Workflow][Workflow]**: A sequence of steps and services that are executed as part of a [pipeline][Pipeline]. Workflows are represented by YAML files. Each workflow has its own isolated [workspace][Workspace], and often additional resources like a shared network (docker).
-- **Steps**: Individual commands, actions or tasks within a [workflow][Workflow].
 - **Code**: Refers to the files tracked by the version control system used by the [forge][Forge].
-- **Repos**: Short for repositories, these are storage locations where code is stored.
-- **[Forge][Forge]**: The hosting platform or service where the repositories are hosted.
-- **[Workspace][workspace]**: A folder shared between all steps of a [workflow][Workflow] containing the repository and all the generated data from previous steps.
-- **[Event][Event]**: Triggers the execution of a [pipeline][Pipeline], such as a [forge][Forge] event like `push`, or `manual` triggered manually from the UI.
 - **Commit**: A defined state of the code, usually associated with a version control system like Git.
-- **[Matrix][Matrix]**: A configuration option that allows the execution of [workflows][Workflow] for each value in the matrix.
-- **Service**: A service is a step that is executed from the start of a [workflow][Workflow] until its end. It can be accessed by name via the network from other steps within the same [workflow][Workflow].
-- **[Plugins][Plugin]**: Plugins are extensions that provide pre-defined actions or commands for a step in a [workflow][Workflow]. They can be configured via settings.
 - **Container**: A lightweight and isolated environment where commands are executed.
-- **YAML File**: A file format used to define and configure [workflows][Workflow].
 - **Dependency**: [Workflows][Workflow] can depend on each other, and if possible, they are executed in parallel.
-- **Status**: Status refers to the outcome of a step or [workflow][Workflow] after it has been executed, determined by the internal command exit code. At the end of a [workflow][Workflow], its status is sent to the [forge][Forge].
+- **[Event][Event]**: Triggers the execution of a [pipeline][Pipeline], such as a [forge][Forge] event like `push`, or `manual` triggered manually from the UI.
+- **[Forge][Forge]**: The hosting platform or service where the repositories are hosted.
+- **[Matrix][Matrix]**: A configuration option that allows the execution of [workflows][Workflow] for each value in the matrix.
+- **[Pipeline][Pipeline]**: A sequence of [workflows][Workflow] that are executed on the code. Pipelines are triggered by events.
+- **[Plugins][Plugin]**: Plugins are extensions that provide pre-defined actions or commands for a step in a [workflow][Workflow]. They can be configured via settings.
+- **Repos**: Short for repositories, these are storage locations where code is stored.
+- **Server**: The component of Woodpecker that handles webhooks from forges, orchestrates agents, and sends status back. It also serves the API and web UI for administration and configuration.
+- **Service**: A service is a step that is executed from the start of a [workflow][Workflow] until its end. It can be accessed by name via the network from other steps within the same [workflow][Workflow].
 - **Service extension**: Some parts of Woodpecker internal services like secrets storage or config fetcher can be replaced through service extensions.
+- **Status**: Status refers to the outcome of a step or [workflow][Workflow] after it has been executed, determined by the internal command exit code. At the end of a [workflow][Workflow], its status is sent to the [forge][Forge].
+- **Steps**: Individual commands, actions or tasks within a [workflow][Workflow].
 - **Task**: A task is a [workflow][Workflow] that's currently waiting for its execution in the task queue.
+- **Woodpecker**: An open-source tool that executes [pipelines][Pipeline] on your code.
+- **Woodpecker CI**: The project name around Woodpecker.
+- **[Workflow][Workflow]**: A sequence of steps and services that are executed as part of a [pipeline][Pipeline]. Workflows are represented by YAML files. Each workflow has its own isolated [workspace][Workspace], and often additional resources like a shared network (docker).
+- **[Workspace][workspace]**: A folder shared between all steps of a [workflow][Workflow] containing the repository and all the generated data from previous steps.
+- **YAML File**: A file format used to define and configure [workflows][Workflow].
 
 ## Woodpecker architecture
 

--- a/docs/versioned_docs/version-3.13/20-usage/15-terminology/index.md
+++ b/docs/versioned_docs/version-3.13/20-usage/15-terminology/index.md
@@ -2,29 +2,29 @@
 
 ## Glossary
 
-- **Woodpecker CI**: The project name around Woodpecker.
-- **Woodpecker**: An open-source tool that executes [pipelines][Pipeline] on your code.
-- **Server**: The component of Woodpecker that handles webhooks from forges, orchestrates agents, and sends status back. It also serves the API and web UI for administration and configuration.
 - **Agent**: A component of Woodpecker that executes [pipelines][Pipeline] (specifically one or more [workflows][Workflow]) with a specific backend (e.g. [Docker][], Kubernetes, [local][Local]). It connects to the server via GRPC.
 - **CLI**: The Woodpecker command-line interface (CLI) is a terminal tool used to administer the server, to execute pipelines locally for debugging / testing purposes, and to perform tasks like linting pipelines.
-- **[Pipeline][Pipeline]**: A sequence of [workflows][Workflow] that are executed on the code. Pipelines are triggered by events.
-- **[Workflow][Workflow]**: A sequence of steps and services that are executed as part of a [pipeline][Pipeline]. Workflows are represented by YAML files. Each workflow has its own isolated [workspace][Workspace], and often additional resources like a shared network (docker).
-- **Steps**: Individual commands, actions or tasks within a [workflow][Workflow].
 - **Code**: Refers to the files tracked by the version control system used by the [forge][Forge].
-- **Repos**: Short for repositories, these are storage locations where code is stored.
-- **[Forge][Forge]**: The hosting platform or service where the repositories are hosted.
-- **[Workspace][workspace]**: A folder shared between all steps of a [workflow][Workflow] containing the repository and all the generated data from previous steps.
-- **[Event][Event]**: Triggers the execution of a [pipeline][Pipeline], such as a [forge][Forge] event like `push`, or `manual` triggered manually from the UI.
 - **Commit**: A defined state of the code, usually associated with a version control system like Git.
-- **[Matrix][Matrix]**: A configuration option that allows the execution of [workflows][Workflow] for each value in the matrix.
-- **Service**: A service is a step that is executed from the start of a [workflow][Workflow] until its end. It can be accessed by name via the network from other steps within the same [workflow][Workflow].
-- **[Plugins][Plugin]**: Plugins are extensions that provide pre-defined actions or commands for a step in a [workflow][Workflow]. They can be configured via settings.
 - **Container**: A lightweight and isolated environment where commands are executed.
-- **YAML File**: A file format used to define and configure [workflows][Workflow].
 - **Dependency**: [Workflows][Workflow] can depend on each other, and if possible, they are executed in parallel.
-- **Status**: Status refers to the outcome of a step or [workflow][Workflow] after it has been executed, determined by the internal command exit code. At the end of a [workflow][Workflow], its status is sent to the [forge][Forge].
+- **[Event][Event]**: Triggers the execution of a [pipeline][Pipeline], such as a [forge][Forge] event like `push`, or `manual` triggered manually from the UI.
+- **[Forge][Forge]**: The hosting platform or service where the repositories are hosted.
+- **[Matrix][Matrix]**: A configuration option that allows the execution of [workflows][Workflow] for each value in the matrix.
+- **[Pipeline][Pipeline]**: A sequence of [workflows][Workflow] that are executed on the code. Pipelines are triggered by events.
+- **[Plugins][Plugin]**: Plugins are extensions that provide pre-defined actions or commands for a step in a [workflow][Workflow]. They can be configured via settings.
+- **Repos**: Short for repositories, these are storage locations where code is stored.
+- **Server**: The component of Woodpecker that handles webhooks from forges, orchestrates agents, and sends status back. It also serves the API and web UI for administration and configuration.
+- **Service**: A service is a step that is executed from the start of a [workflow][Workflow] until its end. It can be accessed by name via the network from other steps within the same [workflow][Workflow].
 - **Service extension**: Some parts of Woodpecker internal services like secrets storage or config fetcher can be replaced through service extensions.
+- **Status**: Status refers to the outcome of a step or [workflow][Workflow] after it has been executed, determined by the internal command exit code. At the end of a [workflow][Workflow], its status is sent to the [forge][Forge].
+- **Steps**: Individual commands, actions or tasks within a [workflow][Workflow].
 - **Task**: A task is a [workflow][Workflow] that's currently waiting for its execution in the task queue.
+- **Woodpecker**: An open-source tool that executes [pipelines][Pipeline] on your code.
+- **Woodpecker CI**: The project name around Woodpecker.
+- **[Workflow][Workflow]**: A sequence of steps and services that are executed as part of a [pipeline][Pipeline]. Workflows are represented by YAML files. Each workflow has its own isolated [workspace][Workspace], and often additional resources like a shared network (docker).
+- **[Workspace][workspace]**: A folder shared between all steps of a [workflow][Workflow] containing the repository and all the generated data from previous steps.
+- **YAML File**: A file format used to define and configure [workflows][Workflow].
 
 ## Woodpecker architecture
 


### PR DESCRIPTION
Sorted the glossary items from A to Z, as defined by the word glossary: 

`an alphabetical list, with meanings, of the words or phrases in a text that are difficult to understand`  - Oxford Dictionary

The text were keep the same, I only changed the order of the items on the list.
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
