### PR TITLE
Fix workflow serialize to omit skip_clone if false

### DIFF
--- a/pipeline/frontend/yaml/parse_test.go
+++ b/pipeline/frontend/yaml/parse_test.go
@@ -48,8 +48,7 @@ func TestParse(t *testing.T) {
 		assert.Equal(t, "build", out.Labels["com.example.type"])
 		assert.Equal(t, "lint", out.DependsOn[0])
 		assert.Equal(t, "test", out.DependsOn[1])
-		assert.Equal(t, ("success"), out.RunsOn[0]) //nolint:staticcheck
-		assert.Equal(t, ("failure"), out.RunsOn[1]) //nolint:staticcheck
+		assert.EqualValues(t, []string{"success", "failure"}, out.When.Constraints[0].Status)
 		assert.False(t, out.SkipClone)
 	})
 
@@ -171,8 +170,10 @@ when:
   - event:
     - tester
     - tester2
+    status: [ success, failure ]
   - branch:
     - tester
+    status: [ success, failure ]
 workspace:
   path: src/github.com/octocat/hello-world
   base: /go
@@ -204,9 +205,6 @@ labels:
 depends_on:
   - lint
   - test
-runs_on:
-  - success
-  - failure
 `
 
 var simpleYamlAnchors = `
@@ -278,7 +276,6 @@ func TestReSerialize(t *testing.T) {
       environment:
         DRIVER: next
         PLATFORM: linux
-skip_clone: false
 `, string(work1Bin))
 
 	work2, err := ParseString(sampleYaml)
@@ -289,10 +286,16 @@ skip_clone: false
 
 	// TODO: fix "steps.[1].depends_on: []" to be re-serialized!
 	assert.EqualValues(t, `when:
-    - event:
+    - status:
+        - success
+        - failure
+      event:
         - tester
         - tester2
     - branch: tester
+      status:
+        - success
+        - failure
 workspace:
     base: /go
     path: src/github.com/octocat/hello-world
@@ -322,10 +325,6 @@ labels:
 depends_on:
     - lint
     - test
-skip_clone: false
-runs_on:
-    - success
-    - failure
 `, string(workBin2))
 }
 

--- a/pipeline/frontend/yaml/types/workflow.go
+++ b/pipeline/frontend/yaml/types/workflow.go
@@ -28,7 +28,7 @@ type (
 		Services  ContainerList     `yaml:"services,omitempty"`
 		Labels    map[string]string `yaml:"labels,omitempty"`
 		DependsOn []string          `yaml:"depends_on,omitempty"`
-		SkipClone bool              `yaml:"skip_clone"`
+		SkipClone bool              `yaml:"skip_clone,omitempty"`
 		// Deprecated: use when.status. TODO remove in next major.
 		RunsOn []string `yaml:"runs_on,omitempty"`
 	}


### PR DESCRIPTION
as skip_clone is false by default we can omit it.

this also prepares the test to use the modern workflow RunsOn to use the when filter.

fixes https://codeberg.org/lafriks/woodpecker-pipeline-transform/issues/35