### PR TITLE
fix(cli,server): fix trusted flags copy-paste bug and server nil pointer panic

### DIFF
--- a/cli/repo/repo_update.go
+++ b/cli/repo/repo_update.go
@@ -118,11 +118,11 @@ func repoUpdate(ctx context.Context, c *cli.Command) error {
 		}
 		if c.IsSet("trusted-network") {
 			t := c.Bool("trusted-network")
-			patch.Trusted.Security = &t
+			patch.Trusted.Network = &t
 		}
 		if c.IsSet("trusted-volumes") {
 			t := c.Bool("trusted-volumes")
-			patch.Trusted.Security = &t
+			patch.Trusted.Volumes = &t
 		}
 	}
 

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -234,10 +234,14 @@ func PatchRepo(c *gin.Context) {
 	}
 
 	if in.Trusted != nil {
-		if ((in.Trusted.Network != nil && *in.Trusted.Network != repo.Trusted.Network) ||
-			(in.Trusted.Volumes != nil && *in.Trusted.Volumes != repo.Trusted.Volumes) ||
-			(in.Trusted.Security != nil && *in.Trusted.Security != repo.Trusted.Security)) && !user.Admin {
+		// if user is not admin
+		if !user.Admin &&
+			// and some trusted settings got changed
+			((in.Trusted.Network != nil && *in.Trusted.Network != repo.Trusted.Network) ||
+				(in.Trusted.Volumes != nil && *in.Trusted.Volumes != repo.Trusted.Volumes) ||
+				(in.Trusted.Security != nil && *in.Trusted.Security != repo.Trusted.Security)) {
 			log.Trace().Msgf("user '%s' wants to change trusted without being an instance admin", user.Login)
+			// return error
 			c.String(http.StatusForbidden, "Insufficient privileges")
 			return
 		}

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -234,7 +234,9 @@ func PatchRepo(c *gin.Context) {
 	}
 
 	if in.Trusted != nil {
-		if (*in.Trusted.Network != repo.Trusted.Network || *in.Trusted.Volumes != repo.Trusted.Volumes || *in.Trusted.Security != repo.Trusted.Security) && !user.Admin {
+		if ((in.Trusted.Network != nil && *in.Trusted.Network != repo.Trusted.Network) ||
+			(in.Trusted.Volumes != nil && *in.Trusted.Volumes != repo.Trusted.Volumes) ||
+			(in.Trusted.Security != nil && *in.Trusted.Security != repo.Trusted.Security)) && !user.Admin {
 			log.Trace().Msgf("user '%s' wants to change trusted without being an instance admin", user.Login)
 			c.String(http.StatusForbidden, "Insufficient privileges")
 			return


### PR DESCRIPTION
## Summary

Two related bugs in `repo update --trusted-*` flags:

### Bug 1 — CLI copy-paste error (`cli/repo/repo_update.go`)

`--trusted-network` and `--trusted-volumes` both set `patch.Trusted.Security` instead of their respective fields:

```go
// before (broken)
if c.IsSet("trusted-network") {
    t := c.Bool("trusted-network")
    patch.Trusted.Security = &t  // wrong field
}
if c.IsSet("trusted-volumes") {
    t := c.Bool("trusted-volumes")
    patch.Trusted.Security = &t  // wrong field
}
```

This means the CLI always sends `{Security: <value>, Network: nil, Volumes: nil}` regardless of which flag was passed.

### Bug 2 — Server nil pointer panic (`server/api/repo.go`)

`PatchRepo` unconditionally dereferences all three fields of `in.Trusted` before checking for nil:

```go
// before (broken)
if (*in.Trusted.Network != repo.Trusted.Network || ...) && !user.Admin {
```

When the CLI sends a partial payload (only some fields set), this panics with `nil pointer dereference`.

### Fix

- CLI: correct the field assignments for `--trusted-network` → `.Network` and `--trusted-volumes` → `.Volumes`
- Server: guard each dereference with a nil check — only flag a trust escalation attempt if the specific field is present in the patch and differs from the current value

## How to reproduce

```shell
woodpecker-cli repo update --trusted-volumes owner/repo
# → server panics: runtime error: invalid memory address or nil pointer dereference
# at server/api/repo.go:237
```

## Test plan

- [ ] `repo update --trusted-volumes owner/repo` no longer panics
- [ ] `repo update --trusted-network owner/repo` no longer panics
- [ ] `repo update --trusted-security owner/repo` still works
- [ ] `repo update --trusted-volumes --trusted-network --trusted-security owner/repo` sets all three correctly
- [ ] Non-admin attempting to escalate trust is still rejected with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)