### PR TITLE
Allow default clone step to run unprivileged

### DIFF
--- a/pipeline/frontend/yaml/compiler/compiler.go
+++ b/pipeline/frontend/yaml/compiler/compiler.go
@@ -149,7 +149,11 @@ func (c *Compiler) Compile(conf *yaml_types.Workflow) (*backend_types.Config, er
 
 	// add default clone step
 	if !c.local && len(conf.Clone.ContainerList) == 0 && !conf.SkipClone && len(c.defaultClonePlugin) != 0 {
-		cloneSettings := map[string]any{"depth": "0"}
+		cloneSettings := map[string]any{
+			"depth":  "0",
+			"home":   "/tmp",
+			"target": path.Join(pluginWorkspaceBase, c.workspacePath),
+		}
 		if c.metadata.Curr.Event == metadata.EventTag {
 			cloneSettings["tags"] = "true"
 		}
@@ -158,6 +162,7 @@ func (c *Compiler) Compile(conf *yaml_types.Workflow) (*backend_types.Config, er
 			Image:       c.defaultClonePlugin,
 			Settings:    cloneSettings,
 			Environment: make(map[string]any),
+			Directory:   pluginWorkspaceBase,
 		}
 		for k, v := range c.cloneEnv {
 			container.Environment[k] = v


### PR DESCRIPTION
Currently, the default clone step requires root privileges to run in Kubernetes (and probably on other container based runtimes). 

As explained in https://github.com/woodpecker-ci/woodpecker/issues/5346#issuecomment-4107529989:
> The issue @dhess reported earlier with the Permission denied error when running the clone step as non-root happens because the woodpecker-agent sets the plugin-git step container's workingDir to $CI_WORKSPACE, which is a non-existent directory inside the PVC for the workflow pod. The container runtime then creates it with permissions 0755 and ownership set to root.

This PR fixes the issue by setting the working directory of the default clone step to `pluginWorkspaceBase`, which should exists as it's the volume the agent mounts for the container by default.

In addition to that, to preserve the same behavior as before, it sets the `target` option of `plugin-git` to ` path.Join(pluginWorkspaceBase, c.workspacePath)`, so that the git repo contents are cloned to the same directory as before. The `plugin-git` image already [does a `mkdir` op](https://github.com/woodpecker-ci/plugin-git/blob/4da134977004a7137974b247d79804b2f04ad60e/plugin.go#L37-L42) if the target directory doesn't exists. In this case the directory gets created with the correct permissions and ownership, as opposed to what happens when we let the container runtime create it.

Finally, it sets the `home` option of `plugin-git` to `/tmp`, which is a directory that already exists in Alpine images and is writable by everybody. I'm unsure wether this `home` fix needs to be here or is better to directly [fix it in the `plugin-git` image itself](https://github.com/woodpecker-ci/plugin-git/blob/4da134977004a7137974b247d79804b2f04ad60e/docker/Dockerfile.multiarch#L11).

This PR, in addition to #6307 and #6310, should close #5346.

While both PRs need to be merged to properly close #5346, this PR changes are self-contained and don't require either PR to be merged first.