### PR TITLE
cli exec: have uniq prefix for each workflow

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -152,14 +152,13 @@ func runExec(ctx context.Context, c *cli.Command, yamls []*builder.YamlFile, rep
 
 	privilegedPlugins := c.StringSlice("plugins-privileged")
 
-	// emulate server prefix for volume/network naming
+	// prefix for the local-execution workspace volume name
 	prefix := "wp_" + ulid.Make().String()
 
 	// build compiler options — mirrors server behavior
 	compilerOpts := []compiler.Option{
 		compiler.WithEscalated(privilegedPlugins...),
 		compiler.WithNetworks(c.StringSlice("network")...),
-		compiler.WithPrefix(prefix),
 		compiler.WithProxy(compiler.ProxyOptions{
 			NoProxy:    c.String("backend-no-proxy"),
 			HTTPProxy:  c.String("backend-http-proxy"),


### PR DESCRIPTION
preparation to have cli exec run workflows in parallel

fix taken from https://github.com/woodpecker-ci/woodpecker/pull/6490 (https://github.com/woodpecker-ci/woodpecker/pull/6490/changes/6c88ea3a5f2dca37849589140e20a33771982c3e)