### PR TITLE
docs: clarify skipped workflow dependencies

### DIFF
--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -757,7 +757,13 @@ skip_clone: true
 
 ## `when` - Global workflow conditions
 
-Woodpecker gives the ability to skip whole workflows ([not just steps](#when---conditional-execution)) based on certain conditions by a `when` block. If all conditions in the `when` block evaluate to true the workflow is executed, otherwise it is skipped, but treated as successful and other workflows depending on it will still continue.
+Woodpecker gives the ability to skip whole workflows ([not just steps](#when---conditional-execution)) based on certain conditions by a `when` block. If all conditions in the `when` block evaluate to true the workflow is executed, otherwise the complete workflow is skipped.
+
+:::info
+A workflow skipped by a global `when` block does not count as a successful dependency for other workflows using `depends_on`. Those dependent workflows are not executed.
+
+If another workflow should continue after optional work is skipped, move the condition to the relevant steps or keep a lightweight step that can complete successfully.
+:::
 
 For more information about the specific filters, take a look at the [step-specific `when` filters](#when---conditional-execution).
 

--- a/docs/docs/20-usage/25-workflows.md
+++ b/docs/docs/20-usage/25-workflows.md
@@ -82,6 +82,8 @@ The workflows run in parallel on separate agents and share nothing.
 
 Dependencies between workflows can be set with the `depends_on` element. A workflow doesn't execute until all of its dependencies finished successfully.
 
+Only workflows that are created and finish successfully satisfy `depends_on`. A workflow skipped by a global [`when` condition](./20-workflow-syntax.md#when---global-workflow-conditions) is not treated as a successful dependency, so workflows depending on it are not executed.
+
 The name for a `depends_on` entry is the filename without the path, leading dots and without the file extension `.yml` or `.yaml`. If the project config for example uses `.woodpecker/` as path for CI files with a file named `.woodpecker/.lint.yaml` the corresponding `depends_on` entry would be `lint`.
 
 ```diff


### PR DESCRIPTION
## Summary
- correct the global workflow `when` docs to say skipped workflows are skipped completely
- clarify that globally skipped workflows do not satisfy `depends_on`
- add a workaround note for optional work that should not block dependent workflows

Closes #6457

## Validation
- `cd docs && pnpm format:check`
- `make spellcheck`
- `GOROOT=$(go env GOROOT) GOTOOLCHAIN=local PATH="$(go env GOROOT)/bin:$PATH" make build-docs`
- `git diff --check`

Note: `make build-docs` succeeds with existing plugin-fetch warnings and the existing Docusaurus warning for the old versioned `2.8` CLI page.