### PR TITLE
fix(agent): persist agent ID after auth to prevent crashloop duplicates

### DIFF
--- a/agent/rpc/auth_client_grpc.go
+++ b/agent/rpc/auth_client_grpc.go
@@ -41,6 +41,10 @@ func NewAuthGrpcClient(conn *grpc.ClientConn, agentToken string, agentID int64) 
 	return client
 }
 
+func (c *AuthClient) AgentID() int64 {
+	return c.agentID
+}
+
 func (c *AuthClient) Auth(ctx context.Context) (string, int64, error) {
 	ctx, cancel := context.WithTimeout(ctx, authClientTimeout)
 	defer cancel()

--- a/agent/rpc/auth_client_grpc_test.go
+++ b/agent/rpc/auth_client_grpc_test.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestAuthClientAgentID(t *testing.T) {
+	conn, err := grpc.NewClient("localhost:0", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	client := NewAuthGrpcClient(conn, "test-token", 42)
+	assert.Equal(t, int64(42), client.AgentID())
+}

--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -137,6 +137,15 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 		return fmt.Errorf("agent could not auth: %w", err)
 	}
 
+	// Persist the agent ID received during auth so that crashloops reuse the
+	// same server-side entry instead of creating a new one on every restart.
+	if agentConfigPath != "" {
+		agentConfig.AgentID = authClient.AgentID()
+		if err := writeAgentConfig(agentConfig, agentConfigPath); err == nil {
+			log.Debug().Msgf("persisted agent ID %d after auth", agentConfig.AgentID)
+		}
+	}
+
 	conn, err := grpc.NewClient(
 		c.String("server"),
 		transport,


### PR DESCRIPTION
Fixes #6527

## Bug

When the Woodpecker agent is unable to query Docker, it crashes and restarts. Each restart creates a new agent entry on the server, leading to an infinite number of agent entries during crashloop.

## Root Cause

The agent receives its assigned ID during authentication but only persists it after completing registration. If the agent crashes between auth and registration (e.g., Docker connection failure), the ID is lost. On restart, it authenticates as a new agent (ID 0) and gets a fresh server-side entry.

## Fix

Persist the agent ID immediately after successful authentication in `cmd/agent/core/agent.go`. This ensures subsequent restarts reuse the same server-side entry via `AgentUpdate` instead of creating new ones.

Added `AgentID()` method to `AuthClient` to expose the agent ID received during auth.

## Verification

- `go build ./cmd/agent/...` passes
- `go test ./cmd/agent/... ./agent/...` passes
- `go test ./server/rpc/... -run TestRegisterAgent` passes