### PR TITLE
Improve linter warning when step has no when block

### DIFF
--- a/pipeline/frontend/yaml/linter/linter.go
+++ b/pipeline/frontend/yaml/linter/linter.go
@@ -342,8 +342,10 @@ func (l *Linter) lintBadHabits(config *WorkflowConfig) (err error) {
 		// root whens do not necessarily have an event filter, check steps
 		for _, step := range parsed.Steps.ContainerList {
 			var field string
+			var msg string
 			if len(step.When.Constraints) == 0 {
 				field = fmt.Sprintf("steps.%s", step.Name)
+				msg = "Consider adding a `when` block with an `event` filter to this step or the entire workflow"
 			} else {
 				stepEventIndex := -1
 				for i, c := range step.When.Constraints {
@@ -354,12 +356,13 @@ func (l *Linter) lintBadHabits(config *WorkflowConfig) (err error) {
 				}
 				if stepEventIndex > -1 {
 					field = fmt.Sprintf("steps.%s.when[%d]", step.Name, stepEventIndex)
+					msg = "Set an event filter for all steps or the entire workflow on all items of the `when` block"
 				}
 			}
 			if field != "" {
 				err = multierr.Append(err, &pipeline_errors.PipelineError{
 					Type:    pipeline_errors.PipelineErrorTypeBadHabit,
-					Message: "Set an event filter for all steps or the entire workflow on all items of the `when` block",
+					Message: msg,
 					Data: pipeline_errors.BadHabitErrorData{
 						File:  config.File,
 						Field: field,

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -214,10 +214,14 @@ func TestBadHabits(t *testing.T) {
 	}{
 		{
 			from: "steps: { build: { image: golang } }",
-			want: "Set an event filter for all steps or the entire workflow on all items of the `when` block",
+			want: "Consider adding a `when` block with an `event` filter to this step or the entire workflow",
 		},
 		{
 			from: "when: [{branch: xyz}, {event: push}]\nsteps: { build: { image: golang } }",
+			want: "Consider adding a `when` block with an `event` filter to this step or the entire workflow",
+		},
+		{
+			from: "steps: { build: { image: golang, when: [{branch: main}] } }",
 			want: "Set an event filter for all steps or the entire workflow on all items of the `when` block",
 		},
 	}


### PR DESCRIPTION
When a step has no `when` block at all, the linter produced a confusing message referencing "the `when` block" that doesn't exist. This differentiates the message:

- **No `when` block**: "Consider adding a `when` block with an `event` filter to this step or the entire workflow"
- **`when` block exists but missing event filter**: keeps the existing message

Also adds a test case for the scenario where a step has a `when` block without an event filter.

Closes #3773