### PR TITLE
feat(ui): show forge origin in admin users panel

### DIFF
--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -406,7 +406,8 @@
           "placeholder": "User is an admin"
         },
         "delete_user": "Delete user",
-        "edit_user": "Edit user"
+        "edit_user": "Edit user",
+        "forge": "Forge"
       },
       "orgs": {
         "orgs": "Organizations",

--- a/web/src/views/admin/AdminUsers.vue
+++ b/web/src/views/admin/AdminUsers.vue
@@ -18,12 +18,13 @@
       >
         <img v-if="user.avatar_url" class="h-6 rounded-md" :src="user.avatar_url" />
         <span>{{ user.login }}</span>
+        <Badge v-if="getForgeLabel(user.forge_id)" :label="$t('admin.settings.users.forge')" :value="getForgeLabel(user.forge_id)" />
         <Badge
           v-if="user.admin"
-          class="md:display-unset ml-auto hidden"
+          class="md:display-unset hidden"
           :value="$t('admin.settings.users.admin.admin')"
         />
-        <div class="flex items-center gap-2" :class="{ 'ml-auto': !user.admin, 'ml-2': user.admin }">
+        <div class="flex items-center gap-2" :class="{ 'ml-auto': !user.admin }">
           <IconButton
             icon="edit"
             :title="$t('admin.settings.users.edit_user')"
@@ -62,6 +63,10 @@
           </div>
         </InputField>
 
+        <InputField v-if="isEditingUser && selectedUser.forge_id" :label="$t('admin.settings.users.forge')">
+          <Badge :value="getForgeLabel(selectedUser.forge_id)" />
+        </InputField>
+
         <InputField :label="$t('admin.settings.users.admin.admin')">
           <Checkbox
             :model-value="selectedUser.admin || false"
@@ -87,7 +92,7 @@
 
 <script lang="ts" setup>
 import { cloneDeep } from 'lodash';
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import Badge from '~/components/atomic/Badge.vue';
@@ -104,7 +109,7 @@ import { useAsyncAction } from '~/compositions/useAsyncAction';
 import useNotifications from '~/compositions/useNotifications';
 import { usePagination } from '~/compositions/usePaginate';
 import { useWPTitle } from '~/compositions/useWPTitle';
-import type { User } from '~/lib/api/types';
+import type { Forge, User } from '~/lib/api/types';
 
 const apiClient = useApiClient();
 const notifications = useNotifications();
@@ -112,6 +117,38 @@ const { t } = useI18n();
 
 const selectedUser = ref<Partial<User>>();
 const isEditingUser = computed(() => !!selectedUser.value?.id);
+
+const forgesMap = ref<Map<number, Forge>>(new Map());
+
+async function loadForges() {
+  const forges = await apiClient.getForges({ page: 1 });
+  if (forges) {
+    forgesMap.value = new Map(forges.map((f) => [f.id, f]));
+  }
+}
+
+const forgeTypeNames: Record<string, string> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  gitea: 'Gitea',
+  forgejo: 'Forgejo',
+  bitbucket: 'Bitbucket',
+  'bitbucket-dc': 'Bitbucket DC',
+  addon: 'Addon',
+};
+
+function getForgeLabel(forgeId: number | undefined): string | undefined {
+  if (!forgeId) {
+    return undefined;
+  }
+  const forge = forgesMap.value.get(forgeId);
+  if (!forge) {
+    return undefined;
+  }
+  return forgeTypeNames[forge.type] || forge.type;
+}
+
+onMounted(loadForges);
 
 async function loadUsers(page: number): Promise<User[] | null> {
   return apiClient.getUsers({ page });


### PR DESCRIPTION
Closes #5678

## Summary

Adds a forge indicator to the admin users list and detail view, so admins can see which forge (GitHub, Gitea, GitLab, Forgejo, Bitbucket, etc.) each user belongs to.

## Changes

- **Admin users list**: Added a `Badge` next to each user showing the forge type (e.g. "Forge: GitHub")
- **User detail/edit view**: Added a read-only forge field when editing an existing user
- **Data fetching**: Forges are loaded on mount and cached in a `Map<forgeId, Forge>` for efficient lookup
- **i18n**: Added `admin.settings.users.forge` key for the "Forge" label

## How it works

The component fetches all configured forges via `getForges()` on mount, builds a lookup map by ID, and uses `user.forge_id` to resolve and display the forge type name for each user.

## Test plan

- [ ] Open the admin panel > Users page
- [ ] Verify each user shows a forge badge (e.g. "Forge: GitHub") in the list
- [ ] Click edit on a user — verify the forge field appears as read-only
- [ ] Verify the page works correctly with multiple forges configured
- [ ] Verify no errors when a user has no forge_id set