### PR TITLE
Surface `.env` load errors

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -80,6 +80,7 @@
     "gocritic",
     "GODEBUG",
     "godoc",
+    "godotenv",
     "Gogs",
     "golangci",
     "gomod",

--- a/cmd/agent/core/run.go
+++ b/cmd/agent/core/run.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"slices"
 
-	// Load config from .env file.
-	_ "github.com/joho/godotenv/autoload"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v3"
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -37,7 +37,7 @@ var backends = []backend_types.Backend{
 
 func main() {
 	if err := godotenv.Load(); err != nil {
-		log.Error().Err(err)
+		fmt.Fprintf(os.Stderr, "Error could not load .env: %s", err)
 		os.Exit(1)
 	}
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"context"
+	"os"
 
+	"github.com/joho/godotenv"
 	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v3/cmd/agent/core"
@@ -34,6 +36,11 @@ var backends = []backend_types.Backend{
 }
 
 func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Error().Err(err)
+		os.Exit(1)
+	}
+
 	ctx := utils.WithContextSigtermCallback(context.Background(), func() {
 		log.Info().Msg("termination signal is received, shutting down agent")
 	})

--- a/cmd/agent/man.go
+++ b/cmd/agent/man.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/joho/godotenv"
 	docs "github.com/urfave/cli-docs/v3"

--- a/cmd/agent/man.go
+++ b/cmd/agent/man.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/joho/godotenv"
 	docs "github.com/urfave/cli-docs/v3"
 
 	"go.woodpecker-ci.org/woodpecker/v3/cmd/agent/core"
@@ -35,6 +36,11 @@ var backends = []backend_types.Backend{
 }
 
 func main() {
+	if err := godotenv.Load(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error could not load .env: %s", err)
+		os.Exit(1)
+	}
+
 	app := core.GenApp(backends)
 	md, err := docs.ToMan(app)
 	if err != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -26,7 +26,7 @@ import (
 
 func main() {
 	if err := godotenv.Load(); err != nil {
-		log.Error().Err(err)
+		fmt.Fprintf(os.Stderr, "Error could not load .env: %s", err)
 		os.Exit(1)
 	}
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -18,13 +18,18 @@ import (
 	"context"
 	"os"
 
-	_ "github.com/joho/godotenv/autoload"
+	"github.com/joho/godotenv"
 	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v3/shared/utils"
 )
 
 func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Error().Err(err)
+		os.Exit(1)
+	}
+
 	ctx := utils.WithContextSigtermCallback(context.Background(), func() {
 		log.Info().Msg("termination signal is received, terminate cli")
 	})

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,7 +29,7 @@ import (
 
 func main() {
 	if err := godotenv.Load(); err != nil {
-		log.Error().Err(err)
+		fmt.Fprintf(os.Stderr, "Error could not load .env: %s", err)
 		os.Exit(1)
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"os"
 
-	_ "github.com/joho/godotenv/autoload"
+	"github.com/joho/godotenv"
 	"github.com/rs/zerolog/log"
 
 	_ "go.woodpecker-ci.org/woodpecker/v3/cmd/server/openapi"
@@ -28,6 +28,11 @@ import (
 )
 
 func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Error().Err(err)
+		os.Exit(1)
+	}
+
 	ctx := utils.WithContextSigtermCallback(context.Background(), func() {
 		log.Info().Msg("termination signal is received, shutting down server")
 	})

--- a/cmd/server/man.go
+++ b/cmd/server/man.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/rs/zerolog/log"
 	docs "github.com/urfave/cli-docs/v3"
 
 	_ "go.woodpecker-ci.org/woodpecker/v3/cmd/server/openapi"

--- a/cmd/server/man.go
+++ b/cmd/server/man.go
@@ -29,7 +29,7 @@ import (
 
 func main() {
 	if err := godotenv.Load(); err != nil {
-		log.Error().Err(err)
+		fmt.Fprintf(os.Stderr, "Error could not load .env: %s", err)
 		os.Exit(1)
 	}
 

--- a/cmd/server/man.go
+++ b/cmd/server/man.go
@@ -18,14 +18,21 @@ package main
 
 import (
 	"fmt"
+	"os"
 
-	_ "github.com/joho/godotenv/autoload"
+	"github.com/joho/godotenv"
+	"github.com/rs/zerolog/log"
 	docs "github.com/urfave/cli-docs/v3"
 
 	_ "go.woodpecker-ci.org/woodpecker/v3/cmd/server/openapi"
 )
 
 func main() {
+	if err := godotenv.Load(); err != nil {
+		log.Error().Err(err)
+		os.Exit(1)
+	}
+
 	app := genApp()
 	md, err := docs.ToMan(app)
 	if err != nil {


### PR DESCRIPTION
currently we just drop errors loading from loading `.env`, this is hard to debug and can cause confusion.

## Before
<img width="1186" height="89" alt="image" src="https://github.com/user-attachments/assets/c17982d9-5a9c-4ec8-9740-bcdd7cbbc22c" />

## Now
<img width="2560" height="204" alt="image" src="https://github.com/user-attachments/assets/d288d7a5-280c-447f-a681-529a61ee641f" />
