### PR TITLE
fix(gitlab): preserve private flag when webhook payload omits project visibility

### DIFF
--- a/server/forge/gitlab/convert.go
+++ b/server/forge/gitlab/convert.go
@@ -30,8 +30,13 @@ import (
 )
 
 const (
-	mergeRefs               = "refs/merge-requests/%d/head" // merge request merged with base
-	VisibilityLevelInternal = 10
+	mergeRefs = "refs/merge-requests/%d/head" // merge request merged with base
+
+	// GitLab project visibility_level values, as sent in webhook payloads.
+	// See https://docs.gitlab.com/api/projects/#project-visibility-level.
+	visibilityLevelPrivate  = 0
+	visibilityLevelInternal = 10
+	visibilityLevelPublic   = 20
 
 	stateOpened = "opened"
 
@@ -251,12 +256,21 @@ func convertPushHook(hook *gitlab.PushEvent) (*model.Repo, *model.Pipeline, erro
 	repo.FullName = hook.Project.PathWithNamespace
 	repo.Branch = hook.Project.DefaultBranch
 
+	// GitLab does not send `project.visibility` (string) in push event
+	// payloads — only `project.visibility_level` (numeric), which the
+	// go-gitlab library does not expose on PushEventProject. So this switch
+	// is a no-op for real-world payloads, leaving Visibility/IsSCMPrivate
+	// at zero values. model.Repo.Update() must therefore guard against
+	// overwriting the value previously synced via the forge API.
 	switch hook.Project.Visibility {
 	case gitlab.PrivateVisibility:
+		repo.Visibility = model.VisibilityPrivate
 		repo.IsSCMPrivate = true
 	case gitlab.InternalVisibility:
+		repo.Visibility = model.VisibilityInternal
 		repo.IsSCMPrivate = true
 	case gitlab.PublicVisibility:
+		repo.Visibility = model.VisibilityPublic
 		repo.IsSCMPrivate = false
 	}
 
@@ -304,12 +318,17 @@ func convertTagHook(hook *gitlab.TagEvent) (*model.Repo, *model.Pipeline, string
 	repo.FullName = hook.Project.PathWithNamespace
 	repo.Branch = hook.Project.DefaultBranch
 
+	// See note in convertPushHook: tag event payloads also omit
+	// `project.visibility`, so this switch typically does nothing.
 	switch hook.Project.Visibility {
 	case gitlab.PrivateVisibility:
+		repo.Visibility = model.VisibilityPrivate
 		repo.IsSCMPrivate = true
 	case gitlab.InternalVisibility:
+		repo.Visibility = model.VisibilityInternal
 		repo.IsSCMPrivate = true
 	case gitlab.PublicVisibility:
+		repo.Visibility = model.VisibilityPublic
 		repo.IsSCMPrivate = false
 	}
 
@@ -353,7 +372,21 @@ func convertReleaseHook(hook *gitlab.ReleaseEvent) (*model.Repo, *model.Pipeline
 	repo.CloneSSH = hook.Project.GitSSHURL
 	repo.FullName = hook.Project.PathWithNamespace
 	repo.Branch = hook.Project.DefaultBranch
-	repo.IsSCMPrivate = hook.Project.VisibilityLevel > VisibilityLevelInternal
+
+	// Release events expose visibility as a numeric level (unlike push/tag
+	// which omit it from the payload entirely). Map it to both Visibility
+	// and IsSCMPrivate so model.Repo.Update() will propagate the value.
+	switch hook.Project.VisibilityLevel {
+	case visibilityLevelPrivate:
+		repo.Visibility = model.VisibilityPrivate
+		repo.IsSCMPrivate = true
+	case visibilityLevelInternal:
+		repo.Visibility = model.VisibilityInternal
+		repo.IsSCMPrivate = true
+	case visibilityLevelPublic:
+		repo.Visibility = model.VisibilityPublic
+		repo.IsSCMPrivate = false
+	}
 
 	pipeline := &model.Pipeline{
 		Event:    model.EventRelease,

--- a/server/model/repo.go
+++ b/server/model/repo.go
@@ -138,14 +138,16 @@ func (r *Repo) Update(from *Repo) {
 		r.CloneSSH = from.CloneSSH
 	}
 	r.Branch = from.Branch
-	if from.IsSCMPrivate != r.IsSCMPrivate {
-		if from.IsSCMPrivate {
-			r.Visibility = VisibilityPrivate
-		} else {
-			r.Visibility = VisibilityPublic
-		}
+	// Only propagate visibility when the source supplies it. Some webhook
+	// payloads (notably GitLab push/tag/merge events) do not include project
+	// visibility, leaving from.Visibility empty and from.IsSCMPrivate at the
+	// zero value. Updating the stored fields from those payloads would
+	// overwrite the authoritative value previously synced from the forge API
+	// during activation or repair, breaking netrc-protected clones.
+	if from.Visibility != "" {
+		r.Visibility = from.Visibility
+		r.IsSCMPrivate = from.IsSCMPrivate
 	}
-	r.IsSCMPrivate = from.IsSCMPrivate
 }
 
 // RepoPatch represents a repository patch object.

--- a/server/model/repo_test.go
+++ b/server/model/repo_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepoUpdate_Visibility(t *testing.T) {
+	tests := []struct {
+		name           string
+		stored         Repo
+		from           Repo
+		wantVisibility RepoVisibility
+		wantPrivate    bool
+	}{
+		{
+			name:           "empty source visibility preserves stored value",
+			stored:         Repo{Visibility: VisibilityPrivate, IsSCMPrivate: true},
+			from:           Repo{Visibility: "", IsSCMPrivate: false},
+			wantVisibility: VisibilityPrivate,
+			wantPrivate:    true,
+		},
+		{
+			name:           "empty source visibility preserves stored public value",
+			stored:         Repo{Visibility: VisibilityPublic, IsSCMPrivate: false},
+			from:           Repo{Visibility: "", IsSCMPrivate: false},
+			wantVisibility: VisibilityPublic,
+			wantPrivate:    false,
+		},
+		{
+			name:           "source can change public to private",
+			stored:         Repo{Visibility: VisibilityPublic, IsSCMPrivate: false},
+			from:           Repo{Visibility: VisibilityPrivate, IsSCMPrivate: true},
+			wantVisibility: VisibilityPrivate,
+			wantPrivate:    true,
+		},
+		{
+			name:           "source can change private to public",
+			stored:         Repo{Visibility: VisibilityPrivate, IsSCMPrivate: true},
+			from:           Repo{Visibility: VisibilityPublic, IsSCMPrivate: false},
+			wantVisibility: VisibilityPublic,
+			wantPrivate:    false,
+		},
+		{
+			name:           "internal visibility is preserved (not collapsed to private)",
+			stored:         Repo{Visibility: VisibilityPublic, IsSCMPrivate: false},
+			from:           Repo{Visibility: VisibilityInternal, IsSCMPrivate: true},
+			wantVisibility: VisibilityInternal,
+			wantPrivate:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.stored
+			r.Update(&tt.from)
+			assert.Equal(t, tt.wantVisibility, r.Visibility)
+			assert.Equal(t, tt.wantPrivate, r.IsSCMPrivate)
+		})
+	}
+}


### PR DESCRIPTION
## Symptom

On every push (or tag/MR) webhook from GitLab to a Woodpecker server hosting a private GitLab repo, the clone step starts failing with:

```
+ git fetch --no-tags --depth=1 --filter=tree:0 origin +<sha>:
fatal: could not read Username for 'https://gitlab.com': No such device or address
exit status 128
```

Clicking **Repair Repository** in the UI fixes it temporarily â€” until the next push, when the cycle starts again. `WOODPECKER_AUTHENTICATE_PUBLIC_REPOS=true` is an effective workaround.

## Root cause

GitLab's push, tag, and merge-request webhook payloads include `project.visibility_level` (numeric: 0 / 10 / 20) but **not** `project.visibility` (string). The fixtures in this repo confirm this â€” `server/forge/gitlab/fixtures/HookPush.json`, `HookTag.json`, and `HookPullRequestOpened.json` all carry `visibility_level` and no `visibility`.

The go-gitlab library (`gitlab.com/gitlab-org/api/client-go/v2`) maps `PushEventProject.Visibility` to JSON key `visibility` only and does not expose `visibility_level` for these event types. So `hook.Project.Visibility` is `""` for real GitLab payloads, the `switch` in `convertPushHook` / `convertTagHook` matches no case, and the returned `Repo.IsSCMPrivate` is left at its Go zero value `false`.

`(*Repo).Update` then unconditionally copied that `false` over the stored value previously set by `convertGitLabRepo` during repo activation or repair â€” flipping the stored repo to `private=0, visibility=public`. Downstream, `server/pipeline/items.go` skips attaching the netrc to the clone step when `repo.IsSCMPrivate` is false (and `AuthenticatePublicRepos` is unset), so the next clone runs without credentials and fails with the error above.

The Repair button hits the GitLab API (where `visibility` *is* populated), routes through `convertGitLabRepo`, and re-syncs the correct value â€” until the next webhook clobbers it again.

I traced this end-to-end on a 3.14.0 deployment by:

1. Snapshotting the SQLite store and confirming the affected repo had `private=0, visibility=public` while the GitLab API returned `visibility=private` for the same project.
2. Verifying the stored access token clones the repo fine via direct `git clone https://oauth2:$TOKEN@gitlab.com/...` â€” it is not a token / scope problem.
3. Tracing `parsePipeline` â†’ `compiler.WithNetrc(..., repo.IsSCMPrivate || AuthenticatePublicRepos)` and identifying the gate.
4. Confirming `WOODPECKER_AUTHENTICATE_PUBLIC_REPOS=true` made clones succeed without any other change.
5. Confirming the patch keeps the stored row at `private=1, visibility=private` after a fresh push event.

## Fix

- **`model.Repo.Update`**: only propagate `Visibility` / `IsSCMPrivate` when the source actually supplies visibility info. An empty `from.Visibility` now signals "no information" and leaves the stored fields untouched. The API path (`convertGitLabRepo`) always populates `Visibility`, so repo activation/repair is unchanged. Side benefit: "internal" is now preserved instead of being collapsed to "private" by the old `IsSCMPrivate`-based recomputation.

- **`gitlab.convertReleaseHook`**: the previous expression
  ```go
  repo.IsSCMPrivate = hook.Project.VisibilityLevel > VisibilityLevelInternal
  ```
  was inverted: with `VisibilityLevelInternal == 10`, only `Public (20)` satisfied `> 10`, so it marked public projects as private and private/internal projects as public. Replaced with an explicit switch over the three numeric levels that sets both `Visibility` and `IsSCMPrivate`, so the new `Update` gate propagates the value.

- **`gitlab.convertPushHook` / `convertTagHook`**: also set `Visibility` alongside `IsSCMPrivate`, mirroring `convertGitLabRepo`. Today this is effectively dead code (because the `Visibility` string is empty in real payloads), but it is symmetric and forward-compatible if GitLab ever populates the field.

## Tests

`server/model/repo_test.go` (new) covers:

- empty `from.Visibility` preserves the stored private value (the regression);
- empty `from.Visibility` preserves the stored public value;
- API path can change publicâ†’private and privateâ†’public;
- `internal` is preserved instead of being collapsed to `private`.

Existing `server/forge/gitlab` and `server/model` tests continue to pass.

## Verification

Built from this branch on top of a 3.14.0 base and deployed against a private GitLab project that previously failed on every push. After the patch:

- DB row stays at `private=1, visibility=private` across multiple webhook-triggered pipelines.
- Clone step passes without `WOODPECKER_AUTHENTICATE_PUBLIC_REPOS`.
- Repair button no longer needs to be clicked between pushes.
