### PR TITLE
Remove twine plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -206,11 +206,6 @@
       "verified": true
     },
     {
-      "name": "Twine",
-      "docs": "https://gitea.elara.ws/music-kraken/plugin-twine/raw/branch/master/docs.md",
-      "verified": false
-    },
-    {
       "name": "Gitea Package",
       "docs": "https://codeberg.org/woodpecker-community/gitea-package/raw/branch/main/docs.md",
       "verified": false


### PR DESCRIPTION
seems this does not exist anymore - https://git.elara.ws/music-kraken/plugin-twine/ gives a 404