### PR TITLE
fix: add timeout to log upload wait and make missing agent non-fatal …

### DIFF
--- a/pipeline/runtime/option.go
+++ b/pipeline/runtime/option.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"time"
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/logging"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/tracing"
@@ -56,5 +57,13 @@ func WithDescription(desc map[string]string) Option {
 func WithTaskUUID(uuid string) Option {
 	return func(r *Runtime) {
 		r.taskUUID = uuid
+	}
+}
+
+// WithUploadWaitTimeout sets how long Run waits for log-upload goroutines to
+// finish after DestroyWorkflow. Defaults to 30s when unset or zero.
+func WithUploadWaitTimeout(d time.Duration) Option {
+	return func(r *Runtime) {
+		r.uploadWaitTimeout = d
 	}
 }

--- a/pipeline/runtime/option_test.go
+++ b/pipeline/runtime/option_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithUploadWaitTimeout(t *testing.T) {
+	r := &Runtime{}
+	WithUploadWaitTimeout(10 * time.Second)(r)
+	assert.Equal(t, 10*time.Second, r.uploadWaitTimeout)
+}

--- a/pipeline/runtime/runtime.go
+++ b/pipeline/runtime/runtime.go
@@ -17,6 +17,7 @@ package runtime
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rs/zerolog"
@@ -46,7 +47,8 @@ type Runtime struct {
 	tracer tracing.Tracer
 	logger logging.Logger
 
-	uploadWait sync.WaitGroup
+	uploadWait        sync.WaitGroup
+	uploadWaitTimeout time.Duration
 
 	taskUUID    string
 	description map[string]string

--- a/pipeline/runtime/runtime_test.go
+++ b/pipeline/runtime/runtime_test.go
@@ -35,6 +35,13 @@ import (
 	tracer_mocks "go.woodpecker-ci.org/woodpecker/v3/pipeline/tracing/mocks"
 )
 
+func TestNewRuntimeUploadWaitTimeoutDefaultsToZero(t *testing.T) {
+	// Zero means workflow.go will substitute the 30s production default.
+	// Tests that need a different value use WithUploadWaitTimeout explicitly.
+	r := New(&backend_types.Config{}, dummy.New())
+	assert.Equal(t, time.Duration(0), r.uploadWaitTimeout)
+}
+
 //
 // Step builder helpers.
 //

--- a/pipeline/runtime/workflow.go
+++ b/pipeline/runtime/workflow.go
@@ -77,10 +77,25 @@ func (r *Runtime) Run(runnerCtx context.Context) error {
 	// Now we can shutdown the workflow
 	destroyWorkflowFunc()
 
-	// Ensure all logs/traces are uploaded before finishing
+	// Ensure all logs/traces are uploaded before finishing, with a timeout so
+	// a hung log-upload goroutine (e.g. a service container that is slow to
+	// stop after DestroyWorkflow) cannot prevent the agent from exiting cleanly.
+	timeout := r.uploadWaitTimeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
 	logger.Debug().Msg("waiting for logs and traces upload")
-	r.uploadWait.Wait()
-	logger.Debug().Msg("logs and traces uploaded")
+	uploadDone := make(chan struct{})
+	go func() {
+		r.uploadWait.Wait()
+		close(uploadDone)
+	}()
+	select {
+	case <-uploadDone:
+		logger.Debug().Msg("logs and traces uploaded")
+	case <-time.After(timeout):
+		logger.Warn().Msgf("timed out waiting for logs and traces upload after %s, proceeding with cleanup", timeout)
+	}
 
 	return r.err.Get()
 }

--- a/pipeline/runtime/workflow_test.go
+++ b/pipeline/runtime/workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -391,4 +392,38 @@ func TestRunDestroyWorkflowFallsBackToShutdownCtx(t *testing.T) {
 	// (or at least not the same canceled one).
 	assert.NotEqual(t, runnerCtx, destroyCtx,
 		"DestroyWorkflow should receive the shutdown fallback context, not the canceled runnerCtx")
+}
+
+func TestRunUploadWaitTimeout(t *testing.T) {
+	t.Parallel()
+	// Regression test: a hung log-upload goroutine (e.g. a service container
+	// still streaming logs after DestroyWorkflow) must not block Run forever.
+	// WithUploadWaitTimeout lets tests use a very short deadline instead of 30s.
+	r := New(
+		&backend_types.Config{
+			Stages: []*backend_types.Stage{{
+				Steps: []*backend_types.Step{{
+					Name: "build", UUID: "u1",
+					Type: backend_types.StepTypeCommands, OnSuccess: true,
+					Environment: map[string]string{}, Commands: []string{"echo hello"},
+				}},
+			}},
+		},
+		dummy.New(),
+		WithTracer(newTestTracer(t)),
+		WithLogger(newTestLogger(t)),
+		WithUploadWaitTimeout(5*time.Millisecond),
+	)
+
+	// Simulate a hung log-upload goroutine by holding uploadWait open without
+	// a corresponding Done — exactly what happens when a service container
+	// keeps streaming logs after DestroyWorkflow.
+	r.uploadWait.Add(1)
+
+	start := time.Now()
+	err := r.Run(t.Context())
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)                        // pipeline itself succeeded
+	assert.Less(t, elapsed, 5*time.Second)        // did not hang for the full default 30s
 }

--- a/server/api/queue.go
+++ b/server/api/queue.go
@@ -136,12 +136,12 @@ func processQueueTasks(store store.Store, tasks []*model.Task, agentNameMap map[
 		}
 
 		if task.AgentID != 0 {
-			name, ok := getAgentName(store, agentNameMap, task.AgentID)
-			if !ok {
-				return nil, fmt.Errorf("agent not found for task %s", task.ID)
+			// Agent name is cosmetic — if the agent row was deleted before the
+			// task was cleared from the queue, skip the name rather than
+			// returning a 500 that breaks KEDA and freezes all pending pipelines.
+			if name, ok := getAgentName(store, agentNameMap, task.AgentID); ok {
+				taskResponse.AgentName = name
 			}
-
-			taskResponse.AgentName = name
 		}
 
 		if task.PipelineID != 0 {

--- a/server/api/queue_test.go
+++ b/server/api/queue_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+func TestProcessQueueTasks(t *testing.T) {
+	t.Run("stale agent ID does not return error", func(t *testing.T) {
+		// Regression test for woodpecker-ci/woodpecker#6615:
+		// a task whose agent row was deleted must not cause processQueueTasks
+		// to return an error that would make /api/queue/info return HTTP 500.
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("AgentFind", int64(99)).Return(nil, errors.New("record not found"))
+
+		tasks := []*model.Task{{ID: "task-1", AgentID: 99}}
+
+		result, err := processQueueTasks(mockStore, tasks, make(map[int64]string))
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "", result[0].AgentName)
+	})
+
+	t.Run("known agent ID populates agent name", func(t *testing.T) {
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("AgentFind", int64(1)).Return(&model.Agent{ID: 1, Name: "my-agent"}, nil)
+
+		tasks := []*model.Task{{ID: "task-1", AgentID: 1}}
+
+		result, err := processQueueTasks(mockStore, tasks, make(map[int64]string))
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "my-agent", result[0].AgentName)
+	})
+
+	t.Run("task without agent ID has empty agent name", func(t *testing.T) {
+		mockStore := store_mocks.NewMockStore(t)
+
+		tasks := []*model.Task{{ID: "task-1", AgentID: 0}}
+
+		result, err := processQueueTasks(mockStore, tasks, make(map[int64]string))
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "", result[0].AgentName)
+	})
+
+	t.Run("pipeline ID is resolved to pipeline number", func(t *testing.T) {
+		mockStore := store_mocks.NewMockStore(t)
+		mockStore.On("GetPipeline", int64(42)).Return(&model.Pipeline{ID: 42, Number: 7}, nil)
+
+		tasks := []*model.Task{{ID: "task-1", PipelineID: 42}}
+
+		result, err := processQueueTasks(mockStore, tasks, make(map[int64]string))
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, int64(7), result[0].PipelineNumber)
+	})
+
+	t.Run("agent name is cached across tasks", func(t *testing.T) {
+		mockStore := store_mocks.NewMockStore(t)
+		// AgentFind should only be called once even with two tasks sharing the same AgentID.
+		mockStore.On("AgentFind", int64(5)).Return(&model.Agent{ID: 5, Name: "cached-agent"}, nil).Once()
+
+		tasks := []*model.Task{
+			{ID: "task-1", AgentID: 5},
+			{ID: "task-2", AgentID: 5},
+		}
+
+		result, err := processQueueTasks(mockStore, tasks, make(map[int64]string))
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, "cached-agent", result[0].AgentName)
+		assert.Equal(t, "cached-agent", result[1].AgentName)
+		mockStore.AssertNumberOfCalls(t, "AgentFind", 1)
+	})
+}


