### PR TITLE
fix(oauth): prevent Cloudflare 524 during Bitbucket login behind tunnel

### DIFF
--- a/server/api/login.go
+++ b/server/api/login.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"context"
 	"encoding/base32"
 	"errors"
 	"fmt"
@@ -43,6 +44,25 @@ const (
 	perPage            = 50
 	maxPage            = 10000
 )
+
+// SyncRepoPermissionsFn runs repo permission sync after login.
+// Tests may replace this to run synchronously.
+var SyncRepoPermissionsFn = syncRepoPermissionsAsync
+
+func syncRepoPermissionsAsync(ctx context.Context, user *model.User, _store store.Store, _forge forge.Forge, forgeID int64) {
+	go func() {
+		if err := updateRepoPermissions(ctx, user, _store, _forge, forgeID); err != nil {
+			log.Error().Err(err).Msgf("background repo permission sync failed for user %s", user.Login)
+		}
+	}()
+}
+
+// SyncRepoPermissionsSyncForTesting runs permission sync synchronously in tests.
+func SyncRepoPermissionsSyncForTesting(ctx context.Context, user *model.User, _store store.Store, _forge forge.Forge, forgeID int64) {
+	if err := updateRepoPermissions(ctx, user, _store, _forge, forgeID); err != nil {
+		log.Error().Err(err).Msgf("background repo permission sync failed for user %s", user.Login)
+	}
+}
 
 func HandleAuth(c *gin.Context) {
 	// TODO: check if this is really needed
@@ -293,21 +313,16 @@ func HandleAuth(c *gin.Context) {
 		return
 	}
 
-	err = updateRepoPermissions(c, user, _store, _forge, forgeID)
-	if err != nil {
-		log.Error().Err(err).Msgf("cannot update repo permissions for user %s", user.Login)
-		c.Redirect(http.StatusSeeOther, server.Config.Server.RootPath+"/login?error=internal_error")
-		return
-	}
-
 	httputil.SetCookie(c.Writer, c.Request, "user_sess", tokenString)
+
+	SyncRepoPermissionsFn(context.WithoutCancel(c.Request.Context()), user, _store, _forge, forgeID)
 
 	c.Redirect(http.StatusSeeOther, server.Config.Server.RootPath+"/")
 }
 
