### PR TITLE
Enhance datastore DB test setup

### DIFF
--- a/server/store/datastore/engine_test.go
+++ b/server/store/datastore/engine_test.go
@@ -38,9 +38,15 @@ func testDriverConfig() (driver, config string) {
 // newTestStore creates a new database connection for testing purposes.
 // The database driver and connection string are provided by
 // environment variables, with fallback to in-memory sqlite.
-func newTestStore(t *testing.T, tables ...any) (*storage, func()) {
+func newTestStore(t *testing.T, tables ...any) (store *storage, closer func()) {
 	engine, err := xorm.NewEngine(testDriverConfig())
 	require.NoError(t, err)
+
+	// MaxOpenConns=1 and MaxIdleConns=1 are required for in-memory sqlite:
+	// without them the pool drops idle connections, destroying the in-memory
+	// schema between calls and breaking migrations.
+	engine.SetMaxOpenConns(1)
+	engine.SetMaxIdleConns(1)
 
 	for _, table := range tables {
 		if err := engine.Sync(table); err != nil {


### PR DESCRIPTION
taken from https://github.com/woodpecker-ci/woodpecker/pull/6391

in case sqlite is used in-memory it otherwise looses the schema ... this makes it more resistant