### PR TITLE
Make CLI lint prefer detected Woodpecker config

### DIFF
--- a/cli/common/pipeline.go
+++ b/cli/common/pipeline.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/urfave/cli/v3"
@@ -26,16 +27,37 @@ import (
 )
 
 func DetectPipelineConfig() (isDir bool, config string, _ error) {
-	for _, config := range constant.DefaultConfigOrder {
-		shouldBeDir := strings.HasSuffix(config, "/")
-		config = strings.TrimSuffix(config, "/")
-
-		if fi, err := os.Stat(config); err == nil && shouldBeDir == fi.IsDir() {
-			return fi.IsDir(), config, nil
-		}
+	isDir, config, found, err := FindPipelineConfig(".")
+	if err != nil {
+		return false, "", err
+	}
+	if found {
+		return isDir, config, nil
 	}
 
 	return false, "", fmt.Errorf("could not detect pipeline config")
+}
+
+// FindPipelineConfig searches dir using the default pipeline config order.
+func FindPipelineConfig(dir string) (isDir bool, config string, found bool, _ error) {
+	for _, configPath := range constant.DefaultConfigOrder {
+		shouldBeDir := strings.HasSuffix(configPath, "/")
+		configPath = filepath.Join(dir, strings.TrimSuffix(configPath, "/"))
+
+		fi, err := os.Stat(configPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, "", false, err
+		}
+
+		if shouldBeDir == fi.IsDir() {
+			return fi.IsDir(), configPath, true, nil
+		}
+	}
+
+	return false, "", false, nil
 }
 
 func RunPipelineFunc(ctx context.Context, c *cli.Command, fileFunc, dirFunc func(context.Context, *cli.Command, string) error) error {

--- a/cli/common/pipeline_test.go
+++ b/cli/common/pipeline_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindPipelineConfig(t *testing.T) {
+	t.Run("PrefersWoodpeckerDirectory", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(repoRoot, ".woodpecker"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".woodpecker.yaml"), []byte("steps: {}\n"), 0o644))
+
+		isDir, config, found, err := FindPipelineConfig(repoRoot)
+
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.True(t, isDir)
+		assert.Equal(t, filepath.Join(repoRoot, ".woodpecker"), config)
+	})
+
+	t.Run("FindsFileConfig", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".woodpecker.yml"), []byte("steps: {}\n"), 0o644))
+
+		isDir, config, found, err := FindPipelineConfig(repoRoot)
+
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.False(t, isDir)
+		assert.Equal(t, filepath.Join(repoRoot, ".woodpecker.yml"), config)
+	})
+
+	t.Run("MissingConfig", func(t *testing.T) {
+		isDir, config, found, err := FindPipelineConfig(t.TempDir())
+
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.False(t, isDir)
+		assert.Empty(t, config)
+	})
+}

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -67,6 +67,21 @@ func lint(ctx context.Context, c *cli.Command) error {
 }
 
 func lintDir(ctx context.Context, c *cli.Command, dir string) error {
+	isDir, config, found, err := common.FindPipelineConfig(dir)
+	if err != nil {
+		return err
+	}
+	if found {
+		if !isDir {
+			return lintFile(ctx, c, config)
+		}
+		dir = config
+	}
+
+	return lintFilesInDir(ctx, c, dir)
+}
+
+func lintFilesInDir(ctx context.Context, c *cli.Command, dir string) error {
 	var errorStrings []string
 	if err := filepath.Walk(dir, func(path string, info os.FileInfo, e error) error {
 		if e != nil {

--- a/cli/lint/lint_test.go
+++ b/cli/lint/lint_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestLintDirPrefersDefaultWoodpeckerDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	writeFile(t, filepath.Join(repoRoot, ".woodpecker", "pipeline.yaml"), `steps:
+  test:
+    image: alpine
+    commands:
+      - echo ok
+`)
+	writeFile(t, filepath.Join(repoRoot, "compose.yaml"), `services:
+  database:
+    image: postgres
+`)
+
+	runLintCommand(t, func(c *cli.Command) {
+		require.NoError(t, lintDir(t.Context(), c, repoRoot))
+	})
+}
+
+func runLintCommand(t *testing.T, fn func(c *cli.Command)) {
+	t.Helper()
+
+	command := &cli.Command{
+		Flags: Command.Flags,
+		Action: func(_ context.Context, c *cli.Command) error {
+			fn(c)
+			return nil
+		},
+	}
+	require.NoError(t, command.Run(t.Context(), []string{"woodpecker-cli"}))
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}


### PR DESCRIPTION
## Summary
- reuse the default Woodpecker config search order for `woodpecker-cli lint <directory>`
- when a provided directory contains `.woodpecker/`, `.woodpecker.yaml`, or `.woodpecker.yml`, lint that detected config instead of unrelated YAML files in the repo tree
- add regression coverage for directory linting with an unrelated `compose.yaml` and direct tests for config detection order

Closes #6120

## Validation
- `go test -race -tags test ./cli/lint -run TestLintDirPrefersDefaultWoodpeckerDirectory -count=1 -v`
- `go test -race -tags test ./cli/common ./cli/lint -count=1`
- `go vet -tags test ./cli/common ./cli/lint`
- `make test-cli`
- CLI smoke: `woodpecker-cli lint <repo-root>` with `.woodpecker/pipeline.yaml` plus unrelated `compose.yaml` lints only the Woodpecker config
