### PR TITLE
server: for grpc store extracted agentID in context

### DIFF
--- a/server/rpc/authorizer.go
+++ b/server/rpc/authorizer.go
@@ -26,7 +26,7 @@
 // Authorizer interceptors validate JWT tokens on every request:
 //  1. Extract JWT from metadata["token"]
 //  2. Verify signature and expiration
-//  3. Extract and add agent_id to metadata for downstream handlers
+//  3. Extract agent_id from JWT claims and store in context
 //
 // Auth endpoint (/proto.WoodpeckerAuth/Auth) bypasses validation to allow initial authentication.
 //
@@ -48,7 +48,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -116,7 +115,7 @@ func (a *Authorizer) UnaryInterceptor(ctx context.Context, req any, info *grpc.U
 	return handler(newCtx, req)
 }
 
-// authorize validates JWT and enriches context with agent_id metadata.
+// authorize validates JWT and injects verified agent_id into the context.
 // Bypasses validation for /proto.WoodpeckerAuth/Auth endpoint.
 func (a *Authorizer) authorize(ctx context.Context, fullMethod string) (context.Context, error) {
 	// bypass auth for token endpoint
@@ -140,7 +139,8 @@ func (a *Authorizer) authorize(ctx context.Context, fullMethod string) (context.
 		return ctx, status.Errorf(codes.Unauthenticated, "access token is invalid: %v", err)
 	}
 
-	md.Append("agent_id", fmt.Sprintf("%d", claims.AgentID))
+	// inject agentID into context
+	ctx = context.WithValue(ctx, agentIDKey, claims.AgentID)
 
-	return metadata.NewIncomingContext(ctx, md), nil
+	return ctx, nil
 }