-func updateRepoPermissions(c *gin.Context, user *model.User, _store store.Store, _forge forge.Forge, forgeID int64) error {
+func updateRepoPermissions(ctx context.Context, user *model.User, _store store.Store, _forge forge.Forge, forgeID int64) error {
 	repos, err := utils.Paginate(func(page int) ([]*model.Repo, error) {
-		return _forge.Repos(c, user, &model.ListOptions{
+		return _forge.Repos(ctx, user, &model.ListOptions{
 			Page:    page,
 			PerPage: perPage,
 		})

--- a/server/api/login_test.go
+++ b/server/api/login_test.go
@@ -42,6 +42,12 @@ import (
 func TestHandleAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	originalSync := api.SyncRepoPermissionsFn
+	api.SyncRepoPermissionsFn = api.SyncRepoPermissionsSyncForTesting
+	t.Cleanup(func() {
+		api.SyncRepoPermissionsFn = originalSync
+	})
+
 	user := &model.User{
 		ID:            1,
 		OrgID:         1,

--- a/server/api/stream.go
+++ b/server/api/stream.go
@@ -42,8 +42,15 @@ const (
 	maxQueuedBatchesPerClient int = 30
 
 	// Is the time till we send a ping to keep the connection alive.
-	idlePingTime = time.Second * 30
+	idlePingTime = time.Second * 15
+
+	ssePingFrame = ": ping\n\nevent: ping\ndata: {}\n\n"
 )
+
+func writeSSEPing(rw io.Writer, flusher http.Flusher) {
+	logWriteStringErr(io.WriteString(rw, ssePingFrame))
+	flusher.Flush()
+}
 
 // EventStreamSSE
 //
@@ -67,9 +74,7 @@ func EventStreamSSE(c *gin.Context) {
 		return
 	}
 
-	// ping the client
-	logWriteStringErr(io.WriteString(rw, ": ping\n\n"))
-	flusher.Flush()
+	writeSSEPing(rw, flusher)
 
 	log.Debug().Msg("user feed: connection opened")
 
@@ -107,15 +112,17 @@ func EventStreamSSE(c *gin.Context) {
 		cancel(err)
 	}()
 
+	pingTicker := time.NewTicker(idlePingTime)
+	defer pingTicker.Stop()
+
 	for {
 		select {
 		case <-requestCtx.Done():
 			return
 		case <-ctx.Done():
 			return
-		case <-time.After(idlePingTime):
-			logWriteStringErr(io.WriteString(rw, ": ping\n\n"))
-			flusher.Flush()
+		case <-pingTicker.C:
+			writeSSEPing(rw, flusher)
 		case buf, ok := <-eventChan:
 			if ok {
 				logWriteStringErr(io.WriteString(rw, "data: "))
@@ -151,8 +158,7 @@ func LogStreamSSE(c *gin.Context) {
 		return
 	}
 
-	logWriteStringErr(io.WriteString(rw, ": ping\n\n"))
-	flusher.Flush()
+	writeSSEPing(rw, flusher)
 
 	_store := store.FromContext(c)
 	repo := session.Repo(c)
@@ -249,6 +255,9 @@ func LogStreamSSE(c *gin.Context) {
 		log.Debug().Msgf("log stream: reconnect: last-event-id: %d", last)
 	}
 
+	pingTicker := time.NewTicker(idlePingTime)
+	defer pingTicker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done(): // Monitor if the "tail" context is canceled.
@@ -261,9 +270,8 @@ func LogStreamSSE(c *gin.Context) {
 		case <-requestCtx.Done(): // Monitor the request context for cancellation when the client has gone away.
 			log.Debug().Msg("log stream: closed, client has gone away")
 			return
-		case <-time.After(idlePingTime):
-			logWriteStringErr(io.WriteString(rw, ": ping\n\n"))
-			flusher.Flush()
+		case <-pingTicker.C:
+			writeSSEPing(rw, flusher)
 		case buf, ok := <-logChan:
 			if ok {
 				if id > last {

--- a/server/api/stream_test.go
+++ b/server/api/stream_test.go
@@ -19,12 +19,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/logging"
@@ -34,6 +37,75 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/scheduler"
 	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
 )
+
+func TestSSEPingFrame(t *testing.T) {
+	assert.Contains(t, ssePingFrame, ": ping")
+	assert.Contains(t, ssePingFrame, "event: ping")
+	assert.Contains(t, ssePingFrame, "data: {}")
+}
+
+func TestEventStreamSSEInitialPing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	broker := memory.New()
+	server.Config.Services.Scheduler = scheduler.NewScheduler(nil, broker)
+	t.Cleanup(func() { server.Config.Services.Scheduler = nil })
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	ctx, cancel := context.WithCancelCause(t.Context())
+	t.Cleanup(func() { cancel(nil) })
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/stream/events", nil)
+	require.NoError(t, err)
+	c.Request = req
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		EventStreamSSE(c)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel(nil)
+	<-done
+
+	body := w.Body.String()
+	assert.Contains(t, body, ": ping")
+	assert.Contains(t, body, "event: ping")
+}
+
+func TestEventStreamSSETickerPing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSE ticker ping test in short mode")
+	}
+
+	gin.SetMode(gin.TestMode)
+	broker := memory.New()
+	server.Config.Services.Scheduler = scheduler.NewScheduler(nil, broker)
+	t.Cleanup(func() { server.Config.Services.Scheduler = nil })
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	ctx, cancel := context.WithCancelCause(t.Context())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/stream/events", nil)
+	require.NoError(t, err)
+	c.Request = req
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		EventStreamSSE(c)
+	}()
+
+	time.Sleep(idlePingTime + time.Second)
+	cancel(nil)
+	<-done
+
+	body := w.Body.String()
+	assert.GreaterOrEqual(t, strings.Count(body, "event: ping"), 2)
+}
 
 func TestEventStreamSSEConcurrentDisconnect(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -5,6 +5,8 @@
   "repos": "Repos",
   "repositories": {
     "title": "Repositories",
+    "loading": "Loading repositories…",
+    "syncing": "Syncing repository permissions from your forge. This may take a moment if you have many repositories.",
     "all": {
       "title": "All repositories",
       "desc": "Repositories sorted by last pipeline creation"

--- a/web/src/compositions/useAuthentication.ts
+++ b/web/src/compositions/useAuthentication.ts
@@ -1,5 +1,7 @@
 import useConfig from '~/compositions/useConfig';
 
+import { closeEvents } from './useEvents';
+
 export default () =>
   ({
     isAuthenticated: !!useConfig().user,
@@ -7,6 +9,7 @@ export default () =>
     user: useConfig().user,
 
     authenticate(forgeId?: number) {
+      closeEvents();
       window.location.href = `${useConfig().rootPath}/authorize?${forgeId !== undefined ? `forge_id=${forgeId}` : ''}`;
     },
   }) as const;

--- a/web/src/compositions/useEvents.ts
+++ b/web/src/compositions/useEvents.ts
@@ -1,21 +1,51 @@
+import type { RouteLocationNormalizedLoaded, Router } from 'vue-router';
+
 import { usePipelineStore } from '~/store/pipelines';
 import { useRepoStore } from '~/store/repos';
 
 import useApiClient from './useApiClient';
+import useConfig from './useConfig';
 
 const apiClient = useApiClient();
 let initialized = false;
+let eventSource: EventSource | undefined;
 
-export default () => {
+function getAuthenticationMode(route: RouteLocationNormalizedLoaded) {
+  return route.matched.toReversed().find((record) => record.meta.authentication != null)?.meta
+    .authentication;
+}
+
+export function shouldSubscribeEvents(route: RouteLocationNormalizedLoaded): boolean {
+  const authenticationMode = getAuthenticationMode(route);
+
+  if (authenticationMode === 'guest-only') {
+    return false;
+  }
+
+  if (authenticationMode === 'required' && !useConfig().user) {
+    return false;
+  }
+
+  return true;
+}
+
+export function closeEvents() {
+  eventSource?.close();
+  eventSource = undefined;
+  initialized = false;
+}
+
+function subscribeEvents() {
   if (initialized) {
     return;
   }
+
   const repoStore = useRepoStore();
   const pipelineStore = usePipelineStore();
 
   initialized = true;
 
-  apiClient.on((data) => {
+  eventSource = apiClient.on((data) => {
     // contains repo update
     if (!data.repo) {
       return;
@@ -30,4 +60,21 @@ export default () => {
     const { pipeline } = data;
     pipelineStore.setPipeline(repo.id, pipeline);
   });
-};
+}
+
+export function syncEventsSubscription(route: RouteLocationNormalizedLoaded) {
+  if (shouldSubscribeEvents(route)) {
+    subscribeEvents();
+  } else {
+    closeEvents();
+  }
+}
+
+export function setupEvents(router: Router) {
+  syncEventsSubscription(router.currentRoute.value);
+  router.afterEach((to) => {
+    syncEventsSubscription(to);
+  });
+}
+
+export default subscribeEvents;

--- a/web/src/lib/utils/useEvents.test.ts
+++ b/web/src/lib/utils/useEvents.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { RouteLocationNormalizedLoaded, RouteRecordNormalized } from 'vue-router';
+
+import { shouldSubscribeEvents } from '~/compositions/useEvents';
+
+function makeRoute(authentication?: 'required' | 'guest-only'): RouteLocationNormalizedLoaded {
+  const matched: RouteRecordNormalized[] = authentication
+    ? [{ meta: { authentication }, path: '/', redirect: undefined, name: undefined, components: {} } as RouteRecordNormalized]
+    : [{ meta: {}, path: '/', redirect: undefined, name: undefined, components: {} } as RouteRecordNormalized];
+
+  return { matched } as RouteLocationNormalizedLoaded;
+}
+
+describe('shouldSubscribeEvents', () => {
+  it('skips SSE on the login page', () => {
+    expect(shouldSubscribeEvents(makeRoute('guest-only'))).toBe(false);
+  });
+
+  it('skips SSE on auth-required routes without a user', () => {
+    expect(shouldSubscribeEvents(makeRoute('required'))).toBe(false);
+  });
+
+  it('allows SSE on public routes without a user', () => {
+    expect(shouldSubscribeEvents(makeRoute())).toBe(true);
+  });
+
+  it('allows SSE on auth-required routes with a user', () => {
+    window.WOODPECKER_USER = {
+      id: 1,
+      forge_id: 1,
+      forge_remote_id: 'remote-1',
+      login: 'test',
+      email: 'test@example.com',
+      avatar_url: '',
+      admin: false,
+      admin_env: false,
+      active: true,
+      org_id: 1,
+    };
+    expect(shouldSubscribeEvents(makeRoute('required'))).toBe(true);
+    delete window.WOODPECKER_USER;
+  });
+});

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -6,7 +6,7 @@ import { createPinia } from 'pinia';
 import { createApp } from 'vue';
 
 import App from '~/App.vue';
-import useEvents from '~/compositions/useEvents';
+import { setupEvents } from '~/compositions/useEvents';
 import { i18n } from '~/compositions/useI18n';
 import { notifications } from '~/compositions/useNotifications';
 import router from '~/router';
@@ -21,4 +21,6 @@ app.use(i18n);
 app.use(createPinia());
 app.mount('#app');
 
-useEvents();
+void router.isReady().then(() => {
+  setupEvents(router);
+});

--- a/web/src/store/repos.ts
+++ b/web/src/store/repos.ts
@@ -15,6 +15,8 @@ export const useRepoStore = defineStore('repos', () => {
 
   const repos: Map<number, Repo> = reactive(new Map());
   const ownedRepoIds = ref<number[]>([]);
+  const isLoadingRepos = ref(false);
+  const isSyncingRepos = ref(false);
 
   const ownedRepos = computed(() =>
     [...repos.entries()].filter(([repoId]) => ownedRepoIds.value.includes(repoId)).map(([, repo]) => repo),
@@ -38,6 +40,15 @@ export const useRepoStore = defineStore('repos', () => {
   }
 
   async function loadRepos() {
+    isLoadingRepos.value = true;
+    try {
+      return await fetchRepos();
+    } finally {
+      isLoadingRepos.value = false;
+    }
+  }
+
+  async function fetchRepos() {
     const _ownedRepos = await apiClient.getRepoList();
 
     _ownedRepos.forEach((repo) => {
@@ -65,15 +76,45 @@ export const useRepoStore = defineStore('repos', () => {
         setRepo(repo);
       });
     }
+
+    return _ownedRepos;
+  }
+
+  async function loadReposWithBackgroundSync(maxAttempts = 40, pollIntervalMs = 3000) {
+    isSyncingRepos.value = false;
+
+    const initialRepos = await loadRepos();
+    if (initialRepos.length > 0) {
+      return;
+    }
+
+    isSyncingRepos.value = true;
+    try {
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, pollIntervalMs);
+        });
+
+        const syncedRepos = await fetchRepos();
+        if (syncedRepos.length > 0) {
+          return;
+        }
+      }
+    } finally {
+      isSyncingRepos.value = false;
+    }
   }
 
   return {
     repos,
     ownedRepos,
     ownedRepoIds,
+    isLoadingRepos,
+    isSyncingRepos,
     getRepo,
     setRepo,
     loadRepo,
     loadRepos,
+    loadReposWithBackgroundSync,
   };
 });

--- a/web/src/views/Repos.vue
+++ b/web/src/views/Repos.vue
@@ -8,7 +8,17 @@
       <Button :to="{ name: 'repo-add' }" start-icon="plus" :text="$t('repo.add')" />
     </template>
 
-    <Transition name="fade" mode="out-in">
+    <div
+      v-if="isLoadingRepos || isSyncingRepos"
+      class="text-wp-text-alt-100 flex flex-col items-center justify-center gap-4 py-16"
+    >
+      <Icon name="spinner" class="h-8 w-8 animate-spin" />
+      <p class="max-w-lg text-center">
+        {{ isSyncingRepos ? $t('repositories.syncing') : $t('repositories.loading') }}
+      </p>
+    </div>
+
+    <Transition v-else name="fade" mode="out-in">
       <div v-if="search === '' && repos.length > 0" class="grid gap-8">
         <div v-if="reposLastAccess.length > 0 && repos.length > 4" class="flex flex-col gap-4">
           <div>
@@ -41,10 +51,12 @@
 </template>
 
 <script lang="ts" setup>
+import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import Button from '~/components/atomic/Button.vue';
+import Icon from '~/components/atomic/Icon.vue';
 import Scaffold from '~/components/layout/scaffold/Scaffold.vue';
 import RepoItem from '~/components/repo/RepoItem.vue';
 import useRepos from '~/compositions/useRepos';
@@ -53,6 +65,7 @@ import { useWPTitle } from '~/compositions/useWPTitle';
 import { useRepoStore } from '~/store/repos';
 
 const repoStore = useRepoStore();
+const { isLoadingRepos, isSyncingRepos } = storeToRefs(repoStore);
 
 const { sortReposByLastAccess, sortReposByLastActivity, repoWithLastPipeline } = useRepos();
 const repos = computed(() => Object.values(repoStore.ownedRepos).map((r) => repoWithLastPipeline(r)));
@@ -64,7 +77,7 @@ const { searchedRepos } = useRepoSearch(repos, search);
 const reposLastActivity = computed(() => sortReposByLastActivity(searchedRepos.value || []));
 
 onMounted(async () => {
-  await repoStore.loadRepos();
+  await repoStore.loadReposWithBackgroundSync();
 });
 
 const { t } = useI18n();


### PR DESCRIPTION
## Summary
  Fixes OAuth login failures (Cloudflare Error 524) when Woodpecker is deployed behind Cloudflare Tunnel with Bitbucket Cloud as the forge.
  The login page opened an idle SSE connection to `/api/stream/events` on load. During the OAuth round-trip, the reverse proxy closed that connection after ~30s. In practice this correlated with the
   browser never completing the `/authorize?code=...` callback, and login failed with `invalid_grant` / expired state token errors.
  This PR addresses three contributing factors:
  - **Frontend:** Skip SSE on the login page and other routes where it is not needed; close SSE explicitly before OAuth redirect; keep SSE for anonymous public repo views.
  - **Server:** Shorten SSE keepalive interval from 30s to 15s and send both comment and named `event: ping` data frames so proxies reset idle timers reliably.
  - **Server:** Defer post-login repo permission sync to a background goroutine so the OAuth callback can respond quickly (important for users with many Bitbucket repos).
  ## Root cause
  1. Browser opens SSE at `/api/stream/events` on page load
  2. User clicks login → redirect to Bitbucket
  3. Cloudflare Tunnel closes the idle SSE stream after ~30s
  4. OAuth callback from Bitbucket does not complete successfully
  5. Browser shows Cloudflare Error 524
  Existing SSE keepalives were sent every 30s, which matched the observed proxy timeout window.
  ## Changes
  ### Web UI
  - Route-aware SSE subscription via `shouldSubscribeEvents()` / `setupEvents(router)`
  - No SSE on `guest-only` routes (login)
  - No SSE on `authentication: required` routes without a logged-in user
  - SSE still enabled for anonymous public repo pages
  - `closeEvents()` called before OAuth redirect
  ### Server
  - SSE ping interval: 30s → 15s, using `time.Ticker`
  - Heartbeat frame: `: ping` comment + `event: ping\ndata: {}`
  - Applied to both event and log SSE streams
  - Login: set session cookie and redirect first; sync repo permissions in background
  ## Test plan
  - [ ] Open `/login` → confirm no `/api/stream/events` request in browser Network tab before clicking login
  - [ ] Complete Bitbucket OAuth behind Cloudflare Tunnel → login succeeds, no Error 524
  - [ ] After login, SSE opens and pipeline/repo updates still stream live
  - [ ] View a public repo while logged out → live updates still work
  - [ ] Login with many Bitbucket repos → redirect to home is fast; repos appear after background permission sync
  ### Automated tests
  ```bash
  go test ./server/api/... -short -count=1
  go test ./server/api/... -count=1
  pnpm --dir web typecheck
  pnpm --dir web test --run
  ```
  ## Environment where reproduced
  | Field | Value |
  |-------|--------|
  | Woodpecker version | 3.15.0 |
  | Forge | Bitbucket Cloud |
  | Deployment | Docker Compose |
  | Reverse proxy | Cloudflare Tunnel (free tier) |
  | Bitbucket repos | 100+ |


<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
