### PR TITLE
Fix race in local backend tests

### DIFF
--- a/pipeline/backend/local/local_test.go
+++ b/pipeline/backend/local/local_test.go
@@ -26,7 +26,6 @@ import (
 	"runtime"
 	"slices"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -221,19 +220,17 @@ func TestRunStep(t *testing.T) {
 			stepState, _ := stepStateWraped.(*stepState)
 			assert.NotNil(t, stepState.cmd)
 
-			var outputData []byte
-			outputDataMutex := sync.Mutex{}
-			go t.Run("TailStep", func(t *testing.T) {
-				outputDataMutex.Lock()
-				go outputDataMutex.Unlock()
+			outputDataCh := make(chan []byte)
+			go func() {
 				output, err := backend.TailStep(ctx, step, taskUUID)
 				require.NoError(t, err)
 				assert.NotNil(t, output)
 
 				// Read output
-				outputData, err = io.ReadAll(output)
+				data, err := io.ReadAll(output)
 				require.NoError(t, err)
-			})
+				outputDataCh <- data
+			}()
 
 			// Wait for step to finish
 			t.Run("TestWaitStep", func(t *testing.T) {
@@ -245,8 +242,13 @@ func TestRunStep(t *testing.T) {
 			})
 
 			// Verify output
-			outputDataMutex.Lock()
-			go outputDataMutex.Unlock()
+			var outputData []byte
+			select {
+			case outputData = <-outputDataCh:
+			case <-t.Context().Done():
+				t.Fail()
+				return
+			}
 			outputLines := strings.Split(strings.TrimSpace(string(outputData)), "\n")
 			require.Truef(t, len(outputLines) > 3, "output of lines must be bigger than 3 at least but we got: %#v", outputLines)
 			// we first test output without environments
@@ -423,8 +425,9 @@ func TestConcurrentWorkflows(t *testing.T) {
 
 	counter := atomic.Int32{}
 	counter.Store(0)
+	t.Parallel()
 	for _, uuid := range taskUUIDs {
-		go t.Run("start step in "+uuid, func(t *testing.T) {
+		t.Run("start step in "+uuid, func(t *testing.T) {
 			for i := 0; i < 3; i++ {
 				counter.Store(counter.Load() + 1)
 				step := &types.Step{


### PR DESCRIPTION
fix https://ci.woodpecker-ci.org/repos/3780/pipeline/34237/38
```
==================
WARNING: DATA RACE
Write at 0x00c0000e0710 by goroutine 66:
  testing.(*common).setRan()
      /usr/local/go/src/testing/testing.go:957 +0xc6
  testing.(*common).setRan()
      /usr/local/go/src/testing/testing.go:953 +0x65
  testing.(*common).setRan()
      /usr/local/go/src/testing/testing.go:953 +0x65
  testing.tRunner.func1()
      /usr/local/go/src/testing/testing.go:2025 +0x949
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:668 +0x5d
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:2101 +0x38

Previous read at 0x00c0000e0710 by main goroutine:
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2594 +0xa59
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2443 +0xf4b
  main.main()
      _testmain.go:74 +0x164

Goroutine 66 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:2101 +0xb12
  go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/local.TestConcurrentWorkflows.gowrap1()
      /woodpecker/src/github.com/woodpecker-ci/woodpecker/pipeline/backend/local/local_test.go:427 +0x54
==================
Found 1 data race(s)
```


# !!! NOTE !!!

`go t.Run(...)` is an the cause! either do `go func{}()` or use `t.Parallel()` depending on the usecase 