### PR TITLE
feat(ui): show global/org registries in repo/org registries tab

### DIFF
--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -517,6 +517,8 @@
   "update_woodpecker": "Please update your Woodpecker instance to {0}",
   "global_level_secret": "global secret",
   "org_level_secret": "organization secret",
+  "global_level_registry": "global registry",
+  "org_level_registry": "organization registry",
   "login_to_cli": "Login to CLI",
   "login_to_cli_description": "If you continue, you will be logged in to the CLI.",
   "abort": "Abort",

--- a/web/src/components/registry/RegistryList.vue
+++ b/web/src/components/registry/RegistryList.vue
@@ -6,15 +6,20 @@
       class="bg-wp-background-200! dark:bg-wp-background-200! items-center"
     >
       <span>{{ registry.address }}</span>
+      <Badge
+        v-if="registry.edit === false"
+        class="ml-2"
+        :value="registry.org_id === 0 ? $t('global_level_registry') : $t('org_level_registry')"
+      />
       <div class="ml-auto flex items-center gap-2">
         <IconButton
-          :icon="registry.readonly ? 'chevron-right' : 'edit'"
+          :icon="registry.edit === false ? 'chevron-right' : 'edit'"
           class="h-8 w-8"
-          :title="registry.readonly ? $t('registries.view') : $t('registries.edit')"
+          :title="registry.edit === false ? $t('registries.view') : $t('registries.edit')"
           @click="editRegistry(registry)"
         />
         <IconButton
-          v-if="!registry.readonly"
+          v-if="registry.edit !== false"
           icon="trash"
           class="hover:text-wp-error-100 h-8 w-8"
           :is-loading="isDeleting"