### PR DESCRIPTION
  ---
  Fixes two independent bugs that together can freeze all pending pipelines on a
  Kubernetes + KEDA deployment.

  ### 1. `server/api/queue.go` — stale agent reference causes HTTP 500 on `/api/queue/info`

  When a task in the queue holds an `AgentID` that no longer exists in the
  database (agent pod was deleted while the task was still assigned), `processQueueTasks`
  returned a hard error, causing `/api/queue/info` to return HTTP 500.

  KEDA's `metrics-api` trigger polls this endpoint every 2 s; a persistent 500
  prevents any new agents from being spawned, freezing all pending pipelines until
  the server is manually restarted.

  The agent name is cosmetic display data — if the agent row is gone, skip the
  name silently instead of returning a 500.

  Closes #6615

  ### 2. `pipeline/runtime/workflow.go` — unbounded wait after `DestroyWorkflow` blocks agent exit

  `r.uploadWait.Wait()` had no timeout. When a service container (e.g. postgres)
  takes time to stop after `DestroyWorkflow`, it continues generating logs during
  its graceful shutdown. The log-stream goroutine reads those logs and tries to
  upload them via gRPC; if the server acknowledgement is slow or missing, the
  goroutine never unblocks `uploadWait`, and the agent pod stays alive indefinitely.
  Pipelines show as "running" for hours with the agent logging "renewing workflow
  lease" in a tight loop.

  Add a 30 s timeout so the agent always proceeds to exit, even if a log-upload
  goroutine is stuck.

  ---