### PR TITLE
Fix race condition in event stream channel handling

### DIFF
--- a/server/api/stream.go
+++ b/server/api/stream.go
@@ -90,7 +90,6 @@ func EventStreamSSE(c *gin.Context) {
 
 	defer func() {
 		cancel(nil)
-		close(eventChan)
 		log.Debug().Msg("user feed: connection closed")
 	}()
 
@@ -99,9 +98,7 @@ func EventStreamSSE(c *gin.Context) {
 			func(m pubsub.Message) {
 				select {
 				case <-ctx.Done():
-					return
-				default:
-					eventChan <- m.Data
+				case eventChan <- m.Data:
 				}
 			})
 		cancel(err)
@@ -207,7 +204,6 @@ func LogStreamSSE(c *gin.Context) {
 
 	defer func() {
 		cancel(nil)
-		close(logChan)
 		log.Debug().Msg("log stream: connection closed")
 	}()
 
@@ -230,15 +226,14 @@ func LogStreamSSE(c *gin.Context) {
 
 			for entries := range batches {
 				for _, entry := range entries {
-					select {
-					case <-ctx.Done():
-						return
-					default:
-						if ee, err := json.Marshal(entry); err == nil {
-							logChan <- ee
-						} else {
-							log.Error().Err(err).Msg("unable to serialize log entry")
+					if ee, err := json.Marshal(entry); err == nil {
+						select {
+						case <-ctx.Done():
+							return
+						case logChan <- ee:
 						}
+					} else {
+						log.Error().Err(err).Msg("unable to serialize log entry")
 					}
 				}
 			}

--- a/server/pubsub/memory/pub_test.go
+++ b/server/pubsub/memory/pub_test.go
@@ -30,11 +30,14 @@ func TestPubsubConcurrentCancel(t *testing.T) {
 	testTopic := map[string]struct{}{"test": {}}
 	broker := New()
 
-	for range 50 {
+	for range 100 {
 		ctx, cancel := context.WithCancelCause(t.Context())
-		ch := make(chan []byte, 1)
+		ch := make(chan []byte) // Unbuffered to force blocking sends
 
+		var wg sync.WaitGroup
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			_ = broker.Subscribe(ctx, testTopic, func(m pubsub.Message) {
 				select {
 				case <-ctx.Done():
@@ -43,17 +46,19 @@ func TestPubsubConcurrentCancel(t *testing.T) {
 			})
 		}()
 
-		<-time.After(10 * time.Millisecond)
-
-		var wg sync.WaitGroup
-		for range 10 {
-			wg.Add(1)
+		// Start publishing many messages to increase chance of blocking send
+		var pubWg sync.WaitGroup
+		for range 100 {
+			pubWg.Add(1)
 			go func() {
-				defer wg.Done()
+				defer pubWg.Done()
 				_ = broker.Publish(ctx, testTopic, pubsub.Message{Data: []byte("x")})
 			}()
 		}
+
+		// Cancel while publishes are in flight to race with pending sends
 		cancel(nil)
+		pubWg.Wait()
 		wg.Wait()
 	}
 }

--- a/server/pubsub/memory/pub_test.go
+++ b/server/pubsub/memory/pub_test.go
@@ -25,6 +25,39 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/pubsub"
 )
 
+// TestPubsubConcurrentCancel verifies no panic occurs when publish and cancel race.
+func TestPubsubConcurrentCancel(t *testing.T) {
+	testTopic := map[string]struct{}{"test": {}}
+	broker := New()
+
+	for range 50 {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		ch := make(chan []byte, 1)
+
+		go func() {
+			_ = broker.Subscribe(ctx, testTopic, func(m pubsub.Message) {
+				select {
+				case <-ctx.Done():
+				case ch <- m.Data:
+				}
+			})
+		}()
+
+		<-time.After(10 * time.Millisecond)
+
+		var wg sync.WaitGroup
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = broker.Publish(ctx, testTopic, pubsub.Message{Data: []byte("x")})
+			}()
+		}
+		cancel(nil)
+		wg.Wait()
+	}
+}
+
 func TestPubsub(t *testing.T) {
 	var (
 		wg sync.WaitGroup


### PR DESCRIPTION
Fixes #6454

We were getting panics when clients disconnected from SSE feeds because the code was closing the channel while goroutines could still be trying to send on it.

The fix removes the explicit close() calls and refactors the select statements so that context cancellation and channel sends happen atomically. If the context is cancelled, we skip the send. The channel gets garbage collected naturally after all goroutines exit the context.

Added a concurrent stress test to make sure this doesn't happen again.