### PR TITLE
golangci: upgrade gomodguard to gomodguard_2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,7 @@ linters:
     - godot
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - govet
     - importas


### PR DESCRIPTION
Address deprication announced in https://ci.woodpecker-ci.org/repos/3780/pipeline/34077/36

<img width="1432" height="220" alt="image" src="https://github.com/user-attachments/assets/77408ecf-51bf-4dde-bc4d-fa21b15b2859" />
