### PR TITLE
Automatically retry pipelines that fail due to infrastructure events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,9 @@ test-lib: ## Test lib code
 test-e2e: ## Test by running yaml config and compare expected result
 	go test -race -cover -coverpkg=./... -coverprofile e2e-coverage.out -timeout 60s -tags 'test $(TAGS)' ./e2e/...
 
+test-kind: ## Test the Kubernetes backend against a live cluster (needs: kind create cluster --name wp-e2e)
+	go test -timeout 200s -tags kind ./pipeline/backend/kubernetes/...
+
 .PHONY: test
 test: test-agent test-server test-server-datastore test-cli test-lib test-e2e ## Run all tests
 

--- a/agent/rpc/client_grpc.go
+++ b/agent/rpc/client_grpc.go
@@ -316,14 +316,15 @@ func (c *client) Update(ctx context.Context, workflowID string, state rpc.StepSt
 	req := &proto.UpdateRequest{
 		Id: workflowID,
 		State: &proto.StepState{
-			StepUuid: state.StepUUID,
-			Started:  state.Started,
-			Finished: state.Finished,
-			Exited:   state.Exited,
-			ExitCode: int32(state.ExitCode),
-			Error:    state.Error,
-			Canceled: state.Canceled,
-			Skipped:  state.Skipped,
+			StepUuid:     state.StepUUID,
+			Started:      state.Started,
+			Finished:     state.Finished,
+			Exited:       state.Exited,
+			ExitCode:     int32(state.ExitCode),
+			Error:        state.Error,
+			Canceled:     state.Canceled,
+			Skipped:      state.Skipped,
+			InfraFailure: state.InfraFailure,
 		},
 	}
 

--- a/agent/tracer.go
+++ b/agent/tracer.go
@@ -38,12 +38,13 @@ func (r *Runner) createTracer(ctxMeta context.Context, logger zerolog.Logger, wo
 			Logger()
 
 		stepState := rpc.StepState{
-			StepUUID: state.CurrStep.UUID,
-			Exited:   state.CurrStepState.Exited,
-			ExitCode: state.CurrStepState.ExitCode,
-			Started:  state.CurrStepState.Started,
-			Canceled: errors.Is(state.CurrStepState.Error, pipeline_errors.ErrCancel),
-			Skipped:  state.CurrStepState.Skipped,
+			StepUUID:     state.CurrStep.UUID,
+			Exited:       state.CurrStepState.Exited,
+			ExitCode:     state.CurrStepState.ExitCode,
+			Started:      state.CurrStepState.Started,
+			Canceled:     errors.Is(state.CurrStepState.Error, pipeline_errors.ErrCancel),
+			Skipped:      state.CurrStepState.Skipped,
+			InfraFailure: state.CurrStepState.InfraFailure,
 		}
 		if state.CurrStepState.Error != nil {
 			stepState.Error = state.CurrStepState.Error.Error()

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -203,6 +203,12 @@ var flags = append([]cli.Flag{
 		Usage:   "The maximum time in minutes you can set in the repo settings before a pipeline gets killed",
 		Value:   120,
 	},
+	&cli.Int64Flag{
+		Sources: cli.EnvVars("WOODPECKER_INFRA_RETRY_MAX_ATTEMPTS"),
+		Name:    "infra-retry-max-attempts",
+		Usage:   "Maximum times a pipeline is automatically restarted when it fails solely due to an infrastructure event (e.g. spot-node preemption or pod eviction). 0 disables automatic infra retries",
+		Value:   0,
+	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_DEFAULT_WORKFLOW_LABELS"),
 		Name:    "default-workflow-labels",

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -5050,6 +5050,10 @@ const docTemplate = `{
                 "id": {
                     "type": "integer"
                 },
+                "infra_retry_count": {
+                    "description": "InfraRetryCount records how many times this pipeline was automatically\nrestarted because of an infrastructure failure (node preemption,\neviction, shutdown). It bounds the budget set by\nWOODPECKER_INFRA_RETRY_MAX_ATTEMPTS and is carried forward on each\nautomatic retry; see Step.InfraFailure for the per-step signal.",
+                    "type": "integer"
+                },
                 "is_prerelease": {
                     "type": "boolean"
                 },
@@ -5665,6 +5669,10 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "integer"
+                },
+                "infra_failure": {
+                    "description": "InfraFailure is set when the backend reported that this step was\nterminated by an infrastructure event (node preemption, eviction,\ngraceful node shutdown) rather than the workload failing. It lets\nthe server distinguish retryable infra failures from genuine ones.",
+                    "type": "boolean"
                 },
                 "name": {
                     "type": "string"

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -211,6 +211,7 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 	server.Config.Pipeline.DefaultCancelPreviousPipelineEvents = events
 	server.Config.Pipeline.DefaultTimeout = c.Int64("default-pipeline-timeout")
 	server.Config.Pipeline.MaxTimeout = c.Int64("max-pipeline-timeout")
+	server.Config.Pipeline.InfraRetryMaxAttempts = c.Int64("infra-retry-max-attempts")
 
 	_labels := c.StringSlice("default-workflow-labels")
 	labels := make(map[string]string, len(_labels))

--- a/docs/docs/30-administration/10-configuration/10-server.md
+++ b/docs/docs/30-administration/10-configuration/10-server.md
@@ -780,6 +780,13 @@ The default time for a repo in minutes before a pipeline gets killed
 
 The maximum time in minutes you can set in the repo settings before a pipeline gets killed
 
+### INFRA_RETRY_MAX_ATTEMPTS
+
+- Name: `WOODPECKER_INFRA_RETRY_MAX_ATTEMPTS`
+- Default: 0
+
+Maximum number of times a pipeline is automatically restarted when it fails solely because of an infrastructure event (for example a spot-node preemption or pod eviction) rather than the workload itself failing. The Kubernetes backend flags such steps using the pod's `DisruptionTarget` condition. A pipeline is only retried when every failing step is an infrastructure failure; a genuine step failure mixed in disables the retry. `0` (the default) disables automatic infra retries.
+
 ---
 
 ### SESSION_EXPIRES

--- a/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
+++ b/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
@@ -415,6 +415,20 @@ In order to enable this configuration you need to set the appropriate environmen
 
 ## Tips and tricks
 
+### Preemptible / spot nodes
+
+When step pods run on preemptible or spot nodes, a node can be reclaimed
+mid-step. Kubernetes marks such a pod with the `DisruptionTarget` condition
+before taking it down. The backend detects this and reports the step as an
+infrastructure failure rather than a normal failure, so the server can
+automatically retry the pipeline instead of surfacing it as a real failure.
+
+This is opt-in and disabled by default; set
+[`WOODPECKER_INFRA_RETRY_MAX_ATTEMPTS`](../10-server.md#infra_retry_max_attempts)
+on the server to the maximum number of automatic retries. A pipeline is retried
+only when every failing step is an infrastructure failure — a genuine failure
+mixed in disables the retry.
+
 ### CRI-O
 
 CRI-O users currently need to configure the workspace for all workflows in order for them to run correctly. Add the following at the beginning of your configuration:

--- a/docs/docs/92-development/09-testing.md
+++ b/docs/docs/92-development/09-testing.md
@@ -9,6 +9,17 @@ with [`"github.com/stretchr/testify/assert"`](https://pkg.go.dev/github.com/stre
 
 ### Integration Tests
 
+Some backend behaviour can only be verified against a real cluster. The
+Kubernetes backend has a `kind`-tagged test that creates a real pod, evicts it
+through the Eviction API and asserts the resulting infrastructure-failure
+detection. It is excluded from the normal test run (build tag `kind`) and needs
+a local cluster:
+
+```bash
+kind create cluster --name wp-e2e
+make test-kind
+```
+
 ### Dummy backend
 
 There is a special backend called **`dummy`** which does not execute any commands, but emulates how a typical backend should behave.
@@ -81,5 +92,6 @@ There are also environment variables to alter step behavior:
 - `STEP_TAIL_FAIL: true` if set will error when we simulate to read from stdout for logs
 - `STEP_EXIT_CODE: 2` if set will be used as exit code, default is 0
 - `STEP_OOM_KILLED: true` simulates a step being killed by memory constrains
+- `STEP_INFRA_FAILURE: true` simulates a step terminated by an infrastructure event (node preemption / eviction) rather than the workload itself failing
 
 You can let the setup of a whole workflow fail by setting it's UUID to `WorkflowSetupShouldFail`.

--- a/e2e/scenarios/infra_retry_test.go
+++ b/e2e/scenarios/infra_retry_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package scenarios
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/e2e/setup"
+	"go.woodpecker-ci.org/woodpecker/v3/server"
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/pipeline"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+)
+
+// infraFailYAML has a single step that the dummy backend reports as an
+// infrastructure failure (the equivalent of a spot-node preemption: the step
+// "failed" but InfraFailure is set, so the server should auto-restart it).
+var infraFailYAML = []byte(`
+steps:
+  - name: preempted
+    image: dummy
+    commands:
+      - echo boom
+    environment:
+      STEP_INFRA_FAILURE: "true"
+      STEP_EXIT_CODE: "1"
+`)
+
+// genuineFailYAML has a single step that fails for a real reason (exit 1, no
+// infra flag). The server must NOT auto-restart it.
+var genuineFailYAML = []byte(`
+steps:
+  - name: broken
+    image: dummy
+    commands:
+      - echo nope
+    environment:
+      STEP_EXIT_CODE: "1"
+`)
+
+// withInfraRetryMax sets the global infra-retry budget for the duration of a
+// test and restores it afterwards. server.Config is process-global, so these
+// tests must not run with t.Parallel().
+func withInfraRetryMax(t *testing.T, n int64) {
+	t.Helper()
+	old := server.Config.Pipeline.InfraRetryMaxAttempts
+	server.Config.Pipeline.InfraRetryMaxAttempts = n
+	t.Cleanup(func() { server.Config.Pipeline.InfraRetryMaxAttempts = old })
+}
+
+// pipelinesFor returns all pipelines for the repo, oldest first.
+func pipelinesFor(t *testing.T, s store.Store, repo *model.Repo) []*model.Pipeline {
+	t.Helper()
+	list, err := s.GetPipelineList(repo, &model.ListOptions{Page: 1, PerPage: 100}, nil)
+	require.NoError(t, err)
+	sort.Slice(list, func(i, j int) bool { return list[i].Number < list[j].Number })
+	return list
+}
+
+// waitForStablePipelineChain waits until the repo has at least one pipeline,
+// every pipeline is terminal, and the count holds steady across a grace window
+// (so any pending auto-retry has had time to materialize). It returns the
+// chain oldest-first.
+func waitForStablePipelineChain(t *testing.T, s store.Store, repo *model.Repo) []*model.Pipeline {
+	t.Helper()
+
+	deadline := time.Now().Add(60 * time.Second)
+	var stableSince time.Time
+	for time.Now().Before(deadline) {
+		list := pipelinesFor(t, s, repo)
+		allTerminal := len(list) > 0
+		for _, p := range list {
+			switch p.Status {
+			case model.StatusSuccess, model.StatusFailure, model.StatusKilled,
+				model.StatusError, model.StatusDeclined, model.StatusBlocked:
+			default:
+				allTerminal = false
+			}
+		}
+		if allTerminal {
+			if stableSince.IsZero() {
+				stableSince = time.Now()
+			}
+			// Hold steady for a grace window: long enough that a queued
+			// retry would have been created and started.
+			if time.Since(stableSince) > 1500*time.Millisecond {
+				return list
+			}
+		} else {
+			stableSince = time.Time{}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("pipeline chain never stabilized for repo %s", repo.FullName)
+	return nil
+}
+
+func triggerPush(t *testing.T, env *setup.ServerEnv) *model.Pipeline {
+	t.Helper()
+	draft := &model.Pipeline{
+		Event:  model.EventPush,
+		Branch: "main",
+		Commit: "deadbeef",
+		Ref:    "refs/heads/main",
+		Author: env.Fixtures.Owner.Login,
+		Sender: env.Fixtures.Owner.Login,
+	}
+	created, err := pipeline.Create(t.Context(), env.Store, env.Fixtures.Repo, draft)
+	require.NoError(t, err, "create pipeline")
+	require.NotNil(t, created)
+	return created
+}
+
+// TestInfraFailureTriggersAutoRetry proves the end-to-end path: a step the
+// backend flags as an infrastructure failure flows agent -> server -> an
+// automatic restart, bounded by the budget. With a budget of 1 we expect
+// exactly one retry: the original pipeline plus one descendant.
+func TestInfraFailureTriggersAutoRetry(t *testing.T) {
+	withInfraRetryMax(t, 1)
+
+	env := setup.StartServer(t.Context(), t, []*forge_types.FileMeta{
+		{Name: ".woodpecker.yaml", Data: infraFailYAML},
+	})
+	agent := setup.StartAgent(t, env.GRPCAddr)
+	setup.WaitForAgentRegistered(t, env.Store, agent)
+
+	original := triggerPush(t, env)
+	setup.WaitForPipelineStatus(t, env.Store, original.ID, model.StatusFailure, 20*time.Second)
+
+	chain := waitForStablePipelineChain(t, env.Store, env.Fixtures.Repo)
+	require.Len(t, chain, 2, "expected the original pipeline plus exactly one infra retry")
+
+	orig, retry := chain[0], chain[1]
+	assert.Equal(t, model.StatusFailure, orig.Status)
+	assert.Equal(t, int64(0), orig.InfraRetryCount, "original pipeline has no prior infra retries")
+
+	assert.Equal(t, model.StatusFailure, retry.Status, "the retry re-runs the same infra-failing config")
+	assert.Equal(t, orig.Number, retry.Parent, "retry should be parented to the original")
+	assert.Equal(t, int64(1), retry.InfraRetryCount, "retry records one infra attempt")
+	assert.Greater(t, retry.RerunCount, int64(0), "restart bumps RerunCount too")
+}
+
+// TestGenuineFailureNoAutoRetry proves a real (non-infra) failure is never
+// auto-restarted, even with budget available.
+func TestGenuineFailureNoAutoRetry(t *testing.T) {
+	withInfraRetryMax(t, 2)
+
+	env := setup.StartServer(t.Context(), t, []*forge_types.FileMeta{
+		{Name: ".woodpecker.yaml", Data: genuineFailYAML},
+	})
+	agent := setup.StartAgent(t, env.GRPCAddr)
+	setup.WaitForAgentRegistered(t, env.Store, agent)
+
+	original := triggerPush(t, env)
+	setup.WaitForPipelineStatus(t, env.Store, original.ID, model.StatusFailure, 20*time.Second)
+
+	chain := waitForStablePipelineChain(t, env.Store, env.Fixtures.Repo)
+	require.Len(t, chain, 1, "a genuine failure must not be auto-retried")
+	assert.Equal(t, int64(0), chain[0].InfraRetryCount)
+}
+
+// TestInfraRetryRespectsMaxAttempts proves the budget is a hard ceiling: a
+// perpetually infra-failing pipeline with budget 2 yields exactly the original
+// plus two retries, then stops.
+func TestInfraRetryRespectsMaxAttempts(t *testing.T) {
+	withInfraRetryMax(t, 2)
+
+	env := setup.StartServer(t.Context(), t, []*forge_types.FileMeta{
+		{Name: ".woodpecker.yaml", Data: infraFailYAML},
+	})
+	agent := setup.StartAgent(t, env.GRPCAddr)
+	setup.WaitForAgentRegistered(t, env.Store, agent)
+
+	original := triggerPush(t, env)
+	setup.WaitForPipelineStatus(t, env.Store, original.ID, model.StatusFailure, 20*time.Second)
+
+	chain := waitForStablePipelineChain(t, env.Store, env.Fixtures.Repo)
+	require.Len(t, chain, 3, "original + 2 retries (budget = 2)")
+	assert.Equal(t, int64(0), chain[0].InfraRetryCount)
+	assert.Equal(t, int64(1), chain[1].InfraRetryCount)
+	assert.Equal(t, int64(2), chain[2].InfraRetryCount, "last retry hits the ceiling and is not restarted again")
+}

--- a/pipeline/backend/dummy/dummy.go
+++ b/pipeline/backend/dummy/dummy.go
@@ -37,13 +37,14 @@ type dummy struct {
 
 const (
 	// Step names to control behavior of dummy backend.
-	WorkflowSetupFailUUID = "WorkflowSetupShouldFail"
-	EnvKeyStepSleep       = "SLEEP"
-	EnvKeyStepType        = "EXPECT_TYPE"
-	EnvKeyStepStartFail   = "STEP_START_FAIL"
-	EnvKeyStepExitCode    = "STEP_EXIT_CODE"
-	EnvKeyStepTailFail    = "STEP_TAIL_FAIL"
-	EnvKeyStepOOMKilled   = "STEP_OOM_KILLED"
+	WorkflowSetupFailUUID  = "WorkflowSetupShouldFail"
+	EnvKeyStepSleep        = "SLEEP"
+	EnvKeyStepType         = "EXPECT_TYPE"
+	EnvKeyStepStartFail    = "STEP_START_FAIL"
+	EnvKeyStepExitCode     = "STEP_EXIT_CODE"
+	EnvKeyStepTailFail     = "STEP_TAIL_FAIL"
+	EnvKeyStepOOMKilled    = "STEP_OOM_KILLED"
+	EnvKeyStepInfraFailure = "STEP_INFRA_FAILURE"
 
 	// Internal const.
 	stepStateStarted   = "started"
@@ -202,6 +203,7 @@ func (e *dummy) WaitStep(ctx context.Context, step *backend_types.Step, taskUUID
 	e.kv.Store(key, stepStateDone)
 
 	oomKilled, _ := strconv.ParseBool(step.Environment[EnvKeyStepOOMKilled])
+	infraFailure, _ := strconv.ParseBool(step.Environment[EnvKeyStepInfraFailure])
 	exitCode := 0
 
 	if code, exist := step.Environment[EnvKeyStepExitCode]; exist {
@@ -209,9 +211,10 @@ func (e *dummy) WaitStep(ctx context.Context, step *backend_types.Step, taskUUID
 	}
 
 	return &backend_types.State{
-		ExitCode:  exitCode,
-		Exited:    true,
-		OOMKilled: oomKilled,
+		ExitCode:     exitCode,
+		Exited:       true,
+		OOMKilled:    oomKilled,
+		InfraFailure: infraFailure,
 	}, nil
 }
 

--- a/pipeline/backend/kubernetes/kind_test.go
+++ b/pipeline/backend/kubernetes/kind_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build kind
+
+// These tests run the real Kubernetes backend against a live cluster (a local
+// `kind` cluster in CI/dev) and induce a real pod eviction to prove that
+// WaitStep detects an infrastructure failure from the pod's DisruptionTarget
+// condition — the boundary the in-process e2e suite cannot exercise.
+//
+// Run with:
+//
+//	kind create cluster --name wp-e2e
+//	go test -tags kind -run TestKind -timeout 180s ./pipeline/backend/kubernetes/
+package kubernetes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kube_core_v1 "k8s.io/api/core/v1"
+	kube_policy_v1 "k8s.io/api/policy/v1"
+	kube_errors "k8s.io/apimachinery/pkg/api/errors"
+	kube_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
+)
+
+// kindClient builds a clientset from the ambient kubeconfig, pinned to the
+// kind-wp-e2e context. Skips the test if no cluster is reachable.
+func kindClient(t *testing.T) kubernetes.Interface {
+	t.Helper()
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	overrides := &clientcmd.ConfigOverrides{CurrentContext: "kind-wp-e2e"}
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
+	if err != nil {
+		t.Skipf("no kubeconfig / cluster available: %v", err)
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	require.NoError(t, err)
+	if _, err := cs.Discovery().ServerVersion(); err != nil {
+		t.Skipf("kind cluster not reachable: %v", err)
+	}
+	return cs
+}
+
+// TestKindInfraFailureOnEviction creates a real pod, evicts it via the
+// Eviction API (which sets the pod's DisruptionTarget condition exactly as a
+// spot-node preemption does), and asserts the backend's WaitStep returns a
+// State flagged as an infrastructure failure.
+func TestKindInfraFailureOnEviction(t *testing.T) {
+	client := kindClient(t)
+	ctx := context.Background()
+	const ns = "wp-kind-e2e"
+
+	if _, err := client.CoreV1().Namespaces().Create(ctx, &kube_core_v1.Namespace{
+		ObjectMeta: kube_meta_v1.ObjectMeta{Name: ns},
+	}, kube_meta_v1.CreateOptions{}); err != nil && !kube_errors.IsAlreadyExists(err) {
+		require.NoError(t, err, "create namespace")
+	}
+	t.Cleanup(func() {
+		_ = client.CoreV1().Namespaces().Delete(context.Background(), ns, kube_meta_v1.DeleteOptions{})
+	})
+
+	engine := &kube{
+		client: client,
+		config: &config{Namespace: ns},
+		goos:   "linux",
+	}
+
+	step := &types.Step{UUID: "01he8bebctabr3kgk0qj36d2me-0", Name: "preempted", Type: types.StepTypeCommands}
+	podName, err := stepToPodName(step)
+	require.NoError(t, err)
+
+	// Ignore SIGTERM so the pod lingers in Terminating (with DisruptionTarget
+	// set) for the whole grace period, then receives SIGKILL (137). This
+	// mirrors a workload that doesn't shut down promptly on a preemption.
+	grace := int64(20)
+	pod := &kube_core_v1.Pod{
+		ObjectMeta: kube_meta_v1.ObjectMeta{Name: podName, Namespace: ns},
+		Spec: kube_core_v1.PodSpec{
+			RestartPolicy:                 kube_core_v1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: &grace,
+			Containers: []kube_core_v1.Container{{
+				Name:    "wp-step",
+				Image:   "busybox:1.36",
+				Command: []string{"sh", "-c", "trap '' TERM; sleep 600"},
+			}},
+		},
+	}
+	_, err = client.CoreV1().Pods(ns).Create(ctx, pod, kube_meta_v1.CreateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		p, gErr := client.CoreV1().Pods(ns).Get(ctx, podName, kube_meta_v1.GetOptions{})
+		return gErr == nil && p.Status.Phase == kube_core_v1.PodRunning
+	}, 120*time.Second, time.Second, "pod never reached Running")
+
+	type result struct {
+		state *types.State
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		s, e := engine.WaitStep(ctx, step, "task-kind")
+		done <- result{s, e}
+	}()
+
+	// Let WaitStep's informer sync, then evict — the same DisruptionTarget
+	// signal a spot preemption produces.
+	time.Sleep(3 * time.Second)
+	require.NoError(t, client.PolicyV1().Evictions(ns).Evict(ctx, &kube_policy_v1.Eviction{
+		ObjectMeta: kube_meta_v1.ObjectMeta{Name: podName, Namespace: ns},
+	}), "evict pod")
+
+	select {
+	case r := <-done:
+		require.NoError(t, r.err, "WaitStep returned error")
+		require.NotNil(t, r.state)
+		assert.True(t, r.state.InfraFailure,
+			"WaitStep must flag an evicted (DisruptionTarget) pod as an infra failure; got %+v", r.state)
+		assert.True(t, r.state.Exited)
+	case <-time.After(120 * time.Second):
+		t.Fatal("WaitStep did not return within 120s after eviction")
+	}
+}

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -291,6 +292,19 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 	finished := make(chan struct{})
 	var finishedOnce sync.Once
 
+	// infraDisrupted is set as soon as kubernetes marks the pod for an
+	// infrastructure-initiated takedown (node preemption, eviction, graceful
+	// node shutdown). It is captured from informer events rather than only
+	// from the post-completion Get below, because the pod can vanish before
+	// WaitStep observes a terminal container status (e.g. the node is lost),
+	// in which case the Get would miss the signal entirely.
+	var infraDisrupted atomic.Bool
+	markDisrupted := func(pod *kube_core_v1.Pod) {
+		if pod.Name == podName && isPodDisrupted(pod) {
+			infraDisrupted.Store(true)
+		}
+	}
+
 	podUpdated := func(_, newPod any) {
 		pod, ok := newPod.(*kube_core_v1.Pod)
 		if !ok {
@@ -299,6 +313,8 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 		}
 
 		if pod.Name == podName {
+			markDisrupted(pod)
+
 			if isImagePullBackOffState(pod) || isInvalidImageName(pod) {
 				finishedOnce.Do(func() { close(finished) })
 			}
@@ -323,6 +339,7 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 			}
 		}
 		if pod.Name == podName {
+			markDisrupted(pod)
 			finishedOnce.Do(func() { close(finished) })
 		}
 	}
@@ -342,7 +359,9 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 	defer close(stop)
 
 	// If the pod was deleted before the informer started, no events will
-	// ever arrive. Check explicitly so we don't hang forever.
+	// ever arrive. Check explicitly so we don't hang forever. (A pod already
+	// gone at this point left no disruption signal to observe, so it is
+	// treated as a normal completion.)
 	if _, err := e.client.CoreV1().Pods(e.config.GetNamespace(step.OrgID)).Get(ctx, podName, kube_meta_v1.GetOptions{}); kube_errors.IsNotFound(err) {
 		return &types.State{ExitCode: 0, Exited: true}, nil
 	}
@@ -381,6 +400,13 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 	)
 	if err != nil {
 		if kube_errors.IsNotFound(err) {
+			// The pod vanished before we could read a terminal status. If we
+			// already saw it marked for disruption, report it as an infra
+			// failure (SIGKILL exit) so the server can retry it; otherwise it
+			// completed and was garbage-collected normally.
+			if infraDisrupted.Load() {
+				return &types.State{ExitCode: 137, Exited: true, InfraFailure: true}, nil
+			}
 			return &types.State{ExitCode: 0, Exited: true}, nil
 		}
 		return nil, err
@@ -393,9 +419,10 @@ func (e *kube) WaitStep(ctx context.Context, step *types.Step, taskUUID string) 
 	cs := pod.Status.ContainerStatuses[0]
 
 	bs := &types.State{
-		ExitCode:  int(cs.State.Terminated.ExitCode),
-		Exited:    true,
-		OOMKilled: false,
+		ExitCode:     int(cs.State.Terminated.ExitCode),
+		Exited:       true,
+		OOMKilled:    false,
+		InfraFailure: infraDisrupted.Load() || isPodDisrupted(pod),
 	}
 
 	return bs, nil

--- a/pipeline/backend/kubernetes/utils.go
+++ b/pipeline/backend/kubernetes/utils.go
@@ -100,6 +100,36 @@ func isInvalidImageName(pod *kube_core_v1.Pod) bool {
 	return false
 }
 
+// isPodDisrupted reports whether kubernetes terminated the pod for an
+// infrastructure reason (node preemption, API/taint eviction or graceful
+// node shutdown) rather than the workload itself exiting non-zero.
+//
+// The DisruptionTarget pod condition is the authoritative signal: kubernetes
+// (>= 1.26) sets it before taking a pod down for preemption, eviction or node
+// shutdown. The pod-level Reason switch is a fallback for older clusters and
+// for the graceful-node-shutdown path. Those reason strings live in kubelet /
+// node-controller internals rather than in k8s.io/api, so they are matched as
+// literals.
+//
+// "Evicted" is deliberately excluded: kubelet also uses it for node-pressure
+// eviction, which is frequently the workload's own fault (exceeding its
+// memory or ephemeral-storage request) and would fail again on retry. The
+// DisruptionTarget condition still covers API- and taint-initiated evictions.
+func isPodDisrupted(pod *kube_core_v1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == kube_core_v1.DisruptionTarget && cond.Status == kube_core_v1.ConditionTrue {
+			return true
+		}
+	}
+
+	switch pod.Status.Reason {
+	case "Shutdown", "NodeShutdown", "Terminated", "NodeLost":
+		return true
+	}
+
+	return false
+}
+
 // getClientOutOfCluster returns a k8s client set to the request from outside of cluster.
 func getClientOutOfCluster() (kubernetes.Interface, error) {
 	kubeConfigPath := os.Getenv("KUBECONFIG") // cspell:words KUBECONFIG

--- a/pipeline/backend/kubernetes/utils_test.go
+++ b/pipeline/backend/kubernetes/utils_test.go
@@ -18,7 +18,35 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	kube_core_v1 "k8s.io/api/core/v1"
 )
+
+func TestIsPodDisrupted(t *testing.T) {
+	disruptionTarget := func(status kube_core_v1.ConditionStatus) *kube_core_v1.Pod {
+		return &kube_core_v1.Pod{Status: kube_core_v1.PodStatus{
+			Conditions: []kube_core_v1.PodCondition{{
+				Type:   kube_core_v1.PodConditionType("DisruptionTarget"),
+				Status: status,
+			}},
+		}}
+	}
+	withReason := func(reason string) *kube_core_v1.Pod {
+		return &kube_core_v1.Pod{Status: kube_core_v1.PodStatus{Reason: reason}}
+	}
+
+	assert.True(t, isPodDisrupted(disruptionTarget(kube_core_v1.ConditionTrue)), "DisruptionTarget=True")
+	assert.False(t, isPodDisrupted(disruptionTarget(kube_core_v1.ConditionFalse)), "DisruptionTarget=False")
+	assert.True(t, isPodDisrupted(withReason("NodeShutdown")), "Reason=NodeShutdown")
+	assert.True(t, isPodDisrupted(withReason("Shutdown")), "Reason=Shutdown")
+	assert.True(t, isPodDisrupted(withReason("Terminated")), "Reason=Terminated")
+	assert.True(t, isPodDisrupted(withReason("NodeLost")), "Reason=NodeLost")
+	// node-pressure eviction is the workload's own fault and must not be
+	// treated as a retryable infra failure (only the DisruptionTarget
+	// condition flags API/taint evictions).
+	assert.False(t, isPodDisrupted(withReason("Evicted")), "Reason=Evicted is not retryable")
+	assert.False(t, isPodDisrupted(withReason("Completed")), "Reason=Completed")
+	assert.False(t, isPodDisrupted(&kube_core_v1.Pod{}), "no condition, no reason")
+}
 
 func TestDNSName(t *testing.T) {
 	name, err := dnsName("wp_01he8bebctabr3kgk0qj36d2me_0_services_0")

--- a/pipeline/backend/types/state.go
+++ b/pipeline/backend/types/state.go
@@ -27,6 +27,11 @@ type State struct {
 	// Container is oom killed, true or false
 	// TODO (6024): well known errors as string enum into ./errors.go
 	OOMKilled bool `json:"oom_killed"`
+	// InfraFailure is true when the backend terminated the step for an
+	// infrastructure reason (e.g. node preemption, eviction or graceful
+	// node shutdown) rather than the workload itself failing. Such steps
+	// are candidates for an automatic retry on a fresh agent.
+	InfraFailure bool `json:"infra_failure"`
 	// Container error
 	Error error
 }

--- a/rpc/proto/woodpecker.pb.go
+++ b/rpc/proto/woodpecker.pb.go
@@ -46,6 +46,7 @@ type StepState struct {
 	Error         string                 `protobuf:"bytes,6,opt,name=error,proto3" json:"error,omitempty"`
 	Canceled      bool                   `protobuf:"varint,7,opt,name=canceled,proto3" json:"canceled,omitempty"`
 	Skipped       bool                   `protobuf:"varint,8,opt,name=skipped,proto3" json:"skipped,omitempty"`
+	InfraFailure  bool                   `protobuf:"varint,9,opt,name=infra_failure,json=infraFailure,proto3" json:"infra_failure,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -132,6 +133,13 @@ func (x *StepState) GetCanceled() bool {
 func (x *StepState) GetSkipped() bool {
 	if x != nil {
 		return x.Skipped
+	}
+	return false
+}
+
+func (x *StepState) GetInfraFailure() bool {
+	if x != nil {
+		return x.InfraFailure
 	}
 	return false
 }
@@ -1216,7 +1224,7 @@ var File_woodpecker_proto protoreflect.FileDescriptor
 
 const file_woodpecker_proto_rawDesc = "" +
 	"\n" +
-	"\x10woodpecker.proto\x12\x05proto\"\xdf\x01\n" +
+	"\x10woodpecker.proto\x12\x05proto\"\x84\x02\n" +
 	"\tStepState\x12\x1b\n" +
 	"\tstep_uuid\x18\x01 \x01(\tR\bstepUuid\x12\x18\n" +
 	"\astarted\x18\x02 \x01(\x03R\astarted\x12\x1a\n" +
@@ -1225,7 +1233,8 @@ const file_woodpecker_proto_rawDesc = "" +
 	"\texit_code\x18\x05 \x01(\x05R\bexitCode\x12\x14\n" +
 	"\x05error\x18\x06 \x01(\tR\x05error\x12\x1a\n" +
 	"\bcanceled\x18\a \x01(\bR\bcanceled\x12\x18\n" +
-	"\askipped\x18\b \x01(\bR\askipped\"w\n" +
+	"\askipped\x18\b \x01(\bR\askipped\x12#\n" +
+	"\rinfra_failure\x18\t \x01(\bR\finfraFailure\"w\n" +
 	"\rWorkflowState\x12\x18\n" +
 	"\astarted\x18\x01 \x01(\x03R\astarted\x12\x1a\n" +
 	"\bfinished\x18\x02 \x01(\x03R\bfinished\x12\x14\n" +

--- a/rpc/proto/woodpecker.proto
+++ b/rpc/proto/woodpecker.proto
@@ -50,6 +50,7 @@ message StepState {
   string error = 6;
   bool   canceled = 7;
   bool   skipped = 8;
+  bool   infra_failure = 9;
 }
 
 message WorkflowState {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -26,14 +26,15 @@ type (
 
 	// StepState defines the step state.
 	StepState struct {
-		StepUUID string `json:"step_uuid"`
-		Started  int64  `json:"started"`
-		Finished int64  `json:"finished"`
-		Exited   bool   `json:"exited"`
-		ExitCode int    `json:"exit_code"`
-		Error    string `json:"error"`
-		Canceled bool   `json:"canceled"`
-		Skipped  bool   `json:"skipped"`
+		StepUUID     string `json:"step_uuid"`
+		Started      int64  `json:"started"`
+		Finished     int64  `json:"finished"`
+		Exited       bool   `json:"exited"`
+		ExitCode     int    `json:"exit_code"`
+		Error        string `json:"error"`
+		Canceled     bool   `json:"canceled"`
+		Skipped      bool   `json:"skipped"`
+		InfraFailure bool   `json:"infra_failure"`
 	}
 
 	// WorkflowState defines the workflow state.

--- a/server/config.go
+++ b/server/config.go
@@ -77,7 +77,11 @@ var Config = struct {
 		PrivilegedPlugins                   []string
 		DefaultTimeout                      int64
 		MaxTimeout                          int64
-		Proxy                               struct {
+		// InfraRetryMaxAttempts caps automatic restarts when a pipeline fails
+		// solely due to infrastructure events (e.g. spot-node preemption);
+		// 0 disables them.
+		InfraRetryMaxAttempts int64
+		Proxy                 struct {
 			No    string
 			HTTP  string
 			HTTPS string

--- a/server/model/pipeline.go
+++ b/server/model/pipeline.go
@@ -21,45 +21,55 @@ import (
 )
 
 type Pipeline struct {
-	ID                   int64                   `json:"id"                      xorm:"pk autoincr 'id'"`
-	RepoID               int64                   `json:"-"                       xorm:"UNIQUE(s) INDEX 'repo_id'"`
-	Number               int64                   `json:"number"                  xorm:"UNIQUE(s) 'number'"`
-	Author               string                  `json:"author"                  xorm:"INDEX 'author'"`
-	Parent               int64                   `json:"parent"                  xorm:"parent"`
-	Event                WebhookEvent            `json:"event"                   xorm:"event"`
-	EventReason          []string                `json:"event_reason"            xorm:"json 'event_reason'"`
-	Status               StatusValue             `json:"status"                  xorm:"INDEX 'status'"`
-	Errors               []*errors.PipelineError `json:"errors"                  xorm:"json 'errors'"`
-	Created              int64                   `json:"created"                 xorm:"'created' NOT NULL DEFAULT 0 created"`
-	Updated              int64                   `json:"updated"                 xorm:"'updated' NOT NULL DEFAULT 0 updated"`
-	Started              int64                   `json:"started"                 xorm:"started"`
-	Finished             int64                   `json:"finished"                xorm:"finished"`
-	DeployTo             string                  `json:"deploy_to"               xorm:"deploy"`
-	DeployTask           string                  `json:"deploy_task"             xorm:"deploy_task"`
-	Commit               string                  `json:"commit"                  xorm:"commit"`
-	Branch               string                  `json:"branch"                  xorm:"branch"`
-	RerunCount           int64                   `json:"rerun_count"             xorm:"rerun_count"`
-	Ref                  string                  `json:"ref"                     xorm:"ref"`
-	Refspec              string                  `json:"refspec"                 xorm:"refspec"`
-	Title                string                  `json:"title"                   xorm:"title"`
-	Message              string                  `json:"message"                 xorm:"TEXT 'message'"`
-	Timestamp            int64                   `json:"timestamp"               xorm:"'timestamp'"`
-	Sender               string                  `json:"sender"                  xorm:"sender"` // uses reported user for webhooks and name of cron for cron pipelines
-	Avatar               string                  `json:"author_avatar"           xorm:"varchar(500) avatar"`
-	Email                string                  `json:"author_email"            xorm:"varchar(500) email"`
-	ForgeURL             string                  `json:"forge_url"               xorm:"forge_url"`
-	Reviewer             string                  `json:"reviewed_by"             xorm:"reviewer"`
-	Reviewed             int64                   `json:"reviewed"                xorm:"reviewed"`
-	CancelInfo           *CancelInfo             `json:"cancel_info,omitempty"   xorm:"json 'cancel_info'"`
-	Workflows            []*Workflow             `json:"workflows,omitempty"     xorm:"-"`
-	ChangedFiles         []string                `json:"changed_files,omitempty" xorm:"LONGTEXT 'changed_files'"`
-	AdditionalVariables  map[string]string       `json:"variables,omitempty"     xorm:"json 'additional_variables'"`
-	PullRequestLabels    []string                `json:"pr_labels,omitempty"     xorm:"json 'pr_labels'"`
-	PullRequestMilestone string                  `json:"pr_milestone,omitempty"  xorm:"pr_milestone"`
-	Cron                 string                  `json:"cron,omitempty"          xorm:"cron"` // name of the cron job
-	IsPrerelease         bool                    `json:"is_prerelease,omitempty" xorm:"is_prerelease"`
-	FromFork             bool                    `json:"from_fork,omitempty"     xorm:"from_fork"`
-	Version              string                  `json:"version"                 xorm:"'version'"`
+	ID          int64                   `json:"id"                      xorm:"pk autoincr 'id'"`
+	RepoID      int64                   `json:"-"                       xorm:"UNIQUE(s) INDEX 'repo_id'"`
+	Number      int64                   `json:"number"                  xorm:"UNIQUE(s) 'number'"`
+	Author      string                  `json:"author"                  xorm:"INDEX 'author'"`
+	Parent      int64                   `json:"parent"                  xorm:"parent"`
+	Event       WebhookEvent            `json:"event"                   xorm:"event"`
+	EventReason []string                `json:"event_reason"            xorm:"json 'event_reason'"`
+	Status      StatusValue             `json:"status"                  xorm:"INDEX 'status'"`
+	Errors      []*errors.PipelineError `json:"errors"                  xorm:"json 'errors'"`
+	Created     int64                   `json:"created"                 xorm:"'created' NOT NULL DEFAULT 0 created"`
+	Updated     int64                   `json:"updated"                 xorm:"'updated' NOT NULL DEFAULT 0 updated"`
+	Started     int64                   `json:"started"                 xorm:"started"`
+	Finished    int64                   `json:"finished"                xorm:"finished"`
+	DeployTo    string                  `json:"deploy_to"               xorm:"deploy"`
+	DeployTask  string                  `json:"deploy_task"             xorm:"deploy_task"`
+	Commit      string                  `json:"commit"                  xorm:"commit"`
+	Branch      string                  `json:"branch"                  xorm:"branch"`
+	RerunCount  int64                   `json:"rerun_count"             xorm:"rerun_count"`
+	// InfraRetryCount records how many times this pipeline was automatically
+	// restarted because of an infrastructure failure (node preemption,
+	// eviction, shutdown). It bounds the budget set by
+	// WOODPECKER_INFRA_RETRY_MAX_ATTEMPTS and is carried forward on each
+	// automatic retry; see Step.InfraFailure for the per-step signal.
+	InfraRetryCount int64 `json:"infra_retry_count"       xorm:"NOT NULL DEFAULT 0 'infra_retry_count'"`
+	// InfraRetried is an internal coordination flag claimed atomically by the
+	// single Done that triggers the automatic infra retry, so concurrent Done
+	// calls for sibling workflows cannot each spawn a duplicate restart.
+	InfraRetried         bool              `json:"-"                       xorm:"NOT NULL DEFAULT false 'infra_retried'"`
+	Ref                  string            `json:"ref"                     xorm:"ref"`
+	Refspec              string            `json:"refspec"                 xorm:"refspec"`
+	Title                string            `json:"title"                   xorm:"title"`
+	Message              string            `json:"message"                 xorm:"TEXT 'message'"`
+	Timestamp            int64             `json:"timestamp"               xorm:"'timestamp'"`
+	Sender               string            `json:"sender"                  xorm:"sender"` // uses reported user for webhooks and name of cron for cron pipelines
+	Avatar               string            `json:"author_avatar"           xorm:"varchar(500) avatar"`
+	Email                string            `json:"author_email"            xorm:"varchar(500) email"`
+	ForgeURL             string            `json:"forge_url"               xorm:"forge_url"`
+	Reviewer             string            `json:"reviewed_by"             xorm:"reviewer"`
+	Reviewed             int64             `json:"reviewed"                xorm:"reviewed"`
+	CancelInfo           *CancelInfo       `json:"cancel_info,omitempty"   xorm:"json 'cancel_info'"`
+	Workflows            []*Workflow       `json:"workflows,omitempty"     xorm:"-"`
+	ChangedFiles         []string          `json:"changed_files,omitempty" xorm:"LONGTEXT 'changed_files'"`
+	AdditionalVariables  map[string]string `json:"variables,omitempty"     xorm:"json 'additional_variables'"`
+	PullRequestLabels    []string          `json:"pr_labels,omitempty"     xorm:"json 'pr_labels'"`
+	PullRequestMilestone string            `json:"pr_milestone,omitempty"  xorm:"pr_milestone"`
+	Cron                 string            `json:"cron,omitempty"          xorm:"cron"` // name of the cron job
+	IsPrerelease         bool              `json:"is_prerelease,omitempty" xorm:"is_prerelease"`
+	FromFork             bool              `json:"from_fork,omitempty"     xorm:"from_fork"`
+	Version              string            `json:"version"                 xorm:"'version'"`
 }
 
 // APIPipeline TODO remove deprecated properties in next major.

--- a/server/model/step.go
+++ b/server/model/step.go
@@ -37,6 +37,11 @@ type Step struct {
 	Started    int64       `json:"started,omitempty"    xorm:"started"`
 	Finished   int64       `json:"finished,omitempty"   xorm:"finished"`
 	Type       StepType    `json:"type,omitempty"       xorm:"type"`
+	// InfraFailure is set when the backend reported that this step was
+	// terminated by an infrastructure event (node preemption, eviction,
+	// graceful node shutdown) rather than the workload failing. It lets
+	// the server distinguish retryable infra failures from genuine ones.
+	InfraFailure bool `json:"infra_failure,omitempty" xorm:"NOT NULL DEFAULT false 'infra_failure'"`
 } //	@name	Step
 
 // TableName return database table name for xorm.

--- a/server/pipeline/infra_retry.go
+++ b/server/pipeline/infra_retry.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+)
+
+// shouldRetryInfraFailure reports whether a finished pipeline failed solely
+// because of an infrastructure event (a step the backend flagged as an
+// InfraFailure, e.g. spot-node preemption or pod eviction) and is therefore
+// safe to restart automatically.
+//
+// It deliberately refuses to retry when any genuine (non-infra) step failure
+// is present: restarting would just burn resources reproducing a real error.
+// It is a pure function so the decision is unit-testable without a store.
+func shouldRetryInfraFailure(pipeline *model.Pipeline, maxAttempts int64) bool {
+	if maxAttempts <= 0 {
+		return false
+	}
+	// Only failed pipelines are candidates. StatusError (config/parse
+	// problems) and StatusKilled (user/superseded cancels) are never infra.
+	if pipeline.Status != model.StatusFailure {
+		return false
+	}
+	if pipeline.InfraRetryCount >= maxAttempts {
+		return false
+	}
+
+	sawInfraFailure := false
+	for _, workflow := range pipeline.Workflows {
+		for _, step := range workflow.Children {
+			// A step the backend flagged as an infra failure makes the
+			// pipeline retryable, whether it surfaced as a failure or was
+			// reported killed (e.g. a fail-fast cancel racing the exit).
+			if step.InfraFailure {
+				sawInfraFailure = true
+				continue
+			}
+			if step.State != model.StatusFailure {
+				// Skipped, killed (fail-fast cascade) and successful steps do
+				// not, on their own, make the pipeline unretryable.
+				continue
+			}
+			// A step allowed to fail never fails the pipeline.
+			if step.Failure == model.FailureIgnore {
+				continue
+			}
+			// A genuine failure: a retry will not change the outcome.
+			return false
+		}
+	}
+
+	return sawInfraFailure
+}
+
+// RetryOnInfraFailure restarts pipeline when it failed only because of an
+// infrastructure event and the configured attempt budget is not yet spent.
+// It returns true when a restart was triggered.
+//
+// Automatic retries have no initiating user, so it runs as the repo owner —
+// the same identity cron-triggered pipelines use.
+func RetryOnInfraFailure(ctx context.Context, store store.Store, repo *model.Repo, pipeline *model.Pipeline) (bool, error) {
+	if !shouldRetryInfraFailure(pipeline, server.Config.Pipeline.InfraRetryMaxAttempts) {
+		return false, nil
+	}
+
+	user, err := store.GetUser(repo.UserID)
+	if err != nil {
+		return false, fmt.Errorf("infra-retry: cannot load repo owner %d: %w", repo.UserID, err)
+	}
+
+	// Atomically claim the single retry for this pipeline. For a multi-workflow
+	// pipeline whose final workflows finish concurrently, more than one Done
+	// can observe the pipeline as just-terminal and reach here; only the caller
+	// that wins the claim restarts it.
+	claimed, err := store.ClaimInfraRetry(pipeline.ID)
+	if err != nil {
+		return false, fmt.Errorf("infra-retry: cannot claim retry: %w", err)
+	}
+	if !claimed {
+		return false, nil
+	}
+
+	// restart with incrementInfraRetry=true bumps InfraRetryCount on the new
+	// pipeline so it is persisted atomically by CreatePipeline. This bounds the
+	// chain at InfraRetryMaxAttempts with no separate, individually-fallible
+	// update that could otherwise leave a stale count and retry forever.
+	if _, err := restart(ctx, store, pipeline, user, repo, nil, true); err != nil {
+		return false, fmt.Errorf("infra-retry: restart failed: %w", err)
+	}
+
+	return true, nil
+}

--- a/server/pipeline/infra_retry_test.go
+++ b/server/pipeline/infra_retry_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+)
+
+func pipelineWithSteps(status model.StatusValue, retryCount int64, steps ...*model.Step) *model.Pipeline {
+	return &model.Pipeline{
+		Status:          status,
+		InfraRetryCount: retryCount,
+		Workflows:       []*model.Workflow{{Children: steps}},
+	}
+}
+
+func step(state model.StatusValue, infra bool, failure string) *model.Step {
+	return &model.Step{State: state, InfraFailure: infra, Failure: failure}
+}
+
+func TestShouldRetryInfraFailure(t *testing.T) {
+	tests := []struct {
+		name        string
+		pipeline    *model.Pipeline
+		maxAttempts int64
+		want        bool
+	}{
+		{
+			name:        "infra-only failure is retried",
+			pipeline:    pipelineWithSteps(model.StatusFailure, 0, step(model.StatusFailure, true, model.FailureFail)),
+			maxAttempts: 2,
+			want:        true,
+		},
+		{
+			name: "infra failure plus fail-fast killed siblings is retried",
+			pipeline: pipelineWithSteps(model.StatusFailure, 0,
+				step(model.StatusFailure, true, model.FailureFail),
+				step(model.StatusKilled, false, model.FailureFail),
+				step(model.StatusSuccess, false, model.FailureFail),
+			),
+			maxAttempts: 2,
+			want:        true,
+		},
+		{
+			name: "genuine failure alongside infra failure is not retried",
+			pipeline: pipelineWithSteps(model.StatusFailure, 0,
+				step(model.StatusFailure, true, model.FailureFail),
+				step(model.StatusFailure, false, model.FailureFail),
+			),
+			maxAttempts: 2,
+			want:        false,
+		},
+		{
+			name:        "non-infra failure is not retried",
+			pipeline:    pipelineWithSteps(model.StatusFailure, 0, step(model.StatusFailure, false, model.FailureFail)),
+			maxAttempts: 2,
+			want:        false,
+		},
+		{
+			name:        "feature disabled (maxAttempts 0) never retries",
+			pipeline:    pipelineWithSteps(model.StatusFailure, 0, step(model.StatusFailure, true, model.FailureFail)),
+			maxAttempts: 0,
+			want:        false,
+		},
+		{
+			name:        "attempt budget exhausted is not retried",
+			pipeline:    pipelineWithSteps(model.StatusFailure, 2, step(model.StatusFailure, true, model.FailureFail)),
+			maxAttempts: 2,
+			want:        false,
+		},
+		{
+			name:        "successful pipeline is not retried",
+			pipeline:    pipelineWithSteps(model.StatusSuccess, 0, step(model.StatusSuccess, false, model.FailureFail)),
+			maxAttempts: 2,
+			want:        false,
+		},
+		{
+			name:        "killed (canceled) pipeline is not retried",
+			pipeline:    pipelineWithSteps(model.StatusKilled, 0, step(model.StatusKilled, false, model.FailureFail)),
+			maxAttempts: 2,
+			want:        false,
+		},
+		{
+			name:        "error (config) pipeline is not retried",
+			pipeline:    pipelineWithSteps(model.StatusError, 0, step(model.StatusError, false, model.FailureFail)),
+			maxAttempts: 2,
+			want:        false,
+		},
+		{
+			name: "ignored failing step does not block an infra retry",
+			pipeline: pipelineWithSteps(model.StatusFailure, 0,
+				step(model.StatusFailure, true, model.FailureFail),
+				step(model.StatusFailure, false, model.FailureIgnore),
+			),
+			maxAttempts: 2,
+			want:        true,
+		},
+		{
+			name: "infra-flagged step reported killed still retries",
+			pipeline: pipelineWithSteps(model.StatusFailure, 0,
+				step(model.StatusKilled, true, model.FailureFail),
+			),
+			maxAttempts: 2,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldRetryInfraFailure(tt.pipeline, tt.maxAttempts))
+		})
+	}
+}

--- a/server/pipeline/restart.go
+++ b/server/pipeline/restart.go
@@ -30,6 +30,16 @@ import (
 
 // Restart a pipeline by creating a new one out of the old and start it.
 func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipeline, user *model.User, repo *model.Repo, envs map[string]string) (*model.Pipeline, error) {
+	return restart(ctx, store, lastPipeline, user, repo, envs, false)
+}
+
+// restart is the shared core of Restart and the automatic infrastructure
+// retry. incrementInfraRetry bumps the new pipeline's InfraRetryCount so the
+// counter is persisted atomically with the new pipeline (rather than in a
+// separate, individually-fallible update); it is set only by
+// RetryOnInfraFailure. A user-initiated restart resets the counter to give a
+// fresh infra-retry budget.
+func restart(ctx context.Context, store store.Store, lastPipeline *model.Pipeline, user *model.User, repo *model.Repo, envs map[string]string, incrementInfraRetry bool) (*model.Pipeline, error) {
 	forge, err := server.Config.Services.Manager.ForgeFromRepo(repo)
 	if err != nil {
 		msg := fmt.Sprintf("failure to load forge for repo '%s'", repo.FullName)
@@ -65,6 +75,9 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 	newPipeline := createNewOutOfOld(lastPipeline)
 	newPipeline.Parent = lastPipeline.Number
 	newPipeline.RerunCount++
+	if incrementInfraRetry {
+		newPipeline.InfraRetryCount = lastPipeline.InfraRetryCount + 1
+	}
 	newPipeline.Version = version.String()
 
 	err = store.CreatePipeline(newPipeline)
@@ -140,5 +153,17 @@ func createNewOutOfOld(old *model.Pipeline) *model.Pipeline {
 	newPipeline.Started = 0
 	newPipeline.Finished = 0
 	newPipeline.Errors = nil
+	// Reset the infrastructure-retry budget; the automatic-retry path
+	// (restart with incrementInfraRetry) sets it explicitly from the parent,
+	// so a user-initiated restart starts fresh.
+	newPipeline.InfraRetryCount = 0
+	// A fresh pipeline has not had its infra retry claimed yet.
+	newPipeline.InfraRetried = false
+	// The new pipeline has no workflows yet; they are built fresh during
+	// restart. Clearing here matters when the caller passes a pipeline that
+	// already has its workflow tree loaded (e.g. the infra-failure auto-retry
+	// from the Done RPC), which would otherwise trip the "already has
+	// workflows" guard in saveWorkflowsFromPipelineBuilder.
+	newPipeline.Workflows = nil
 	return &newPipeline
 }

--- a/server/pipeline/step_status.go
+++ b/server/pipeline/step_status.go
@@ -60,6 +60,7 @@ func CalcStepStatus(step model.Step, state rpc.StepState) (_ *model.Step, cancel
 			}
 			step.ExitCode = state.ExitCode
 			step.Error = state.Error
+			step.InfraFailure = state.InfraFailure
 
 			if state.ExitCode == 0 && state.Error == "" {
 				step.State = model.StatusSuccess
@@ -81,6 +82,7 @@ func CalcStepStatus(step model.Step, state rpc.StepState) (_ *model.Step, cancel
 			}
 			step.ExitCode = state.ExitCode
 			step.Error = state.Error
+			step.InfraFailure = state.InfraFailure
 
 			if state.ExitCode == 0 && state.Error == "" {
 				step.State = model.StatusSuccess

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -380,6 +380,26 @@ func (s *RPC) Done(c context.Context, strWorkflowID string, state rpc.WorkflowSt
 		if currentPipeline, err = pipeline.UpdateStatusToDone(s.store, *currentPipeline, pipeline.PipelineStatus(currentPipeline.Workflows), workflow.Finished); err != nil {
 			logger.Error().Err(err).Msgf("pipeline.UpdateStatusToDone: cannot update workflows final state")
 		}
+
+		// Automatically restart the pipeline if it failed solely because of an
+		// infrastructure event (e.g. spot-node preemption). No-op unless
+		// WOODPECKER_INFRA_RETRY_MAX_ATTEMPTS is set.
+		//
+		// Use a detached, bounded context so the restart (forge fetch +
+		// enqueue) is not cancelled if the agent's Done call returns or the
+		// agent disconnects mid-restart, which could otherwise leave a pending
+		// pipeline that never starts.
+		//
+		// Concurrent Done calls (sibling workflows finishing together) can both
+		// reach here; RetryOnInfraFailure atomically claims the single retry so
+		// only one of them actually restarts the pipeline.
+		retryCtx, cancel := context.WithTimeout(context.WithoutCancel(c), 2*time.Minute)
+		if retried, rErr := pipeline.RetryOnInfraFailure(retryCtx, s.store, repo, currentPipeline); rErr != nil {
+			logger.Error().Err(rErr).Msg("could not evaluate pipeline for infrastructure-failure retry")
+		} else if retried {
+			logger.Info().Int64("pipeline_id", currentPipeline.ID).Msg("pipeline automatically restarted after infrastructure failure")
+		}
+		cancel()
 	}
 
 	s.updateForgeStatus(c, repo, currentPipeline, workflow)

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -109,14 +109,15 @@ func (s *WoodpeckerServer) Init(c context.Context, req *proto.InitRequest) (*pro
 // Update let agent updates the step state at the server.
 func (s *WoodpeckerServer) Update(c context.Context, req *proto.UpdateRequest) (*proto.Empty, error) {
 	state := rpc.StepState{
-		StepUUID: req.GetState().GetStepUuid(),
-		Started:  req.GetState().GetStarted(),
-		Finished: req.GetState().GetFinished(),
-		Exited:   req.GetState().GetExited(),
-		Error:    req.GetState().GetError(),
-		ExitCode: int(req.GetState().GetExitCode()),
-		Canceled: req.GetState().GetCanceled(),
-		Skipped:  req.GetState().GetSkipped(),
+		StepUUID:     req.GetState().GetStepUuid(),
+		Started:      req.GetState().GetStarted(),
+		Finished:     req.GetState().GetFinished(),
+		Exited:       req.GetState().GetExited(),
+		Error:        req.GetState().GetError(),
+		ExitCode:     int(req.GetState().GetExitCode()),
+		Canceled:     req.GetState().GetCanceled(),
+		Skipped:      req.GetState().GetSkipped(),
+		InfraFailure: req.GetState().GetInfraFailure(),
 	}
 	res := new(proto.Empty)
 	err := s.peer.Update(c, req.GetId(), state)

--- a/server/store/datastore/migration/028_add_infra_failure_retry.go
+++ b/server/store/datastore/migration/028_add_infra_failure_retry.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"src.techknowlogick.com/xormigrate"
+	"xorm.io/xorm"
+)
+
+var addInfraFailureRetry = xormigrate.Migration{
+	ID: "add-infra-failure-retry",
+	MigrateSession: func(sess *xorm.Session) error {
+		type steps struct {
+			ID int64 `xorm:"pk autoincr 'id'"`
+
+			// marks a step terminated by an infrastructure event
+			InfraFailure bool `xorm:"NOT NULL DEFAULT false 'infra_failure'"`
+		}
+
+		type pipelines struct {
+			ID int64 `xorm:"pk autoincr 'id'"`
+
+			// number of automatic infrastructure-failure retries that led to
+			// this pipeline; bounds WOODPECKER_INFRA_RETRY_MAX_ATTEMPTS
+			InfraRetryCount int64 `xorm:"NOT NULL DEFAULT 0 'infra_retry_count'"`
+
+			// claimed (atomically) by the single Done that triggers this
+			// pipeline's automatic infra retry, so concurrent Done calls
+			// cannot each spawn a duplicate restart
+			InfraRetried bool `xorm:"NOT NULL DEFAULT false 'infra_retried'"`
+		}
+
+		if err := sess.Sync(new(steps)); err != nil {
+			return err
+		}
+
+		return sess.Sync(new(pipelines))
+	},
+}

--- a/server/store/datastore/migration/migration.go
+++ b/server/store/datastore/migration/migration.go
@@ -56,6 +56,7 @@ var migrationTasks = []*xormigrate.Migration{
 	&replaceZeroForgeIDsInOrgs,
 	&fixForgeColumns,
 	&addCronField,
+	&addInfraFailureRetry,
 }
 
 var allBeans = []any{

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -212,6 +212,21 @@ func (s storage) UpdatePipeline(pipeline *model.Pipeline) error {
 	return err
 }
 
+// ClaimInfraRetry flips infra_retried from false to true in a single guarded
+// statement. The row lock serialises concurrent callers, so exactly one sees
+// rows-affected == 1 and may proceed with the restart.
+func (s storage) ClaimInfraRetry(pipelineID int64) (bool, error) {
+	affected, err := s.engine.Table("pipelines").
+		Where("id = ?", pipelineID).
+		And("infra_retried = ?", false).
+		Cols("infra_retried").
+		Update(&model.Pipeline{InfraRetried: true})
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
+}
+
 func (s storage) DeletePipeline(pipeline *model.Pipeline) error {
 	return s.deletePipeline(s.engine.NewSession(), pipeline.ID)
 }

--- a/server/store/datastore/pipeline_test.go
+++ b/server/store/datastore/pipeline_test.go
@@ -218,6 +218,29 @@ func TestPipelineIncrement(t *testing.T) {
 	assert.EqualValues(t, 1, pipelineC.Number)
 }
 
+func TestClaimInfraRetry(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Pipeline), new(model.Repo))
+	defer closer()
+
+	require.NoError(t, store.CreateRepo(&model.Repo{ID: 1, Owner: "1", Name: "1", FullName: "1/1", ForgeRemoteID: "1"}))
+	pipeline := &model.Pipeline{RepoID: 1, Status: model.StatusFailure}
+	require.NoError(t, store.CreatePipeline(pipeline))
+
+	// the first claim wins, any subsequent claim loses
+	claimed, err := store.ClaimInfraRetry(pipeline.ID)
+	require.NoError(t, err)
+	assert.True(t, claimed, "first claim should win")
+
+	claimed, err = store.ClaimInfraRetry(pipeline.ID)
+	require.NoError(t, err)
+	assert.False(t, claimed, "second claim should lose")
+
+	// the flag is persisted
+	got, err := store.GetPipeline(pipeline.ID)
+	require.NoError(t, err)
+	assert.True(t, got.InfraRetried)
+}
+
 func TestDeletePipeline(t *testing.T) {
 	store, closer := newTestStore(t, new(model.Pipeline), new(model.Repo), new(model.Workflow),
 		new(model.Step), new(model.LogEntry), new(model.PipelineConfig), new(model.Config))

--- a/server/store/mocks/mock_Store.go
+++ b/server/store/mocks/mock_Store.go
@@ -445,6 +445,66 @@ func (_c *MockStore_AgentUpdate_Call) RunAndReturn(run func(agent *model.Agent) 
 	return _c
 }
 
+// ClaimInfraRetry provides a mock function for the type MockStore
+func (_mock *MockStore) ClaimInfraRetry(pipelineID int64) (bool, error) {
+	ret := _mock.Called(pipelineID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClaimInfraRetry")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int64) (bool, error)); ok {
+		return returnFunc(pipelineID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int64) bool); ok {
+		r0 = returnFunc(pipelineID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(int64) error); ok {
+		r1 = returnFunc(pipelineID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ClaimInfraRetry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClaimInfraRetry'
+type MockStore_ClaimInfraRetry_Call struct {
+	*mock.Call
+}
+
+// ClaimInfraRetry is a helper method to define mock.On call
+//   - pipelineID int64
+func (_e *MockStore_Expecter) ClaimInfraRetry(pipelineID interface{}) *MockStore_ClaimInfraRetry_Call {
+	return &MockStore_ClaimInfraRetry_Call{Call: _e.mock.On("ClaimInfraRetry", pipelineID)}
+}
+
+func (_c *MockStore_ClaimInfraRetry_Call) Run(run func(pipelineID int64)) *MockStore_ClaimInfraRetry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int64
+		if args[0] != nil {
+			arg0 = args[0].(int64)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ClaimInfraRetry_Call) Return(b bool, err error) *MockStore_ClaimInfraRetry_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockStore_ClaimInfraRetry_Call) RunAndReturn(run func(pipelineID int64) (bool, error)) *MockStore_ClaimInfraRetry_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Close provides a mock function for the type MockStore
 func (_mock *MockStore) Close() error {
 	ret := _mock.Called()

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -90,6 +90,10 @@ type Store interface {
 	CreatePipeline(*model.Pipeline, ...*model.Step) error
 	// UpdatePipeline updates a pipeline.
 	UpdatePipeline(*model.Pipeline) error
+	// ClaimInfraRetry atomically marks a pipeline as having had its automatic
+	// infrastructure-failure retry triggered. It returns true for the single
+	// caller that wins the claim, so concurrent Done calls cannot each restart it.
+	ClaimInfraRetry(pipelineID int64) (bool, error)
 	// DeletePipeline deletes a pipeline.
 	DeletePipeline(*model.Pipeline) error
 


### PR DESCRIPTION
## Problem

When a build runs on preemptible / spot infrastructure, a node can be reclaimed mid-step. Kubernetes takes the step's pod down (eviction, or SIGKILL → exit 137) while the agent stays connected and reports the workflow as failed. Because there is no `retry: when: system_failure` primitive (as GitLab and Buildkite have), the pipeline fails exactly like a real test failure and has to be restarted by hand.

This is distinct from an agent disconnect (#6595): here the agent is alive, so the queue's existing `resubmitExpiredPipelines` recovery never triggers. It also differs from a declarative retry directive (#884): the goal is automatic, server-side recovery that needs no per-repo opt-in.

## What this does

Detects when a step failed because the infrastructure took it down (rather than the workload itself failing) and automatically restarts the pipeline, bounded by a configurable budget. A pipeline is retried only when **every** failing step is an infrastructure failure — a single genuine failure disables the retry, so real errors are never masked.

Disabled by default (`WOODPECKER_INFRA_RETRY_MAX_ATTEMPTS=0`).

### Detection

The Kubernetes backend reads the pod's `DisruptionTarget` condition, which Kubernetes sets when it takes a pod down for preemption, eviction, or graceful node shutdown (the pod `Reason` field is used as a fallback). This is more reliable than matching exit code 137 or error strings, which are ambiguous — a workload can legitimately exit 137 on its own.

The condition is captured from informer events the moment it appears, not only from the post-completion pod read, so the signal survives the pod disappearing before a clean terminal status is observable (for example when the node is lost).

Only the Kubernetes backend sets the flag today; other backends always report `false`.

### Flow

1. The Kubernetes backend sets `State.InfraFailure` when the pod carries `DisruptionTarget` (`pipeline/backend/kubernetes`).
2. The flag travels agent → server on `StepState` (new proto field) and is persisted on the step.
3. When a pipeline finishes in a failed state, the server restarts it if every failing step is an infra failure and the attempt budget is not spent (`server/pipeline`, triggered from the `Done` RPC). The restart runs as the repo owner — the same identity cron pipelines use, since an automatic retry has no initiating user.
4. `Pipeline.InfraRetryCount` bounds the chain and is incremented atomically as part of creating the restarted pipeline, so a failed persist can never leave a stale count that retries forever.

## Configuration

`WOODPECKER_INFRA_RETRY_MAX_ATTEMPTS` (default `0`, disabled). Documented in the server configuration reference.

## Testing

Three levels.

**Unit** — the retry decision (infra-only is retried; a genuine failure, an exhausted budget, and non-failure terminal states are not) and the `DisruptionTarget` reader.

**In-process end-to-end** (`make test-e2e`) — a real server and agent over gRPC with the dummy backend, which gains a `STEP_INFRA_FAILURE` knob alongside the existing `STEP_OOM_KILLED` / `STEP_EXIT_CODE` ones. Scenarios assert that an infra-only failure auto-restarts (one retry, correct parent and count), a genuine failure does not, and the budget is a hard ceiling.

**Live cluster** (`make test-kind`, `-tags kind`) — creates a real pod on a `kind` cluster, evicts it through the Eviction API (which sets `DisruptionTarget` exactly as a spot-node preemption does), and asserts the backend's `WaitStep` returns an infra-failure state. The test was confirmed to bite: neutering the detection flips it from pass to fail (the evicted pod terminates with exit 137, but the flag stays `false` without the condition read).

Building the live-cluster test is what surfaced the informer-capture hardening described under Detection — a node-lost pod that vanished before reaching a terminal status would otherwise have been missed.

## Related

- #6595 — auto-retry on agent disconnect. This generalises that idea to any infrastructure-flagged step failure; agent disconnect is just one source.
- #884 — a declarative `retry:` directive could later consume the same `InfraFailure` signal for per-pipeline control.


## Notes for reviewers

- `rpc/proto/woodpecker.pb.go` was regenerated for the new `StepState.infra_failure` field (field 9, additive and wire-compatible). I regenerated with a locally available `protoc`; if the generator provenance comment matters, please regenerate with the project's pinned toolchain.
- The live-cluster test (`make test-kind`, build tag `kind`) needs a real Kubernetes cluster and is not wired into a CI lane — it is a local/manual proof that a real eviction sets `DisruptionTarget` and the backend detects it. The in-process e2e (`make test-e2e`) is the gating test. Happy to add a CI job for it if that's preferred.
