### PR TITLE
Pin pnpm to v10.33.4

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
   "name": "woodpecker",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@10",
+  "packageManager": "pnpm@10.33.4",
   "scripts": {
     "start": "cd ../ && make generate-docs && cd docs && docusaurus start",
     "build": "pnpm build:woodpecker-plugins && docusaurus build",

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,7 @@
   "name": "woodpecker",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "pnpm@10",
   "scripts": {
     "start": "cd ../ && make generate-docs && cd docs && docusaurus start",
     "build": "pnpm build:woodpecker-plugins && docusaurus build",

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775662680,
-        "narHash": "sha256-N6F+lC0JNTcj9qP6hneP28xkM62C2ld4kexRv9VuTsg=",
+        "lastModified": 1778351894,
+        "narHash": "sha256-7r2iJchc8Ujmld6pd3nQFXE504Ur1apvZaZBdoA/YD4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "81df7a1e2eefe78b4727c8f3d66293300bf193d1",
+        "rev": "2e8afb433747d87eba54496f93f90f41ee1adeab",
         "type": "github"
       },
       "original": {

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "author": "Woodpecker CI",
   "version": "0.0.0",
   "license": "Apache-2.0",
+  "packageManager": "pnpm@10",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "author": "Woodpecker CI",
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "packageManager": "pnpm@10",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Upstream node LTS image was updated with a newer Corepack whose default
"known good" pnpm version jumped to v11. Because we had no `packageManager`
field in `package.json`, Corepack fell back to that default and silently
bumped pnpm to v11 without any explicit change on our side.

Our tooling does not support pnpm v11 yet, which broke CI.

The fix pins pnpm explicitly so we no longer rely on Corepack's moving
default. Renovate will keep the pinned version up to date going forward.

Also updates the nix dev env to the same pinned version for consistency.

Fixes https://ci.woodpecker-ci.org/repos/3780/pipeline/34117