### PR TITLE
fix cli exec skipped workflow cleanup

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -304,6 +304,9 @@ func execWithAxis(ctx context.Context, c *cli.Command, file, repoPath string, ax
 	if err != nil {
 		return err
 	}
+	if len(compiled.Stages) == 0 {
+		return nil
+	}
 
 	backendCtx := context.WithValue(ctx, backend_types.CliCommand, c)
 	backendEngine, err := backend.FindBackend(backendCtx, backends, c.String("backend-engine"))

--- a/cli/exec/exec_test.go
+++ b/cli/exec/exec_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	backend_types "go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types/mocks"
+)
+
+func TestExecSkipsFilteredWorkflowWithoutBackendSetup(t *testing.T) {
+	originalBackends := backends
+	t.Cleanup(func() {
+		backends = originalBackends
+	})
+
+	backends = []backend_types.Backend{mocks.NewMockBackend(t)}
+
+	repoDir := t.TempDir()
+	workflowPath := filepath.Join(repoDir, "workflow.yaml")
+	require.NoError(t, os.WriteFile(workflowPath, []byte(`when:
+  - event: push
+    branch: "**"
+
+steps:
+  - name: build
+    image: alpine
+    commands:
+      - echo hello
+`), 0o600))
+
+	err := Command.Run(t.Context(), []string{
+		"woodpecker-cli",
+		"--backend-engine", "test-backend",
+		"--repo-path", repoDir,
+		workflowPath,
+	})
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- return successfully from `woodpecker-cli exec` when a workflow compiles to no runnable stages
- avoid selecting/setting up a backend for workflows filtered out by `when`
- add a regression test that fails if a skipped workflow reaches backend setup

Closes #5419

## Validation
- reproduced on `upstream/main` with a Docker-backed workflow filtered by `when`, which failed with `invalid volume name or ID: value is empty` and `invalid network name or ID: value is empty`
- `GOROOT=$(go env GOROOT) GOTOOLCHAIN=local PATH="$(go env GOROOT)/bin:$PATH" go test -race -tags test ./cli/exec -run TestExecSkipsFilteredWorkflowWithoutBackendSetup -count=1 -v`
- Docker skipped-workflow smoke test: `go run ./cmd/cli --disable-update-check exec --backend-engine docker --repo-path "$tmpdir" "$tmpdir/.woodpecker/build.yaml"` exits 0 after this fix
- Docker matching-workflow smoke test with `--pipeline-event push --commit-branch main` runs `alpine:3.23` and prints step output
- `GOROOT=$(go env GOROOT) GOTOOLCHAIN=local PATH="$(go env GOROOT)/bin:$PATH" go test -race -tags test ./cmd/cli ./cli/... -count=1`
- `GOROOT=$(go env GOROOT) GOTOOLCHAIN=local PATH="$(go env GOROOT)/bin:$PATH" make test-cli`

Note: local `pre-commit` is unavailable in this environment (`pre-commit: command not found`).