### PR TITLE
Make cli exec auto detect single workflow test in multi workflow setup

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -26,6 +26,7 @@ import (
 
 	"codeberg.org/6543/xyaml/v2"
 	"github.com/oklog/ulid/v2"
+	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v3"
 	"go.uber.org/multierr"
 
@@ -105,11 +106,14 @@ func repoRootFromFile(file string) string {
 
 	// first we check if file lives inside multi workflow setup
 	if filepath.Base(root) == ".woodpecker" {
+		log.Info().Msg("auto detected workflow in multi workflow setup, parrent directory is used as workspace")
 		root = filepath.Dir(root)
 	}
 
 	// and make sure have the absolute path
 	root, _ = filepath.Abs(root)
+
+	log.Debug().Msgf("auto selected workspace folder at %q", root)
 	return root
 }
 

--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -106,7 +106,7 @@ func repoRootFromFile(file string) string {
 
 	// first we check if file lives inside multi workflow setup
 	if filepath.Base(root) == ".woodpecker" {
-		log.Info().Msg("auto detected workflow in multi workflow setup, parrent directory is used as workspace")
+		log.Info().Msg("auto detected workflow in multi workflow setup, parent directory is used as workspace")
 		root = filepath.Dir(root)
 	}
 

--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -100,12 +100,25 @@ func execDir(ctx context.Context, c *cli.Command, dir string) error {
 	return runExec(ctx, c, yamls, repoPath)
 }
 
+func repoRootFromFile(file string) string {
+	root := filepath.Dir(file)
+
+	// first we check if file lives inside multi workflow setup
+	if filepath.Base(root) == ".woodpecker" {
+		root = filepath.Dir(root)
+	}
+
+	// and make sure have the absolute path
+	root, _ = filepath.Abs(root)
+	return root
+}
+
 func execFile(ctx context.Context, c *cli.Command, file string) error {
 	repoPath := c.String("repo-path")
 	if repoPath != "" {
 		repoPath, _ = filepath.Abs(repoPath)
 	} else {
-		repoPath, _ = filepath.Abs(filepath.Dir(file))
+		repoPath = repoRootFromFile(file)
 	}
 	if runtime.GOOS == "windows" && c.String("backend-engine") != "local" {
 		repoPath = convertPathForWindows(repoPath)

--- a/cli/exec/exec_test.go
+++ b/cli/exec/exec_test.go
@@ -100,3 +100,26 @@ func clearEnv(t *testing.T) {
 	})
 	os.Clearenv()
 }
+
+func TestRepoRootFromFile(t *testing.T) {
+	tmp := t.TempDir()
+
+	// pipeline file inside a `.woodpecker` config folder => repo root is the parent
+	wpDir := filepath.Join(tmp, "myrepo", ".woodpecker")
+	require.NoError(t, os.MkdirAll(wpDir, 0o755))
+	wpFile := filepath.Join(wpDir, "securityscan.yaml")
+	require.NoError(t, os.WriteFile(wpFile, []byte("steps: {}\n"), 0o644))
+	assert.Equal(t, filepath.Join(tmp, "myrepo"), repoRootFromFile(wpFile))
+
+	// legacy single config file at repo root => repo root is the file's directory
+	rootDir := filepath.Join(tmp, "legacy")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	rootFile := filepath.Join(rootDir, ".woodpecker.yml")
+	require.NoError(t, os.WriteFile(rootFile, []byte("steps: {}\n"), 0o644))
+	assert.Equal(t, rootDir, repoRootFromFile(rootFile))
+
+	// arbitrary file not in a `.woodpecker` folder => its own directory
+	otherFile := filepath.Join(rootDir, "ci.yaml")
+	require.NoError(t, os.WriteFile(otherFile, []byte("steps: {}\n"), 0o644))
+	assert.Equal(t, rootDir, repoRootFromFile(otherFile))
+}


### PR DESCRIPTION
now you can do:
```
CI_PIPELINE_EVENT=push ./dist/woodpecker-cli exec .woodpecker/securityscan.yaml
```

before you had to add `--repo-path .`