### PR TITLE
Unify server API parameters to snake_case

### DIFF
--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -679,7 +679,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/forges/{forgeId}": {
+        "/forges/{forge_id}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -699,7 +699,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the forge's id",
-                        "name": "forgeId",
+                        "name": "forge_id",
                         "in": "path",
                         "required": true
                     }
@@ -733,7 +733,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the forge's id",
-                        "name": "forgeId",
+                        "name": "forge_id",
                         "in": "path",
                         "required": true
                     }
@@ -764,7 +764,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the forge's id",
-                        "name": "forgeId",
+                        "name": "forge_id",
                         "in": "path",
                         "required": true
                     },
@@ -2695,7 +2695,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repos/{repo_id}/logs/{number}": {
+        "/repos/{repo_id}/logs/{pipeline_number}": {
             "delete": {
                 "produces": [
                     "text/plain"
@@ -2723,7 +2723,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     }
@@ -2735,7 +2735,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repos/{repo_id}/logs/{number}/{stepID}": {
+        "/repos/{repo_id}/logs/{pipeline_number}/{step_id}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2763,14 +2763,14 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "integer",
                         "description": "the step id",
-                        "name": "stepID",
+                        "name": "step_id",
                         "in": "path",
                         "required": true
                     }
@@ -2786,9 +2786,7 @@ const docTemplate = `{
                         }
                     }
                 }
-            }
-        },
-        "/repos/{repo_id}/logs/{number}/{stepId}": {
+            },
             "delete": {
                 "produces": [
                     "text/plain"
@@ -2816,14 +2814,14 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "integer",
                         "description": "the step id",
-                        "name": "stepId",
+                        "name": "step_id",
                         "in": "path",
                         "required": true
                     }
@@ -3045,7 +3043,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repos/{repo_id}/pipelines/{number}": {
+        "/repos/{repo_id}/pipelines/{pipeline_number}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3073,7 +3071,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline, OR 'latest'",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     }
@@ -3115,7 +3113,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     },
@@ -3168,7 +3166,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     }
@@ -3180,7 +3178,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repos/{repo_id}/pipelines/{number}/approve": {
+        "/repos/{repo_id}/pipelines/{pipeline_number}/approve": {
             "post": {
                 "produces": [
                     "application/json"
@@ -3208,7 +3206,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     }
@@ -3223,7 +3221,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repos/{repo_id}/pipelines/{number}/cancel": {
+        "/repos/{repo_id}/pipelines/{pipeline_number}/cancel": {
             "post": {
                 "produces": [
                     "text/plain"
@@ -3251,7 +3249,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     }
@@ -3263,7 +3261,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repos/{repo_id}/pipelines/{number}/config": {
+        "/repos/{repo_id}/pipelines/{pipeline_number}/config": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3291,7 +3289,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     }
@@ -3309,7 +3307,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repos/{repo_id}/pipelines/{number}/decline": {
+        "/repos/{repo_id}/pipelines/{pipeline_number}/decline": {
             "post": {
                 "produces": [
                     "application/json"
@@ -3337,7 +3335,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     }
@@ -3352,7 +3350,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repos/{repo_id}/pipelines/{number}/metadata": {
+        "/repos/{repo_id}/pipelines/{pipeline_number}/metadata": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3380,7 +3378,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the number of the pipeline",
-                        "name": "number",
+                        "name": "pipeline_number",
                         "in": "path",
                         "required": true
                     }
@@ -4170,7 +4168,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/stream/logs/{repo_id}/{pipeline}/{stepID}": {
+        "/stream/logs/{repo_id}/{pipeline}/{step_id}": {
             "get": {
                 "produces": [
                     "text/plain"
@@ -4197,7 +4195,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "the step id",
-                        "name": "stepID",
+                        "name": "step_id",
                         "in": "path",
                         "required": true
                     }

--- a/server/api/forge.go
+++ b/server/api/forge.go
@@ -64,9 +64,9 @@ func GetForges(c *gin.Context) {
 //	@Success	200	{object}	Forge
 //	@Tags		Forges
 //	@Param		Authorization	header	string	false	"Insert your personal access token"	default(Bearer <personal access token>)
-//	@Param		forgeId			path	int		true	"the forge's id"
+//	@Param		forge_id			path	int		true	"the forge's id"
 func GetForge(c *gin.Context) {
-	forgeID, err := strconv.ParseInt(c.Param("forgeId"), 10, 64)
+	forgeID, err := strconv.ParseInt(c.Param("forge_id"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -94,7 +94,7 @@ func GetForge(c *gin.Context) {
 //	@Success	200	{object}	Forge
 //	@Tags		Forges
 //	@Param		Authorization	header	string						true	"Insert your personal access token"	default(Bearer <personal access token>)
-//	@Param		forgeId			path	int							true	"the forge's id"
+//	@Param		forge_id			path	int							true	"the forge's id"
 //	@Param		forgeData		body	ForgeWithOAuthClientSecret	true	"the forge's data"
 func PatchForge(c *gin.Context) {
 	_store := store.FromContext(c)
@@ -106,7 +106,7 @@ func PatchForge(c *gin.Context) {
 		return
 	}
 
-	forgeID, err := strconv.ParseInt(c.Param("forgeId"), 10, 64)
+	forgeID, err := strconv.ParseInt(c.Param("forge_id"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -178,11 +178,11 @@ func PostForge(c *gin.Context) {
 //	@Success	200
 //	@Tags		Forges
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
-//	@Param		forgeId			path	int		true	"the forge's id"
+//	@Param		forge_id			path	int		true	"the forge's id"
 func DeleteForge(c *gin.Context) {
 	_store := store.FromContext(c)
 
-	forgeID, err := strconv.ParseInt(c.Param("forgeId"), 10, 64)
+	forgeID, err := strconv.ParseInt(c.Param("forge_id"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return

--- a/server/api/forge.go
+++ b/server/api/forge.go
@@ -64,7 +64,7 @@ func GetForges(c *gin.Context) {
 //	@Success	200	{object}	Forge
 //	@Tags		Forges
 //	@Param		Authorization	header	string	false	"Insert your personal access token"	default(Bearer <personal access token>)
-//	@Param		forge_id			path	int		true	"the forge's id"
+//	@Param		forge_id		path	int		true	"the forge's id"
 func GetForge(c *gin.Context) {
 	forgeID, err := strconv.ParseInt(c.Param("forge_id"), 10, 64)
 	if err != nil {
@@ -94,7 +94,7 @@ func GetForge(c *gin.Context) {
 //	@Success	200	{object}	Forge
 //	@Tags		Forges
 //	@Param		Authorization	header	string						true	"Insert your personal access token"	default(Bearer <personal access token>)
-//	@Param		forge_id			path	int							true	"the forge's id"
+//	@Param		forge_id		path	int							true	"the forge's id"
 //	@Param		forgeData		body	ForgeWithOAuthClientSecret	true	"the forge's data"
 func PatchForge(c *gin.Context) {
 	_store := store.FromContext(c)
@@ -178,7 +178,7 @@ func PostForge(c *gin.Context) {
 //	@Success	200
 //	@Tags		Forges
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
-//	@Param		forge_id			path	int		true	"the forge's id"
+//	@Param		forge_id		path	int		true	"the forge's id"
 func DeleteForge(c *gin.Context) {
 	_store := store.FromContext(c)
 

--- a/server/api/forge.go
+++ b/server/api/forge.go
@@ -59,7 +59,7 @@ func GetForges(c *gin.Context) {
 // GetForge
 //
 //	@Summary	Get a forge
-//	@Router		/forges/{forgeId} [get]
+//	@Router		/forges/{forge_id} [get]
 //	@Produce	json
 //	@Success	200	{object}	Forge
 //	@Tags		Forges
@@ -89,7 +89,7 @@ func GetForge(c *gin.Context) {
 // PatchForge
 //
 //	@Summary	Update a forge
-//	@Router		/forges/{forgeId} [patch]
+//	@Router		/forges/{forge_id} [patch]
 //	@Produce	json
 //	@Success	200	{object}	Forge
 //	@Tags		Forges
@@ -173,7 +173,7 @@ func PostForge(c *gin.Context) {
 // DeleteForge
 //
 //	@Summary	Delete a forge
-//	@Router		/forges/{forgeId} [delete]
+//	@Router		/forges/{forge_id} [delete]
 //	@Produce	plain
 //	@Success	200
 //	@Tags		Forges

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -197,7 +197,7 @@ func GetPipelines(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 func DeletePipeline(c *gin.Context) {
 	_store := store.FromContext(c)
 
@@ -237,7 +237,7 @@ func DeletePipeline(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline, OR 'latest'"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline, OR 'latest'"
 func GetPipeline(c *gin.Context) {
 	_store := store.FromContext(c)
 	if c.Param("pipeline_number") == "latest" {
@@ -292,7 +292,7 @@ func GetPipelineLastByBranch(c *gin.Context) {
 //	@Tags		Pipeline logs
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 //	@Param		step_id			path	int		true	"the step id"
 func GetStepLogs(c *gin.Context) {
 	_store := store.FromContext(c)
@@ -348,7 +348,7 @@ func GetStepLogs(c *gin.Context) {
 //	@Tags		Pipeline logs
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 //	@Param		step_id			path	int		true	"the step id"
 func DeleteStepLogs(c *gin.Context) {
 	_store := store.FromContext(c)
@@ -408,7 +408,7 @@ func DeleteStepLogs(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 func GetPipelineConfig(c *gin.Context) {
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
@@ -442,7 +442,7 @@ func GetPipelineConfig(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 func GetPipelineMetadata(c *gin.Context) {
 	repo := session.Repo(c)
 	num, err := strconv.ParseInt(c.Param("pipeline_number"), 10, 64)
@@ -483,7 +483,7 @@ func GetPipelineMetadata(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 func CancelPipeline(c *gin.Context) {
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
@@ -521,7 +521,7 @@ func CancelPipeline(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 func PostApproval(c *gin.Context) {
 	var (
 		_store = store.FromContext(c)
@@ -553,7 +553,7 @@ func PostApproval(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 func PostDecline(c *gin.Context) {
 	var (
 		_store = store.FromContext(c)
@@ -603,7 +603,7 @@ func GetPipelineQueue(c *gin.Context) {
 //	@Tags			Pipelines
 //	@Param			Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param			repo_id			path	int		true	"the repository id"
-//	@Param			pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param			pipeline_number	path	int		true	"the number of the pipeline"
 //	@Param			event			query	string	false	"override the event type"
 //	@Param			deploy_to		query	string	false	"override the target deploy value"
 func PostPipeline(c *gin.Context) {
@@ -685,7 +685,7 @@ func PostPipeline(c *gin.Context) {
 //	@Tags		Pipeline logs
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number	path	int		true	"the number of the pipeline"
 func DeletePipelineLogs(c *gin.Context) {
 	_store := store.FromContext(c)
 

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -191,7 +191,7 @@ func GetPipelines(c *gin.Context) {
 // DeletePipeline
 //
 //	@Summary	Delete a pipeline
-//	@Router		/repos/{repo_id}/pipelines/{number} [delete]
+//	@Router		/repos/{repo_id}/pipelines/{pipeline_number} [delete]
 //	@Produce	plain
 //	@Success	204
 //	@Tags		Pipelines
@@ -231,7 +231,7 @@ func DeletePipeline(c *gin.Context) {
 // GetPipeline
 //
 //	@Summary	Get a repositories pipeline
-//	@Router		/repos/{repo_id}/pipelines/{number} [get]
+//	@Router		/repos/{repo_id}/pipelines/{pipeline_number} [get]
 //	@Produce	json
 //	@Success	200	{object}	Pipeline
 //	@Tags		Pipelines
@@ -240,7 +240,7 @@ func DeletePipeline(c *gin.Context) {
 //	@Param		pipeline_number			path	int		true	"the number of the pipeline, OR 'latest'"
 func GetPipeline(c *gin.Context) {
 	_store := store.FromContext(c)
-	if c.Param("number") == "latest" {
+	if c.Param("pipeline_number") == "latest" {
 		GetPipelineLastByBranch(c)
 		return
 	}
@@ -286,7 +286,7 @@ func GetPipelineLastByBranch(c *gin.Context) {
 // GetStepLogs
 //
 //	@Summary	Get logs for a pipeline step
-//	@Router		/repos/{repo_id}/logs/{number}/{step_id} [get]
+//	@Router		/repos/{repo_id}/logs/{pipeline_number}/{step_id} [get]
 //	@Produce	json
 //	@Success	200	{array}	LogEntry
 //	@Tags		Pipeline logs
@@ -342,7 +342,7 @@ func GetStepLogs(c *gin.Context) {
 // DeleteStepLogs
 //
 //	@Summary	Delete step logs of a pipeline
-//	@Router		/repos/{repo_id}/logs/{number}/{step_id} [delete]
+//	@Router		/repos/{repo_id}/logs/{pipeline_number}/{step_id} [delete]
 //	@Produce	plain
 //	@Success	204
 //	@Tags		Pipeline logs
@@ -402,7 +402,7 @@ func DeleteStepLogs(c *gin.Context) {
 // GetPipelineConfig
 //
 //	@Summary	Get configuration files for a pipeline
-//	@Router		/repos/{repo_id}/pipelines/{number}/config [get]
+//	@Router		/repos/{repo_id}/pipelines/{pipeline_number}/config [get]
 //	@Produce	json
 //	@Success	200	{array}	Config
 //	@Tags		Pipelines
@@ -436,7 +436,7 @@ func GetPipelineConfig(c *gin.Context) {
 // GetPipelineMetadata
 //
 //	@Summary	Get metadata for a pipeline or a specific workflow, including previous pipeline info
-//	@Router		/repos/{repo_id}/pipelines/{number}/metadata [get]
+//	@Router		/repos/{repo_id}/pipelines/{pipeline_number}/metadata [get]
 //	@Produce	json
 //	@Success	200	{object}	metadata.Metadata
 //	@Tags		Pipelines
@@ -477,7 +477,7 @@ func GetPipelineMetadata(c *gin.Context) {
 // CancelPipeline
 //
 //	@Summary	Cancel a pipeline
-//	@Router		/repos/{repo_id}/pipelines/{number}/cancel [post]
+//	@Router		/repos/{repo_id}/pipelines/{pipeline_number}/cancel [post]
 //	@Produce	plain
 //	@Success	200
 //	@Tags		Pipelines
@@ -515,7 +515,7 @@ func CancelPipeline(c *gin.Context) {
 // PostApproval
 //
 //	@Summary	Approve and start a pipeline
-//	@Router		/repos/{repo_id}/pipelines/{number}/approve [post]
+//	@Router		/repos/{repo_id}/pipelines/{pipeline_number}/approve [post]
 //	@Produce	json
 //	@Success	200	{object}	Pipeline
 //	@Tags		Pipelines
@@ -547,7 +547,7 @@ func PostApproval(c *gin.Context) {
 // PostDecline
 //
 //	@Summary	Decline a pipeline
-//	@Router		/repos/{repo_id}/pipelines/{number}/decline [post]
+//	@Router		/repos/{repo_id}/pipelines/{pipeline_number}/decline [post]
 //	@Produce	json
 //	@Success	200	{object}	Pipeline
 //	@Tags		Pipelines
@@ -597,7 +597,7 @@ func GetPipelineQueue(c *gin.Context) {
 //
 //	@Summary		Restart a pipeline
 //	@Description	Restarts a pipeline optional with altered event, deploy or environment
-//	@Router			/repos/{repo_id}/pipelines/{number} [post]
+//	@Router			/repos/{repo_id}/pipelines/{pipeline_number} [post]
 //	@Produce		json
 //	@Success		200	{object}	Pipeline
 //	@Tags			Pipelines
@@ -679,7 +679,7 @@ func PostPipeline(c *gin.Context) {
 // DeletePipelineLogs
 //
 //	@Summary	Deletes all logs of a pipeline
-//	@Router		/repos/{repo_id}/logs/{number} [delete]
+//	@Router		/repos/{repo_id}/logs/{pipeline_number} [delete]
 //	@Produce	plain
 //	@Success	204
 //	@Tags		Pipeline logs

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -286,14 +286,14 @@ func GetPipelineLastByBranch(c *gin.Context) {
 // GetStepLogs
 //
 //	@Summary	Get logs for a pipeline step
-//	@Router		/repos/{repo_id}/logs/{number}/{stepID} [get]
+//	@Router		/repos/{repo_id}/logs/{number}/{step_id} [get]
 //	@Produce	json
 //	@Success	200	{array}	LogEntry
 //	@Tags		Pipeline logs
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
 //	@Param		number			path	int		true	"the number of the pipeline"
-//	@Param		stepID			path	int		true	"the step id"
+//	@Param		step_id			path	int		true	"the step id"
 func GetStepLogs(c *gin.Context) {
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
@@ -312,7 +312,7 @@ func GetStepLogs(c *gin.Context) {
 		return
 	}
 
-	stepID, err := strconv.ParseInt(c.Params.ByName("stepId"), 10, 64)
+	stepID, err := strconv.ParseInt(c.Params.ByName("step_id"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -342,14 +342,14 @@ func GetStepLogs(c *gin.Context) {
 // DeleteStepLogs
 //
 //	@Summary	Delete step logs of a pipeline
-//	@Router		/repos/{repo_id}/logs/{number}/{stepId} [delete]
+//	@Router		/repos/{repo_id}/logs/{number}/{step_id} [delete]
 //	@Produce	plain
 //	@Success	204
 //	@Tags		Pipeline logs
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
 //	@Param		number			path	int		true	"the number of the pipeline"
-//	@Param		stepId			path	int		true	"the step id"
+//	@Param		step_id			path	int		true	"the step id"
 func DeleteStepLogs(c *gin.Context) {
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
@@ -366,7 +366,7 @@ func DeleteStepLogs(c *gin.Context) {
 		return
 	}
 
-	stepID, err := strconv.ParseInt(c.Params.ByName("stepId"), 10, 64)
+	stepID, err := strconv.ParseInt(c.Params.ByName("step_id"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -197,12 +197,12 @@ func GetPipelines(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 func DeletePipeline(c *gin.Context) {
 	_store := store.FromContext(c)
 
 	repo := session.Repo(c)
-	num, err := strconv.ParseInt(c.Param("number"), 10, 64)
+	num, err := strconv.ParseInt(c.Param("pipeline_number"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -237,7 +237,7 @@ func DeletePipeline(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline, OR 'latest'"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline, OR 'latest'"
 func GetPipeline(c *gin.Context) {
 	_store := store.FromContext(c)
 	if c.Param("number") == "latest" {
@@ -246,7 +246,7 @@ func GetPipeline(c *gin.Context) {
 	}
 
 	repo := session.Repo(c)
-	num, err := strconv.ParseInt(c.Param("number"), 10, 64)
+	num, err := strconv.ParseInt(c.Param("pipeline_number"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -292,7 +292,7 @@ func GetPipelineLastByBranch(c *gin.Context) {
 //	@Tags		Pipeline logs
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 //	@Param		step_id			path	int		true	"the step id"
 func GetStepLogs(c *gin.Context) {
 	_store := store.FromContext(c)
@@ -300,7 +300,7 @@ func GetStepLogs(c *gin.Context) {
 
 	// parse the pipeline number and step sequence number from
 	// the request parameter.
-	num, err := strconv.ParseInt(c.Params.ByName("number"), 10, 64)
+	num, err := strconv.ParseInt(c.Params.ByName("pipeline_number"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -348,13 +348,13 @@ func GetStepLogs(c *gin.Context) {
 //	@Tags		Pipeline logs
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 //	@Param		step_id			path	int		true	"the step id"
 func DeleteStepLogs(c *gin.Context) {
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
 
-	pipelineNumber, err := strconv.ParseInt(c.Params.ByName("number"), 10, 64)
+	pipelineNumber, err := strconv.ParseInt(c.Params.ByName("pipeline_number"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -408,11 +408,11 @@ func DeleteStepLogs(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 func GetPipelineConfig(c *gin.Context) {
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
-	num, err := strconv.ParseInt(c.Param("number"), 10, 64)
+	num, err := strconv.ParseInt(c.Param("pipeline_number"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -442,10 +442,10 @@ func GetPipelineConfig(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 func GetPipelineMetadata(c *gin.Context) {
 	repo := session.Repo(c)
-	num, err := strconv.ParseInt(c.Param("number"), 10, 64)
+	num, err := strconv.ParseInt(c.Param("pipeline_number"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -483,7 +483,7 @@ func GetPipelineMetadata(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 func CancelPipeline(c *gin.Context) {
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
@@ -495,7 +495,7 @@ func CancelPipeline(c *gin.Context) {
 		return
 	}
 
-	num, _ := strconv.ParseInt(c.Params.ByName("number"), 10, 64)
+	num, _ := strconv.ParseInt(c.Params.ByName("pipeline_number"), 10, 64)
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {
@@ -521,13 +521,13 @@ func CancelPipeline(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 func PostApproval(c *gin.Context) {
 	var (
 		_store = store.FromContext(c)
 		repo   = session.Repo(c)
 		user   = session.User(c)
-		num, _ = strconv.ParseInt(c.Params.ByName("number"), 10, 64)
+		num, _ = strconv.ParseInt(c.Params.ByName("pipeline_number"), 10, 64)
 	)
 
 	pl, err := _store.GetPipelineNumber(repo, num)
@@ -553,13 +553,13 @@ func PostApproval(c *gin.Context) {
 //	@Tags		Pipelines
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 func PostDecline(c *gin.Context) {
 	var (
 		_store = store.FromContext(c)
 		repo   = session.Repo(c)
 		user   = session.User(c)
-		num, _ = strconv.ParseInt(c.Params.ByName("number"), 10, 64)
+		num, _ = strconv.ParseInt(c.Params.ByName("pipeline_number"), 10, 64)
 	)
 
 	pl, err := _store.GetPipelineNumber(repo, num)
@@ -603,14 +603,14 @@ func GetPipelineQueue(c *gin.Context) {
 //	@Tags			Pipelines
 //	@Param			Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param			repo_id			path	int		true	"the repository id"
-//	@Param			number			path	int		true	"the number of the pipeline"
+//	@Param			pipeline_number			path	int		true	"the number of the pipeline"
 //	@Param			event			query	string	false	"override the event type"
 //	@Param			deploy_to		query	string	false	"override the target deploy value"
 func PostPipeline(c *gin.Context) {
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
 
-	num, err := strconv.ParseInt(c.Param("number"), 10, 64)
+	num, err := strconv.ParseInt(c.Param("pipeline_number"), 10, 64)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -685,12 +685,12 @@ func PostPipeline(c *gin.Context) {
 //	@Tags		Pipeline logs
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
-//	@Param		number			path	int		true	"the number of the pipeline"
+//	@Param		pipeline_number			path	int		true	"the number of the pipeline"
 func DeletePipelineLogs(c *gin.Context) {
 	_store := store.FromContext(c)
 
 	repo := session.Repo(c)
-	num, _ := strconv.ParseInt(c.Params.ByName("number"), 10, 64)
+	num, _ := strconv.ParseInt(c.Params.ByName("pipeline_number"), 10, 64)
 
 	pl, err := _store.GetPipelineNumber(repo, num)
 	if err != nil {

--- a/server/api/pipeline_test.go
+++ b/server/api/pipeline_test.go
@@ -134,7 +134,7 @@ func TestDeletePipeline(t *testing.T) {
 
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Set("store", mockStore)
-		c.Params = gin.Params{{Key: "number", Value: "2"}}
+		c.Params = gin.Params{{Key: "pipeline_number", Value: "2"}}
 
 		DeletePipeline(c)
 
@@ -160,7 +160,7 @@ func TestDeletePipeline(t *testing.T) {
 
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Set("store", mockStore)
-		c.Params = gin.Params{{Key: "number", Value: "2"}}
+		c.Params = gin.Params{{Key: "pipeline_number", Value: "2"}}
 
 		DeletePipeline(c)
 
@@ -197,7 +197,7 @@ func TestGetPipelineMetadata(t *testing.T) {
 		t.Run("should get pipeline metadata", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
-			c.Params = gin.Params{{Key: "number", Value: "2"}}
+			c.Params = gin.Params{{Key: "pipeline_number", Value: "2"}}
 			c.Set("store", mockStore)
 			c.Set("forge", mockForge)
 			c.Set("repo", fakeRepo)
@@ -218,7 +218,7 @@ func TestGetPipelineMetadata(t *testing.T) {
 		t.Run("should return bad request for invalid pipeline number", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
-			c.Params = gin.Params{{Key: "number", Value: "invalid"}}
+			c.Params = gin.Params{{Key: "pipeline_number", Value: "invalid"}}
 
 			GetPipelineMetadata(c)
 
@@ -231,7 +231,7 @@ func TestGetPipelineMetadata(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
-			c.Params = gin.Params{{Key: "number", Value: "3"}}
+			c.Params = gin.Params{{Key: "pipeline_number", Value: "3"}}
 			c.Set("store", mockStore)
 			c.Set("repo", fakeRepo)
 
@@ -271,7 +271,7 @@ func TestCancelPipeline(t *testing.T) {
 		c.Set("store", mockStore)
 		c.Set("repo", fakeRepo)
 		c.Set("user", fakeUser)
-		c.Params = gin.Params{{Key: "number", Value: "2"}}
+		c.Params = gin.Params{{Key: "pipeline_number", Value: "2"}}
 
 		CancelPipeline(c)
 

--- a/server/api/stream.go
+++ b/server/api/stream.go
@@ -130,13 +130,13 @@ func EventStreamSSE(c *gin.Context) {
 // LogStreamSSE
 //
 //	@Summary	Stream logs of a pipeline step
-//	@Router		/stream/logs/{repo_id}/{pipeline}/{stepID} [get]
+//	@Router		/stream/logs/{repo_id}/{pipeline}/{step_id} [get]
 //	@Produce	plain
 //	@Success	200
 //	@Tags		Pipeline logs
 //	@Param		repo_id		path	int	true	"the repository id"
 //	@Param		pipeline	path	int	true	"the number of the pipeline"
-//	@Param		stepID		path	int	true	"the step id"
+//	@Param		step_id		path	int	true	"the step id"
 func LogStreamSSE(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
@@ -170,7 +170,7 @@ func LogStreamSSE(c *gin.Context) {
 		return
 	}
 
-	stepID, err := strconv.ParseInt(c.Param("stepId"), 10, 64)
+	stepID, err := strconv.ParseInt(c.Param("step_id"), 10, 64)
 	if err != nil {
 		log.Debug().Err(err).Msg("step id invalid")
 		logWriteStringErr(io.WriteString(rw, "event: error\ndata: step id invalid\n\n"))

--- a/server/router/api.go
+++ b/server/router/api.go
@@ -120,8 +120,8 @@ func apiRoutes(e *gin.RouterGroup) {
 					repo.POST("/pipelines/:number/approve", session.MustPush, api.PostApproval)
 					repo.POST("/pipelines/:number/decline", session.MustPush, api.PostDecline)
 
-					repo.GET("/logs/:number/:stepId", api.GetStepLogs)
-					repo.DELETE("/logs/:number/:stepId", session.MustPush, api.DeleteStepLogs)
+					repo.GET("/logs/:number/:step_id", api.GetStepLogs)
+					repo.DELETE("/logs/:number/:step_id", session.MustPush, api.DeleteStepLogs)
 
 					// requires push permissions
 					repo.DELETE("/logs/:number", session.MustPush, api.DeletePipelineLogs)
@@ -234,13 +234,13 @@ func apiRoutes(e *gin.RouterGroup) {
 		}
 
 		apiBase.GET("/forges", api.GetForges)
-		apiBase.GET("/forges/:forgeId", api.GetForge)
+		apiBase.GET("/forges/:forge_id", api.GetForge)
 		forgeBase := apiBase.Group("/forges")
 		{
 			forgeBase.Use(session.MustAdmin())
 			forgeBase.POST("", api.PostForge)
-			forgeBase.PATCH("/:forgeId", api.PatchForge)
-			forgeBase.DELETE("/:forgeId", api.DeleteForge)
+			forgeBase.PATCH("/:forge_id", api.PatchForge)
+			forgeBase.DELETE("/:forge_id", api.DeleteForge)
 		}
 
 		apiBase.GET("/signature/public-key", api.GetSignaturePublicKey)
@@ -249,7 +249,7 @@ func apiRoutes(e *gin.RouterGroup) {
 
 		stream := apiBase.Group("/stream")
 		{
-			stream.GET("/logs/:repo_id/:pipeline/:stepId",
+			stream.GET("/logs/:repo_id/:pipeline/:step_id",
 				session.SetRepo(),
 				session.SetPerm(),
 				session.MustPull,

--- a/server/router/api.go
+++ b/server/router/api.go
@@ -109,22 +109,22 @@ func apiRoutes(e *gin.RouterGroup) {
 
 					repo.GET("/pipelines", api.GetPipelines)
 					repo.POST("/pipelines", session.MustPush, api.CreatePipeline)
-					repo.DELETE("/pipelines/:number", session.MustRepoAdmin(), api.DeletePipeline)
-					repo.GET("/pipelines/:number", api.GetPipeline)
-					repo.GET("/pipelines/:number/config", api.GetPipelineConfig)
-					repo.GET("/pipelines/:number/metadata", session.MustPush, api.GetPipelineMetadata)
+					repo.DELETE("/pipelines/:pipeline_number", session.MustRepoAdmin(), api.DeletePipeline)
+					repo.GET("/pipelines/:pipeline_number", api.GetPipeline)
+					repo.GET("/pipelines/:pipeline_number/config", api.GetPipelineConfig)
+					repo.GET("/pipelines/:pipeline_number/metadata", session.MustPush, api.GetPipelineMetadata)
 
 					// requires push permissions
-					repo.POST("/pipelines/:number", session.MustPush, api.PostPipeline)
-					repo.POST("/pipelines/:number/cancel", session.MustPush, api.CancelPipeline)
-					repo.POST("/pipelines/:number/approve", session.MustPush, api.PostApproval)
-					repo.POST("/pipelines/:number/decline", session.MustPush, api.PostDecline)
+					repo.POST("/pipelines/:pipeline_number", session.MustPush, api.PostPipeline)
+					repo.POST("/pipelines/:pipeline_number/cancel", session.MustPush, api.CancelPipeline)
+					repo.POST("/pipelines/:pipeline_number/approve", session.MustPush, api.PostApproval)
+					repo.POST("/pipelines/:pipeline_number/decline", session.MustPush, api.PostDecline)
 
-					repo.GET("/logs/:number/:step_id", api.GetStepLogs)
-					repo.DELETE("/logs/:number/:step_id", session.MustPush, api.DeleteStepLogs)
+					repo.GET("/logs/:pipeline_number/:step_id", api.GetStepLogs)
+					repo.DELETE("/logs/:pipeline_number/:step_id", session.MustPush, api.DeleteStepLogs)
 
 					// requires push permissions
-					repo.DELETE("/logs/:number", session.MustPush, api.DeletePipelineLogs)
+					repo.DELETE("/logs/:pipeline_number", session.MustPush, api.DeletePipelineLogs)
 
 					// requires push permissions
 					repo.GET("/secrets", session.MustPush, api.GetSecretList)


### PR DESCRIPTION
Unify API parameter names for consistency and readability:
- `stepId` → `step_id`
- `number` → `pipeline_number`
- `forgeId` → `forge_id`

Changed pipeline_test.go accordingly to pass test.
Generated swagger.

Closes #3450 