### PR TITLE
fix(runtime): run OnFailure steps after workflow cancel

### DIFF
--- a/pipeline/runtime/workflow.go
+++ b/pipeline/runtime/workflow.go
@@ -66,7 +66,10 @@ func (r *Runtime) Run(runnerCtx context.Context) error {
 		select {
 		case <-r.ctx.Done():
 			<-stageChan
-			return pipeline_errors.ErrCancel
+			if r.err.Get() == nil {
+				r.err.Set(pipeline_errors.ErrCancel)
+			}
+			continue
 		case err := <-stageChan:
 			if err != nil {
 				r.err.Set(err)

--- a/pipeline/runtime/workflow_test.go
+++ b/pipeline/runtime/workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -149,6 +150,37 @@ func TestRunContextCanceled(t *testing.T) {
 	err := r.Run(t.Context())
 
 	assert.ErrorIs(t, err, pipeline_errors.ErrCancel)
+}
+
+func TestRunContextCanceledRunsOnFailureStep(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(t.Context())
+	tracer := newTestTracer(t)
+
+	r := New(
+		&backend_types.Config{
+			Stages: []*backend_types.Stage{
+				{Steps: []*backend_types.Step{cmdStep("build", withSleep("3s"))}},
+				{Steps: []*backend_types.Step{cmdStep("cleanup", withOnFailure())}},
+			},
+		},
+		dummy.New(),
+		WithTracer(tracer),
+		WithContext(ctx),
+		WithLogger(newTestLogger(t)),
+	)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel(pipeline_errors.ErrCancel)
+	}()
+
+	err := r.Run(t.Context())
+
+	assert.ErrorIs(t, err, pipeline_errors.ErrCancel)
+	assert.NotNil(t, findStartedTrace(getTracerStates(tracer), "cleanup"),
+		"OnFailure cleanup step should run when the workflow is canceled")
 }
 
 func TestRunSetupWorkflowError(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #6564

When a pipeline is canceled/killed mid-run, the runtime now continues with later stages instead of aborting immediately. Steps configured with `when.status: [success, failure]` (`OnFailure: true`) still execute for cleanup.

## Root cause
`Runtime.Run` returned `ErrCancel` as soon as the workflow context was canceled, skipping all subsequent stages—even cleanup steps that should run on failure/cancel.

## Approach
- On cancel, drain the current stage, record `ErrCancel`, and continue remaining stages.
- `shouldSkipStep` already skips success-only steps when an error is set, so normal steps are not affected.

## Test plan
- [x] `go test -tags test ./pipeline/runtime/... -run TestRunContextCanceled -v`
- [x] Added `TestRunContextCanceledRunsOnFailureStep`

Made with [Cursor](https://cursor.com)