### PR TITLE
fix(agent): decode CI_SCRIPT to temp file before execution

### DIFF
--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -173,7 +173,7 @@ Only build steps can define commands. You cannot use commands with plugins or se
 
 Allows you to specify the entrypoint for containers. Note that this must be a list of the command and its arguments (e.g. `["/bin/sh", "-c"]`).
 
-If you define [`commands`](#commands), the default entrypoint will be `["/bin/sh", "-c", "echo $CI_SCRIPT | base64 -d | /bin/sh -e"]`.
+If you define [`commands`](#commands), the default entrypoint will be `["/bin/sh", "-c", "script=$(mktemp /tmp/.woodpecker-ci-script.XXXXXX) && echo $CI_SCRIPT | base64 -d > \"$script\" && /bin/sh -e \"$script\"; ret=$?; rm -f \"$script\"; exit $ret"]`.
 You can also use a custom shell with `CI_SCRIPT` (Base64-encoded) if you set `commands`.
 
 ### `environment`

--- a/pipeline/backend/common/script.go
+++ b/pipeline/backend/common/script.go
@@ -18,6 +18,10 @@ import (
 	"encoding/base64"
 )
 
+// PosixEntrypointCommand decodes CI_SCRIPT to a temp file before execution to avoid
+// intermittent truncation when piping base64 output directly to /bin/sh.
+const PosixEntrypointCommand = `script=$(mktemp /tmp/.woodpecker-ci-script.XXXXXX) && echo $CI_SCRIPT | base64 -d > "$script" && /bin/sh -e "$script"; ret=$?; rm -f "$script"; exit $ret`
+
 func GenerateContainerConf(commands []string, osType, workDir string) (env map[string]string, entry []string) {
 	env = make(map[string]string)
 	if osType == "windows" {
@@ -28,7 +32,7 @@ func GenerateContainerConf(commands []string, osType, workDir string) (env map[s
 	} else {
 		env["CI_SCRIPT"] = base64.StdEncoding.EncodeToString([]byte(generateScriptPosix(commands, workDir)))
 		env["SHELL"] = "/bin/sh"
-		entry = []string{"/bin/sh", "-c", "echo $CI_SCRIPT | base64 -d | /bin/sh -e"}
+		entry = []string{"/bin/sh", "-c", PosixEntrypointCommand}
 	}
 
 	return env, entry

--- a/pipeline/backend/common/script_test.go
+++ b/pipeline/backend/common/script_test.go
@@ -33,5 +33,5 @@ func TestGenerateContainerConf(t *testing.T) {
 	gotEnv, gotEntry = GenerateContainerConf([]string{"echo hello world"}, "linux", "/woodpecker/some")
 	assert.Equal(t, posixScriptBase64, gotEnv["CI_SCRIPT"])
 	assert.Equal(t, "/bin/sh", gotEnv["SHELL"])
-	assert.Equal(t, []string{"/bin/sh", "-c", "echo $CI_SCRIPT | base64 -d | /bin/sh -e"}, gotEntry)
+	assert.Equal(t, []string{"/bin/sh", "-c", PosixEntrypointCommand}, gotEntry)
 }

--- a/pipeline/backend/docker/convert_test.go
+++ b/pipeline/backend/docker/convert_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/moby/api/types/system"
 	"github.com/stretchr/testify/assert"
 
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/common"
 	backend_types "go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
 )
 
@@ -133,7 +134,7 @@ func TestStepToConfig(t *testing.T) {
 	// StepTypeCommands
 	conf := testEngine.toConfig(testCmdStep, BackendOptions{})
 	if assert.NotNil(t, conf) {
-		assert.EqualValues(t, []string{"/bin/sh", "-c", "echo $CI_SCRIPT | base64 -d | /bin/sh -e"}, conf.Entrypoint)
+		assert.EqualValues(t, []string{"/bin/sh", "-c", common.PosixEntrypointCommand}, conf.Entrypoint)
 		assert.Nil(t, conf.Cmd)
 		assert.EqualValues(t, testCmdStep.UUID, conf.Labels["wp_uuid"])
 	}
@@ -181,7 +182,7 @@ func TestToConfigSmall(t *testing.T) {
 	assert.EqualValues(t, &container.Config{
 		AttachStdout: true,
 		AttachStderr: true,
-		Entrypoint:   []string{"/bin/sh", "-c", "echo $CI_SCRIPT | base64 -d | /bin/sh -e"},
+		Entrypoint:   []string{"/bin/sh", "-c", common.PosixEntrypointCommand},
 		Labels: map[string]string{
 			"wp_step": "test",
 			"wp_uuid": "09238932",
@@ -242,7 +243,7 @@ func TestToConfigFull(t *testing.T) {
 		WorkingDir:   "/src",
 		AttachStdout: true,
 		AttachStderr: true,
-		Entrypoint:   []string{"/bin/sh", "-c", "echo $CI_SCRIPT | base64 -d | /bin/sh -e"},
+		Entrypoint:   []string{"/bin/sh", "-c", common.PosixEntrypointCommand},
 		Labels: map[string]string{
 			"wp_step": "test",
 			"wp_uuid": "09238932",

--- a/pipeline/backend/kubernetes/pod_test.go
+++ b/pipeline/backend/kubernetes/pod_test.go
@@ -162,7 +162,7 @@ func TestTinyPod(t *testing.T) {
 					"command": [
 						"/bin/sh",
 						"-c",
-						"echo $CI_SCRIPT | base64 -d | /bin/sh -e"
+						"script=$(mktemp /tmp/.woodpecker-ci-script.XXXXXX) && echo $CI_SCRIPT | base64 -d > \"$script\" && /bin/sh -e \"$script\"; ret=$?; rm -f \"$script\"; exit $ret"
 					],
 					"env": [
 						"<<UNORDERED>>",


### PR DESCRIPTION
## Summary

- Change the default POSIX entrypoint to decode `CI_SCRIPT` into a temp file under `/tmp` before executing it with `/bin/sh -e`
- Avoids intermittent command truncation when piping `base64 -d` output directly to the shell (reported in #5450)
- Store script outside the workspace as suggested in the issue discussion

## Test plan

- [x] `go test ./pipeline/backend/common/... ./pipeline/backend/docker/... ./pipeline/backend/kubernetes/...`
- [x] Updated unit tests for docker/kubernetes container config generation

Fixes #5450