### PR TITLE
fix(server): embed IANA timezone database for cron schedules

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,6 +20,11 @@ import (
 	"context"
 	"os"
 
+	// Embed the IANA timezone database so that cron schedule
+	// timezones work in minimal containers (Alpine, scratch)
+	// that lack system timezone data.
+	_ "time/tzdata"
+
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/rs/zerolog/log"
 

--- a/cmd/server/tzdata_test.go
+++ b/cmd/server/tzdata_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTimezoneDatabaseAvailable verifies that the embedded IANA timezone
+// database is available. This ensures cron schedules work in minimal
+// containers (Alpine, scratch) that lack system timezone data.
+// Regression test for https://github.com/woodpecker-ci/woodpecker/issues/6688
+func TestTimezoneDatabaseAvailable(t *testing.T) {
+	timezones := []string{
+		"Europe/Berlin",
+		"America/New_York",
+		"Asia/Tokyo",
+		"Australia/Sydney",
+		"UTC",
+	}
+
+	for _, tz := range timezones {
+		loc, err := time.LoadLocation(tz)
+		if err != nil {
+			t.Errorf("time.LoadLocation(%q) failed: %v", tz, err)
+			continue
+		}
+		if loc == nil {
+			t.Errorf("time.LoadLocation(%q) returned nil location", tz)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Cron schedules fail to accept any non-UTC timezone in minimal containers (Alpine, scratch) that lack system timezone data.

```
Error inserting cron. schedule could not parsed: unknown time zone Europe/Berlin
```

This affects both `TZ` and `WOODPECKER_TIMEZONE` environment variables.

Fixes #6688

## Root Cause

`time.LoadLocation()` relies on the IANA timezone database being available on the system. Alpine Linux and scratch containers don't include this by default.

## Fix

Import `time/tzdata` to embed the IANA timezone database into the server binary. This is the standard Go approach for ensuring timezone support in minimal environments.

### Changes
- `cmd/server/main.go`: Add `import _ "time/tzdata"`
- `cmd/server/tzdata_test.go`: Regression test verifying timezone loading works

### Trade-offs
- Binary size increases by ~450KB (the IANA timezone database)
- This is the same approach recommended by the [Go documentation](https://pkg.go.dev/time/tzdata)

## Testing

Run the regression test to verify the timezone database is embedded:

```
go test ./cmd/server/ -run TestTimezoneDatabaseAvailable -v
```
