### PR TITLE
Add 3rd party secret extensions list

### DIFF
--- a/docs/docs/20-usage/72-extensions/55-secret-extension.md
+++ b/docs/docs/20-usage/72-extensions/55-secret-extension.md
@@ -164,3 +164,11 @@ Example response:
   ]
 }
 ```
+
+## 3rd Party Extensions
+
+:::danger
+These extensions are neither developed nor verified by Woodpecker CI. Make sure you trust them before using.
+:::
+
+- [OpenBao extension](https://github.com/vcheesbrough/woodpecker-openbao-broker)


### PR DESCRIPTION
closes https://github.com/woodpecker-ci/woodpecker/discussions/6502

just like https://github.com/woodpecker-ci/woodpecker/pull/6528. Don't know why this was closed.