### PR TITLE
Fix race in pipeline runtime

### DIFF
--- a/pipeline/runtime/runtime.go
+++ b/pipeline/runtime/runtime.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"sync"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rs/zerolog"
@@ -42,8 +43,9 @@ type Runtime struct {
 	// Cleanup operations should use the runnerCtx passed to Run().
 	ctx context.Context
 
-	tracer tracing.Tracer
-	logger logging.Logger
+	tracer     tracing.Tracer
+	tracerLock sync.Mutex
+	logger     logging.Logger
 
 	taskUUID    string
 	description map[string]string
@@ -58,6 +60,7 @@ func New(spec *backend_types.Config, backend backend_types.Backend, opts ...Opti
 	r.engine = backend
 	r.ctx = context.Background()
 	r.taskUUID = ulid.Make().String()
+	r.tracerLock = sync.Mutex{}
 	for _, opt := range opts {
 		opt(r)
 	}

--- a/pipeline/runtime/step.go
+++ b/pipeline/runtime/step.go
@@ -253,6 +253,10 @@ func (r *Runtime) traceStep(processState *backend_types.State, err error, step *
 		// processState == nil && err == nil: step just started, leave s.CurrStepState zero-valued.
 	}
 
+	// The tracer should just trace changes, but it currently also updates step env vars used in various ways:
+	// https://github.com/woodpecker-ci/woodpecker/blob/7efe8bf510cd4587b1492ee260b56a0f5e24bb84/agent/tracer.go#L79-L86 .
+	r.tracerLock.Lock()
+	defer r.tracerLock.Unlock()
 	if traceErr := r.tracer.Trace(s); traceErr != nil {
 		return traceErr
 	}

--- a/pipeline/runtime/step.go
+++ b/pipeline/runtime/step.go
@@ -254,7 +254,7 @@ func (r *Runtime) traceStep(processState *backend_types.State, err error, step *
 	}
 
 	// The tracer should just trace changes, but it currently also updates step env vars used in various ways:
-	// https://github.com/woodpecker-ci/woodpecker/blob/7efe8bf510cd4587b1492ee260b56a0f5e24bb84/agent/tracer.go#L79-L86 .
+	// https://github.com/woodpecker-ci/woodpecker/blob/main/agent/tracer.go#L79-L86 .
 	r.tracerLock.Lock()
 	defer r.tracerLock.Unlock()
 	if traceErr := r.tracer.Trace(s); traceErr != nil {


### PR DESCRIPTION
as step tracer is also used to update workflow environment variables

taken from https://github.com/woodpecker-ci/woodpecker/pull/6391