### PR TITLE
Set default of WOODPECKER_BACKEND_{DOCKER,K8S}_STOP_TIMEOUT to 20s

### DIFF
--- a/pipeline/backend/docker/flags.go
+++ b/pipeline/backend/docker/flags.go
@@ -60,7 +60,7 @@ var Flags = []cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_DOCKER_STOP_TIMEOUT"),
 		Name:    "backend-docker-stop-timeout",
 		Usage:   "seconds Woodpecker waits for a container to stop gracefully before forcefully killing it",
-		Value:   180, //nolint:mnd
+		Value:   20, //nolint:mnd
 	},
 	//
 	// resource limit parameters

--- a/pipeline/backend/kubernetes/flags.go
+++ b/pipeline/backend/kubernetes/flags.go
@@ -132,6 +132,6 @@ var Flags = []cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_STOP_TIMEOUT"),
 		Name:    "backend-k8s-stop-timeout",
 		Usage:   "seconds Woodpecker waits for pods to stop gracefully before forcefully killing them",
-		Value:   180,
+		Value:   20,
 	},
 }


### PR DESCRIPTION
as per https://github.com/woodpecker-ci/woodpecker/pull/6445#issuecomment-4277232694

It initially was 5s but that was deemed to short, 3min is to long, so 20s it is for now

PS: for edge-cases anyone can now configure it... but for defaults we should expect not let the user wait for 3min till a pipeline -cancel/-stop  finishes