### PR TITLE
Prevent registering as arbitrary agents with system token

### DIFF
--- a/server/rpc/auth_server.go
+++ b/server/rpc/auth_server.go
@@ -76,10 +76,17 @@ func (s *WoodpeckerAuthServer) getAgent(agentID int64, agentToken string) (*mode
 
 		if agentToken == s.agentMasterToken {
 			agent, err := s.store.AgentFind(agentID)
-			if err != nil && errors.Is(err, types.ErrRecordNotExist) {
-				return nil, fmt.Errorf("AgentID not found in database")
+			if err != nil {
+				if errors.Is(err, types.ErrRecordNotExist) {
+					return nil, fmt.Errorf("AgentID not found in database")
+				} else {
+					return nil, err
+				}
 			}
-			return agent, err
+			if !agent.IsSystemAgent() {
+				return nil, fmt.Errorf("the agent with this ID is not a system agent")
+			}
+			return agent, nil
 		}
 	}
 


### PR DESCRIPTION
Prevent that an agent can register as any other agent by its ID if it has the system token.

This is no big thread, just hardening, as if an user has already the system token, he can create new agents anyway as he likes.