### PR TITLE
Fix embed for web ui chunks

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 )
 
-//go:embed dist/*
+//go:embed all:dist/*
 var webFiles embed.FS
 
 func HTTPFS() (http.FileSystem, error) {


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/6607

By default, Go intentionally ignores any files and directories that start with a dot (.) or an underscore (_) when using `embed`. Recently (maybe due to a dependency update to Vite, Rollup, or the Intlify/i18n plugin), the frontend build process started splitting out some JavaScript code into separate chunks that are prefixed with an underscore, such as `_intlify-i18n-19-CTBJX147.js`.

Changing the directive to `//go:embed all:dist/*` (using the all: prefix) tells Go to include everything matching the pattern, including files that start with `_` or `.`, successfully embedding the missing chunks.