### PR TITLE
Add Podman plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -329,6 +329,11 @@
       "name": "Laravel Forge",
       "docs": "https://raw.githubusercontent.com/njaaazi/laravel-forge-woodpecker/main/docs.md",
       "verified": false
+    },
+    {
+      "name": "Podman",
+      "docs": "https://codeberg.org/head1328/woodpecker-ci-plugin-podman/src/branch/main/docs.md",
+      "verified": false
     }
   ]
 }

--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -332,7 +332,7 @@
     },
     {
       "name": "Podman",
-      "docs": "https://codeberg.org/head1328/woodpecker-ci-plugin-podman/src/branch/main/docs.md",
+      "docs": "https://codeberg.org/head1328/woodpecker-ci-plugin-podman/raw/branch/main/docs.md",
       "verified": false
     }
   ]


### PR DESCRIPTION
woodpecker-ci-plugin-podman wraps podman build, podman push and podman manifest push --all (multi-arch manifest lists) and exposes every podman build / podman push flag 1:1 as plugin settings. It only needs CLONE_NEWUSER, which Codeberg's public agent pool grants through its default seccomp profile, so the plugin runs out of the box on ci.codeberg.org without requiring a self-hosted or privileged runner.

On a private self-hosted runner (e.g. the chilly-willy-agent FCOS+Podman reference setup) the plugin unlocks the rest of the Podman feature surface: overlay storage via fuse-overlayfs for fast layer-heavy builds, native cross-arch RUN for linux/amd64 plus linux/arm64 manifest lists via host-registered qemu binfmt handlers (no BUILDPLATFORM cross-stage workaround required), and trusted-image force-escalation through wally-walrus-agent-guard.