### PR TITLE
Sort completed pipeline workflows by their execution order

### DIFF
--- a/web/src/components/repo/pipeline/PipelineStepList.vue
+++ b/web/src/components/repo/pipeline/PipelineStepList.vue
@@ -63,7 +63,7 @@
     <div class="relative min-h-0 w-full grow">
       <div class="absolute top-0 right-0 left-0 flex h-full flex-col gap-y-2 md:overflow-y-auto">
         <div
-          v-for="workflow in pipeline.workflows"
+          v-for="workflow in sortedWorkflows"
           :key="workflow.id"
           class="border-wp-background-400 dark:border-wp-background-100 bg-wp-background-200 rounded-md border p-2"
         >
@@ -99,7 +99,7 @@
             :class="{ 'max-h-0': workflowsCollapsed[workflow.id], 'ml-[1.6rem]': !singleConfig }"
           >
             <button
-              v-for="step in workflow.children"
+              v-for="step in sortedChildren(workflow)"
               ref="steps"
               :key="step.pid"
               :data-step-id="step.pid"
@@ -108,7 +108,7 @@
               class="hover:bg-wp-control-neutral-200 flex w-full cursor-pointer items-center gap-2 rounded-md border-2 border-transparent p-2"
               :class="{
                 'bg-wp-control-neutral-200': selectedStepId && selectedStepId === step.pid,
-                'mt-1': !singleConfig || (workflow.children && step.pid !== workflow.children[0].pid),
+                'mt-1': !singleConfig || step.pid !== sortedChildren(workflow)[0]?.pid,
               }"
               @click="$emit('update:selected-step-id', step.pid)"
             >
@@ -134,7 +134,7 @@ import PipelineStepDuration from '~/components/repo/pipeline/PipelineStepDuratio
 import { requiredInject } from '~/compositions/useInjectProvide';
 import usePipeline from '~/compositions/usePipeline';
 import { StepType } from '~/lib/api/types';
-import type { Pipeline, PipelineStep } from '~/lib/api/types';
+import type { Pipeline, PipelineStep, PipelineWorkflow } from '~/lib/api/types';
 
 const props = defineProps<{
   pipeline: Pipeline;
@@ -167,6 +167,21 @@ const workflowsCollapsed = ref<Record<PipelineStep['id'], boolean>>(
 const singleConfig = computed(
   () => pipelineConfigs?.value?.length === 1 && pipeline.value.workflows && pipeline.value.workflows.length === 1,
 );
+
+const sortedWorkflows = computed(() =>
+  [...(pipeline.value.workflows ?? [])].toSorted((a, b) => {
+    const aStarted = a.started ?? 0;
+    const bStarted = b.started ?? 0;
+    if (aStarted && bStarted) return aStarted - bStarted;
+    if (aStarted) return -1;
+    if (bStarted) return 1;
+    return a.pid - b.pid;
+  }),
+);
+
+function sortedChildren(workflow: PipelineWorkflow): PipelineStep[] {
+  return [...(workflow.children ?? [])].toSorted((a, b) => a.pid - b.pid);
+}
 
 const steps = useTemplateRef('steps');
 watch(selectedStepId, async (newSelectedStepId, oldSelectedStepId) => {


### PR DESCRIPTION
Rearrange the workflows based on the `depends_on` execution order with fallback to `started` timestamp when available.

Falls back to PID for workflows that have not started.

Not an ideal fix since workflows which are yet to start will still be in their PID order, but very useful to analyse executed workflows and completed pipelines.

PS: It is my first time contributing to this project and I am learning, so please let me know if I missed something.

closes #1480

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