@@ -35,6 +40,7 @@
 import { toRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import Badge from '~/components/atomic/Badge.vue';
 import Icon from '~/components/atomic/Icon.vue';
 import IconButton from '~/components/atomic/IconButton.vue';
 import ListItem from '~/components/atomic/ListItem.vue';

--- a/web/src/views/org/settings/OrgRegistries.vue
+++ b/web/src/views/org/settings/OrgRegistries.vue
@@ -64,11 +64,47 @@ const org = requiredInject('org');
 const selectedRegistry = ref<Partial<Registry>>();
 const isEditing = computed(() => !!selectedRegistry.value?.id);
 
-async function loadRegistries(page: number): Promise<Registry[] | null> {
-  return apiClient.getOrgRegistryList(org.value.id, { page });
+async function loadRegistries(page: number, level: 'org' | 'global'): Promise<Registry[] | null> {
+  switch (level) {
+    case 'org':
+      return apiClient.getOrgRegistryList(org.value.id, { page });
+    case 'global':
+      return apiClient.getGlobalRegistryList({ page });
+    default:
+      throw new Error(`Unexpected level: ${level}`);
+  }
 }
 
-const { resetPage, data: registries, loading } = usePagination(loadRegistries, () => !selectedRegistry.value);
+const {
+  resetPage,
+  data: _registries,
+  loading,
+} = usePagination(loadRegistries, () => !selectedRegistry.value, {
+  each: ['org', 'global'],
+});
+const registries = computed(() => {
+  const registriesList: Record<string, Registry & { edit?: boolean; level: 'org' | 'global' }> = {};
+
+  for (const level of ['org', 'global']) {
+    for (const registry of _registries.value) {
+      if (
+        ((level === 'org' && registry.org_id !== 0) || (level === 'global' && registry.org_id === 0)) &&
+        !registriesList[registry.address]
+      ) {
+        registriesList[registry.address] = { ...registry, edit: registry.org_id !== 0, level };
+      }
+    }
+  }
+
+  const levelsOrder = {
+    global: 0,
+    org: 1,
+  };
+
+  return Object.values(registriesList)
+    .toSorted((a, b) => a.address.localeCompare(b.address))
+    .toSorted((a, b) => levelsOrder[b.level] - levelsOrder[a.level]);
+});
 
 const { doSubmit: createRegistry, isLoading: isSaving } = useAsyncAction(async () => {
   if (!selectedRegistry.value) {

--- a/web/src/views/repo/settings/Registries.vue
+++ b/web/src/views/repo/settings/Registries.vue
@@ -60,11 +60,52 @@ const repo = requiredInject('repo');
 const selectedRegistry = ref<Partial<Registry>>();
 const isEditingRegistry = computed(() => !!selectedRegistry.value?.id);
 
-async function loadRegistries(page: number): Promise<Registry[] | null> {
-  return apiClient.getRegistryList(repo.value.id, { page });
+async function loadRegistries(page: number, level: 'repo' | 'org' | 'global'): Promise<Registry[] | null> {
+  switch (level) {
+    case 'repo':
+      return apiClient.getRegistryList(repo.value.id, { page });
+    case 'org':
+      return apiClient.getOrgRegistryList(repo.value.org_id, { page });
+    case 'global':
+      return apiClient.getGlobalRegistryList({ page });
+    default:
+      throw new Error(`Unexpected level: ${level}`);
+  }
 }
 
-const { resetPage, data: registries, loading } = usePagination(loadRegistries, () => !selectedRegistry.value);
+const {
+  resetPage,
+  data: _registries,
+  loading,
+} = usePagination(loadRegistries, () => !selectedRegistry.value, {
+  each: ['repo', 'org', 'global'],
+});
+const registries = computed(() => {
+  const registriesList: Record<string, Registry & { edit?: boolean; level: 'repo' | 'org' | 'global' }> = {};
+
+  for (const level of ['repo', 'org', 'global']) {
+    for (const registry of _registries.value) {
+      if (
+        ((level === 'repo' && registry.repo_id !== 0 && registry.org_id === 0) ||
+          (level === 'org' && registry.repo_id === 0 && registry.org_id !== 0) ||
+          (level === 'global' && registry.repo_id === 0 && registry.org_id === 0)) &&
+        !registriesList[registry.address]
+      ) {
+        registriesList[registry.address] = { ...registry, edit: registry.repo_id !== 0, level };
+      }
+    }
+  }
+
+  const levelsOrder = {
+    global: 0,
+    org: 1,
+    repo: 2,
+  };
+
+  return Object.values(registriesList)
+    .toSorted((a, b) => a.address.localeCompare(b.address))
+    .toSorted((a, b) => levelsOrder[b.level] - levelsOrder[a.level]);
+});
 
 const { doSubmit: createRegistry, isLoading: isSaving } = useAsyncAction(async () => {
   if (!selectedRegistry.value) {


### PR DESCRIPTION
Closes #5950

## Summary

Replicates the existing pattern used for secrets to also show global and organization-level registries in the repository and organization registries tabs as read-only entries with level badges.

### Changes

- **Repo registries tab** (`Registries.vue`): Now loads registries from repo, org, and global levels using the `usePagination` `each` parameter (same pattern as `Secrets.vue`). Deduplicates by address with repo-level taking priority, and sorts by level then address.
- **Org registries tab** (`OrgRegistries.vue`): Now loads registries from org and global levels. Global registries are shown as read-only with a badge.
- **RegistryList component** (`RegistryList.vue`): Added a `Badge` component to indicate when a registry comes from the global or organization level (matching the existing `SecretList.vue` pattern). Edit/delete buttons are hidden for read-only (inherited) registries.
- **Locale** (`en.json`): Added `global_level_registry` and `org_level_registry` translation keys.

### How it works

This follows the exact same approach already used for secrets:
1. The `usePagination` hook's `each` parameter iterates through levels (repo → org → global)
2. A computed property deduplicates entries by address, giving priority to the most specific level
3. Inherited (non-repo) registries are marked as `edit: false` and shown as read-only
4. The `RegistryEdit` component already supports `readonly` mode, so clicking a read-only registry shows its details without allowing edits

### Testing

- `pnpm typecheck` passes
- `pnpm build` passes