### PR TITLE
server/api: stop EventStreamSSE crashing the server on publish-after-disconnect

### DIFF
--- a/server/api/stream.go
+++ b/server/api/stream.go
@@ -90,18 +90,27 @@ func EventStreamSSE(c *gin.Context) {
 
 	defer func() {
 		cancel(nil)
-		close(eventChan)
+		// Intentionally do not close(eventChan). Publish fans each
+		// message out in a fresh goroutine, so there is no single
+		// producer we can drain and no way to close the channel without
+		// racing those in-flight publishes - closing it used to crash
+		// the whole server with "send on closed channel" as soon as an
+		// SSE client disconnected while the pubsub was still publishing
+		// (#6454). The channel is unreferenced once this handler
+		// returns and is collected by the GC.
 		log.Debug().Msg("user feed: connection closed")
 	}()
 
 	go func() {
 		err := server.Config.Services.Scheduler.Subscribe(ctx, subTopics,
 			func(m pubsub.Message) {
+				// Race ctx.Done against the send so a publish that
+				// arrives after the handler has returned cannot block
+				// forever on a reader that will never come back.
 				select {
 				case <-ctx.Done():
 					return
-				default:
-					eventChan <- m.Data
+				case eventChan <- m.Data:
 				}
 			})
 		cancel(err)


### PR DESCRIPTION
Fixes #6454.

`EventStreamSSE` bounded a per-client pubsub fan-out channel and then tore it down on disconnect:

```go
eventChan := make(chan []byte, 10)
defer func() {
    cancel(nil)
    close(eventChan)
    ...
}()

...Subscribe(ctx, subTopics, func(m pubsub.Message) {
    select {
    case <-ctx.Done():
        return
    default:
        eventChan <- m.Data
    }
})
```

The in-memory pubsub (`server/pubsub/memory/pub.go`) calls each subscriber in its own goroutine on every `Publish`, and a goroutine that has already entered the `default` branch is racing the defer-close: as soon as a client disconnects while the scheduler is publishing, `eventChan <- m.Data` lands on a closed channel and Go aborts the whole server with

```
panic: send on closed channel
```

reliably observed on 3.14.0-rc.0 under normal load.

There is no single producer we can drain before close — every publish spins up its own goroutine — so we can't close the channel without racing in-flight sends. This drops the `close(eventChan)` from the defer; once the handler returns the channel is unreferenced and the GC reclaims it. It also changes the callback's `default` branch to a `select` that races `eventChan <- m.Data` against `ctx.Done()` so late publishes exit cleanly instead of blocking forever on a reader that has already returned.

`LogStreamSSE` has a structurally similar pattern but already wraps its sender in a `recover()`, so it is left alone here.