### PR TITLE
pipeline runtime on cancel still should wait for stage to close chan

### DIFF
--- a/pipeline/runtime/workflow.go
+++ b/pipeline/runtime/workflow.go
@@ -59,10 +59,12 @@ func (r *Runtime) Run(runnerCtx context.Context) error {
 	}
 
 	for _, stage := range r.spec.Stages {
+		stageChan := r.runStage(runnerCtx, stage.Steps)
 		select {
 		case <-r.ctx.Done():
+			<-stageChan
 			return pipeline_errors.ErrCancel
-		case err := <-r.runStage(runnerCtx, stage.Steps):
+		case err := <-stageChan:
 			if err != nil {
 				r.err.Set(err)
 			}


### PR DESCRIPTION
taken from #6391

currently we do not wait for stage to finish if workfow gets canceled, but as runStage should also respect the context cancel and could have some cleanup running ... we have to wait for it