### PR TITLE
Fix build error and include status calculation

### DIFF
--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -81,6 +81,9 @@ func (when *When) Match(metadata metadata.Metadata, global bool, env map[string]
 }
 
 func (when *When) IncludesStatusFailure(metadata metadata.Metadata, global bool, env map[string]string) bool {
+	if when.IsEmpty() {
+		return false
+	}
 	for _, c := range when.Constraints {
 		if matches, err := c.Match(metadata, global, env); err == nil && matches {
 			if slices.Contains(c.Status, statusFailure) {
@@ -100,7 +103,6 @@ func (when *When) IncludesStatusSuccess(metadata metadata.Metadata, global bool,
 		return true
 	}
 	for _, c := range when.Constraints {
-		matches, err := c.Match(metadata, global, env)
 		if matches, err := c.Match(metadata, global, env); err == nil && matches {
 			if len(c.Status) > 0 && !slices.Contains(c.Status, statusSuccess) {
 				return false

--- a/pipeline/frontend/yaml/constraint/constraint.go
+++ b/pipeline/frontend/yaml/constraint/constraint.go
@@ -104,12 +104,12 @@ func (when *When) IncludesStatusSuccess(metadata metadata.Metadata, global bool,
 	}
 	for _, c := range when.Constraints {
 		if matches, err := c.Match(metadata, global, env); err == nil && matches {
-			if len(c.Status) > 0 && !slices.Contains(c.Status, statusSuccess) {
-				return false
+			if len(c.Status) == 0 || slices.Contains(c.Status, statusSuccess) {
+				return true
 			}
 		}
 	}
-	return true
+	return false
 }
 
 // False if (any) non local.

--- a/pipeline/frontend/yaml/constraint/constraint_test.go
+++ b/pipeline/frontend/yaml/constraint/constraint_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/metadata"
@@ -33,16 +34,29 @@ func TestConstraintStatusSuccessFailure(t *testing.T) {
 		{conf: "{status: [failure]}", wantSuccess: false, wantFail: true},
 		{conf: "{status: [success]}", wantSuccess: true, wantFail: false},
 		{conf: "{status: [failure, success]}", wantSuccess: true, wantFail: true},
-		{conf: "{event: push, status: [failure, success]}", wantSuccess: true, wantFail: false},
+		{conf: "{event: push, status: [failure, success]}", wantSuccess: false, wantFail: false},
 		{conf: "{event: pull_request, status: [failure, success]}", wantSuccess: true, wantFail: true},
-		{conf: "{event: push, status: [failure]}", wantSuccess: true, wantFail: false},
+		{conf: "{event: push, status: failure}", wantSuccess: false, wantFail: false},
 		{conf: "{event: pull_request, status: [failure]}", wantSuccess: false, wantFail: true},
 		{conf: "{status: success}", wantSuccess: true, wantFail: false},
+		{conf: "[{}]", wantSuccess: true, wantFail: false},
+		{conf: "[{status: success}]", wantSuccess: true, wantFail: false},
+		{conf: "[{},{status: failure}]", wantSuccess: true, wantFail: true},
+		{conf: "[{event: push, status: success},{status: failure}]", wantSuccess: false, wantFail: true},
+		{conf: "[{status: failure},{event: push, status: success}]", wantSuccess: false, wantFail: true},
 	}
 	for _, test := range testdata {
-		c := parseConstraints(t, test.conf)
-		assert.Equal(t, test.wantSuccess, c.IncludesStatusSuccess(metadata.Metadata{Curr: metadata.Pipeline{Event: metadata.EventPull}}, true, map[string]string{}), "when: '%s'", test.conf)
-		assert.Equal(t, test.wantFail, c.IncludesStatusFailure(metadata.Metadata{Curr: metadata.Pipeline{Event: metadata.EventPull}}, true, map[string]string{}), "when: '%s'", test.conf)
+		t.Run(test.conf, func(t *testing.T) {
+			c := parseConstraints(t, test.conf)
+			assert.Equalf(t,
+				test.wantSuccess,
+				c.IncludesStatusSuccess(metadata.Metadata{Curr: metadata.Pipeline{Event: metadata.EventPull}}, true, map[string]string{}),
+				"include success is wrong for when: '%s'", test.conf)
+			assert.Equal(t,
+				test.wantFail,
+				c.IncludesStatusFailure(metadata.Metadata{Curr: metadata.Pipeline{Event: metadata.EventPull}}, true, map[string]string{}),
+				"include fail is wrong for when: '%s'", test.conf)
+		})
 	}
 }
 
@@ -186,7 +200,8 @@ func TestConstraints(t *testing.T) {
 }
 
 func parseConstraints(t *testing.T, s string) *When {
+	t.Helper()
 	c := &When{}
-	assert.NoError(t, yaml.Unmarshal([]byte(s), c))
+	require.NoError(t, yaml.Unmarshal([]byte(s), c))
 	return c
 }


### PR DESCRIPTION
followup of https://github.com/woodpecker-ci/woodpecker/pull/6432

fix:
<img width="998" height="97" alt="image" src="https://github.com/user-attachments/assets/ab6ed79b-ba35-4abd-b99f-8d131d5b95b2" />

also if we had no match we still returned true on include success.

this now requires at least one constrain match and then returns true immediately instead of checking the rest