### PR TITLE
Remove excessive dev/test log outputs

### DIFF
--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -101,7 +101,6 @@ func (when *When) IncludesStatusSuccess(metadata metadata.Metadata, global bool,
 	}
 	for _, c := range when.Constraints {
 		matches, err := c.Match(metadata, global, env)
-		fmt.Println("mat", matches, err, c.Status)
 		if matches, err := c.Match(metadata, global, env); err == nil && matches {
 			if len(c.Status) > 0 && !slices.Contains(c.Status, statusSuccess) {
 				return false


### PR DESCRIPTION
With the 3.14.0-rc.0, my server output is flooded with dev debug printlns like
```
mat true <nil> [success failure]
mat true <nil> [success failure]
mat true <nil> [success failure]
mat true <nil> [success failure]
mat true <nil> [success failure]
mat true <nil> [success]
mat true <nil> [success failure]
mat true <nil> [success]
mat true <nil> [failure]
...
```