### PR TITLE
Fix flaky TestJWTManager

### DIFF
--- a/server/rpc/jwt_manager_test.go
+++ b/server/rpc/jwt_manager_test.go
@@ -110,8 +110,14 @@ func TestJWTManager(t *testing.T) {
 		token, err := manager.Generate(42)
 		require.NoError(t, err)
 
-		// flip a character in the signature portion
-		tampered := token[:len(token)-1] + "X"
+		// Flip a byte inside the decoded signature, then re-encode.
+		parts := strings.Split(token, ".")
+		require.Len(t, parts, 3)
+		sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+		require.NoError(t, err)
+		sig[0] ^= 0xFF
+		parts[2] = base64.RawURLEncoding.EncodeToString(sig)
+		tampered := strings.Join(parts, ".")
 
 		_, err = manager.Verify(tampered)
 		assert.Error(t, err)


### PR DESCRIPTION
The test verified that a tampered JWT is rejected, but it was flipping the last base64url character of the signature instead of flipping an actual byte.

This was unreliable: the final character of a 32-byte HMAC-SHA256 signature only carries 4 meaningful bits. Go's base64 decoder silently ignores the other 2, so roughly 1 in 16 tokens decoded to the same bytes after the swap — meaning the "tampered" token passed verification and the test flaked.

**Fix:** decode the signature to raw bytes, XOR the first byte, then re-encode. This guarantees the signature bytes are actually different, making the test deterministic.

example: https://ci.woodpecker-ci.org/repos/3780/pipeline/33691/33