--- a/server/rpc/authorizer_test.go
+++ b/server/rpc/authorizer_test.go
@@ -129,11 +129,10 @@ func TestAuthorize(t *testing.T) {
 
 		require.NoError(t, err)
 
-		md, ok := metadata.FromIncomingContext(newCtx)
+		rawAgentID := newCtx.Value(agentIDKey)
+		agentID, ok := rawAgentID.(int64)
 		require.True(t, ok)
-		agentIDs := md["agent_id"]
-		require.Len(t, agentIDs, 1)
-		assert.Equal(t, "77", agentIDs[0])
+		assert.EqualValues(t, 77, agentID)
 	})
 
 	t.Run("valid token preserves existing metadata keys", func(t *testing.T) {
@@ -150,7 +149,9 @@ func TestAuthorize(t *testing.T) {
 		require.NoError(t, err)
 		md, _ := metadata.FromIncomingContext(newCtx)
 		assert.Equal(t, []string{"worker-1"}, md["hostname"])
-		assert.Equal(t, []string{"10"}, md["agent_id"])
+
+		agentID, _ := (newCtx.Value(agentIDKey)).(int64)
+		assert.EqualValues(t, 10, agentID)
 	})
 
 	t.Run("empty token value in metadata slice returns Unauthenticated", func(t *testing.T) {
@@ -191,9 +192,10 @@ func TestUnaryInterceptor(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "ok", resp)
 
-		md, ok := metadata.FromIncomingContext(capturedCtx)
+		_, ok := metadata.FromIncomingContext(capturedCtx)
 		require.True(t, ok)
-		assert.Equal(t, []string{"21"}, md["agent_id"])
+		agentID, _ := (capturedCtx.Value(agentIDKey)).(int64)
+		assert.EqualValues(t, 21, agentID)
 	})
 
 	t.Run("invalid token does not call handler", func(t *testing.T) {
@@ -291,10 +293,12 @@ func TestStreamInterceptor(t *testing.T) {
 		}, handler)
 
 		require.NoError(t, err)
+		capturedCtx := capturedStream.Context()
 
-		md, ok := metadata.FromIncomingContext(capturedStream.Context())
+		_, ok := metadata.FromIncomingContext(capturedCtx)
 		require.True(t, ok)
-		assert.Equal(t, []string{"33"}, md["agent_id"])
+		agentID, _ := (capturedCtx.Value(agentIDKey)).(int64)
+		assert.EqualValues(t, 33, agentID)
 	})
 
 	t.Run("invalid token does not call handler", func(t *testing.T) {

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -42,6 +42,11 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/store"
 )
 
+type ctxKey struct{}
+
+// agentIDKey is a non imitable context key.
+var agentIDKey = &ctxKey{}
+
 // updateAgentLastWorkDelay the delay before the LastWork info should be updated.
 const updateAgentLastWorkDelay = time.Minute
 
@@ -589,19 +594,12 @@ func (s *RPC) notify(c context.Context, repo *model.Repo, pipeline *model.Pipeli
 }
 
 func (s *RPC) getAgentFromContext(ctx context.Context) (*model.Agent, error) {
-	md, ok := grpc_metadata.FromIncomingContext(ctx)
-	if !ok {
-		return nil, errors.New("metadata is not provided")
-	}
-
-	values := md["agent_id"]
-	if len(values) == 0 {
+	rawAgentID := ctx.Value(agentIDKey)
+	if rawAgentID == nil {
 		return nil, errors.New("agent_id is not provided")
 	}
-
-	_agentID := values[0]
-	agentID, err := strconv.ParseInt(_agentID, 10, 64)
-	if err != nil {
+	agentID, ok := rawAgentID.(int64)
+	if !ok {
 		return nil, errors.New("agent_id is not a valid integer")
 	}
 

--- a/server/rpc/rpc_integration_test.go
+++ b/server/rpc/rpc_integration_test.go
@@ -15,6 +15,7 @@
 package rpc
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -136,7 +137,7 @@ func TestRPCUpdate(t *testing.T) {
 		mockStore.On("WorkflowGetTree", mock.Anything).Return([]*model.Workflow{workflow}, nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Update(ctx, "30", rpc.StepState{
 			StepUUID: "step-uuid-123",
@@ -170,7 +171,7 @@ func TestRPCUpdate(t *testing.T) {
 		mockLogStore.On("StepFinished", mock.Anything).Return()
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		// Step reports exit → it will transition to success/failure (terminal)
 		err := rpcInst.Update(ctx, "30", rpc.StepState{
@@ -197,7 +198,7 @@ func TestRPCUpdate(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		// Step reports started but not exited → still running (non-terminal)
 		err := rpcInst.Update(ctx, "30", rpc.StepState{StepUUID: "step-uuid-123"})
@@ -218,7 +219,7 @@ func TestRPCUpdate(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Update(ctx, "30", rpc.StepState{StepUUID: "step-uuid-123"})
 		assert.ErrorIs(t, err, ErrAgentIllegalWorkflowReRunStateChange)
@@ -242,7 +243,7 @@ func TestRPCUpdate(t *testing.T) {
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Update(ctx, "30", rpc.StepState{StepUUID: "step-uuid-123"})
 		require.Error(t, err)
@@ -264,7 +265,7 @@ func TestRPCUpdate(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(repo, nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "2"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(2))
 
 		err := rpcInst.Update(ctx, "30", rpc.StepState{StepUUID: "step-uuid-123"})
 		require.Error(t, err)
@@ -274,7 +275,7 @@ func TestRPCUpdate(t *testing.T) {
 	t.Run("reject invalid workflow ID", func(t *testing.T) {
 		mockStore := store_mocks.NewMockStore(t)
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Update(ctx, "not-a-number", rpc.StepState{StepUUID: "step-uuid-123"})
 		assert.Error(t, err)
@@ -285,7 +286,7 @@ func TestRPCUpdate(t *testing.T) {
 		mockStore.On("WorkflowLoad", int64(999)).Return(nil, errors.New("not found"))
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Update(ctx, "999", rpc.StepState{StepUUID: "step-uuid-123"})
 		assert.Error(t, err)
@@ -303,7 +304,7 @@ func TestRPCUpdate(t *testing.T) {
 		mockStore.On("StepByUUID", "nonexistent").Return(nil, errors.New("not found"))
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Update(ctx, "30", rpc.StepState{StepUUID: "nonexistent"})
 		assert.Error(t, err)
@@ -350,7 +351,7 @@ func TestRPCInit(t *testing.T) {
 		mockStore.On("AgentUpdate", mock.Anything).Return(nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Init(ctx, "30", rpc.WorkflowState{Started: 100})
 		assert.NoError(t, err)
@@ -374,7 +375,7 @@ func TestRPCInit(t *testing.T) {
 		mockStore.On("AgentUpdate", mock.Anything).Return(nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Init(ctx, "30", rpc.WorkflowState{Started: 100})
 		assert.NoError(t, err)
@@ -392,7 +393,7 @@ func TestRPCInit(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Init(ctx, "30", rpc.WorkflowState{Started: 100})
 		assert.ErrorIs(t, err, ErrAgentIllegalWorkflowReRunStateChange)
@@ -410,7 +411,7 @@ func TestRPCInit(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Init(ctx, "30", rpc.WorkflowState{Started: 100})
 		assert.ErrorIs(t, err, ErrAgentIllegalWorkflowRun)
@@ -428,7 +429,7 @@ func TestRPCInit(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "2"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(2))
 
 		err := rpcInst.Init(ctx, "30", rpc.WorkflowState{Started: 100})
 		require.Error(t, err)
@@ -438,7 +439,7 @@ func TestRPCInit(t *testing.T) {
 	t.Run("reject invalid workflow ID", func(t *testing.T) {
 		mockStore := store_mocks.NewMockStore(t)
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Init(ctx, "not-a-number", rpc.WorkflowState{})
 		assert.Error(t, err)
@@ -473,7 +474,7 @@ func TestRPCDone(t *testing.T) {
 		mockQueue.On("Done", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		rpcInst := newTestRPC(t, mockStore, mockQueue)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Done(ctx, "30", rpc.WorkflowState{Started: 100, Finished: 200})
 		assert.NoError(t, err)
@@ -492,7 +493,7 @@ func TestRPCDone(t *testing.T) {
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Done(ctx, "30", rpc.WorkflowState{Finished: 200})
 		assert.ErrorIs(t, err, ErrAgentIllegalWorkflowReRunStateChange)
@@ -511,7 +512,7 @@ func TestRPCDone(t *testing.T) {
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Done(ctx, "30", rpc.WorkflowState{Finished: 200})
 		assert.ErrorIs(t, err, ErrAgentIllegalWorkflowRun)
@@ -530,7 +531,7 @@ func TestRPCDone(t *testing.T) {
 		mockStore.On("AgentFind", int64(2)).Return(agent, nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "2"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(2))
 
 		err := rpcInst.Done(ctx, "30", rpc.WorkflowState{Finished: 200})
 		require.Error(t, err)
@@ -540,7 +541,7 @@ func TestRPCDone(t *testing.T) {
 	t.Run("reject invalid workflow ID", func(t *testing.T) {
 		mockStore := store_mocks.NewMockStore(t)
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Done(ctx, "invalid", rpc.WorkflowState{})
 		assert.Error(t, err)
@@ -582,7 +583,7 @@ func TestRPCLog(t *testing.T) {
 		mockLogStore.On("LogAppend", mock.Anything, mock.Anything).Return(nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		entries := []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Line: 0, Data: []byte("hello")},
@@ -611,7 +612,7 @@ func TestRPCLog(t *testing.T) {
 		mockLogStore.On("LogAppend", mock.Anything, mock.Anything).Return(nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("late log")},
@@ -638,7 +639,7 @@ func TestRPCLog(t *testing.T) {
 		mockLogStore.On("LogAppend", mock.Anything, mock.Anything).Return(nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("running log")},
@@ -665,7 +666,7 @@ func TestRPCLog(t *testing.T) {
 		mockLogStore.On("LogAppend", mock.Anything, mock.Anything).Return(nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("drain log")},
@@ -685,7 +686,7 @@ func TestRPCLog(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("test")},
@@ -707,7 +708,7 @@ func TestRPCLog(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("test")},
@@ -728,7 +729,7 @@ func TestRPCLog(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("test")},
@@ -750,7 +751,7 @@ func TestRPCLog(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("test")},
@@ -771,7 +772,7 @@ func TestRPCLog(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("test")},
@@ -798,7 +799,7 @@ func TestRPCLog(t *testing.T) {
 		mockStore.On("AgentUpdate", mock.Anything).Return(nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		// Second entry has a rogue UUID — agent trying to inject into another step.
 		entries := []*rpc.LogEntry{
@@ -822,7 +823,7 @@ func TestRPCLog(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "2"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(2))
 
 		err := rpcInst.Log(ctx, "step-uuid-123", []*rpc.LogEntry{
 			{StepUUID: "step-uuid-123", Data: []byte("test")},
@@ -836,7 +837,7 @@ func TestRPCLog(t *testing.T) {
 		mockStore.On("StepByUUID", "nonexistent").Return(nil, errors.New("not found"))
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "1"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
 
 		err := rpcInst.Log(ctx, "nonexistent", []*rpc.LogEntry{
 			{StepUUID: "nonexistent", Data: []byte("test")},
@@ -861,7 +862,7 @@ func TestRPCExtend(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "2"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(2))
 
 		err := rpcInst.Extend(ctx, "30")
 		require.Error(t, err)
@@ -883,7 +884,7 @@ func TestRPCWait(t *testing.T) {
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
 
 		rpcInst := newTestRPC(t, mockStore, nil)
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("agent_id", "2"))
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(2))
 
 		_, err := rpcInst.Wait(ctx, "30")
 		require.Error(t, err)

--- a/server/rpc/rpc_test.go
+++ b/server/rpc/rpc_test.go
@@ -15,6 +15,7 @@
 package rpc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -56,8 +57,9 @@ func TestRegisterAgent(t *testing.T) {
 		}
 		ctx := metadata.NewIncomingContext(
 			t.Context(),
-			metadata.Pairs("hostname", "hostname", "agent_id", "1337"),
+			metadata.Pairs("hostname", "hostname"),
 		)
+		ctx = context.WithValue(ctx, agentIDKey, int64(1337))
 		agentID, err := grpc.RegisterAgent(ctx, rpc.AgentInfo{
 			Version:  "version",
 			Platform: "platform",
@@ -96,8 +98,9 @@ func TestRegisterAgent(t *testing.T) {
 		}
 		ctx := metadata.NewIncomingContext(
 			t.Context(),
-			metadata.Pairs("hostname", "newHostname", "agent_id", "1337"),
+			metadata.Pairs("hostname", "newHostname"),
 		)
+		ctx = context.WithValue(ctx, agentIDKey, int64(1337))
 		agentID, err := grpc.RegisterAgent(ctx, rpc.AgentInfo{
 			Version:  "version",
 			Platform: "platform",


### PR DESCRIPTION
long term fix for: https://github.com/woodpecker-ci/woodpecker/issues/6541

simple backport is found at https://github.com/woodpecker-ci/woodpecker/pull/6567