### PR TITLE
Recover agent from expired gRPC access token

### DIFF
--- a/agent/rpc/auth_interceptor.go
+++ b/agent/rpc/auth_interceptor.go
@@ -16,6 +16,7 @@ package rpc
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -25,8 +26,17 @@ import (
 
 // AuthInterceptor is a client interceptor for authentication.
 type AuthInterceptor struct {
-	authClient  *AuthClient
+	authClient *AuthClient
+
+	// mu guards accessToken, which is read by every outgoing RPC (attachToken)
+	// and written by both the background refresh goroutine and on-demand
+	// RefreshToken calls.
+	mu          sync.RWMutex
 	accessToken string
+
+	// refreshMu serializes re-authentication so that a burst of RPCs failing
+	// with an expired token does not trigger a stampede of Auth calls.
+	refreshMu sync.Mutex
 }
 
 // NewAuthInterceptor returns a new auth interceptor.
@@ -72,7 +82,43 @@ func (interceptor *AuthInterceptor) Stream() grpc.StreamClientInterceptor {
 }
 
 func (interceptor *AuthInterceptor) attachToken(ctx context.Context) context.Context {
-	return metadata.AppendToOutgoingContext(ctx, "token", interceptor.accessToken)
+	return metadata.AppendToOutgoingContext(ctx, "token", interceptor.Token())
+}
+
+// Token returns the access token currently in use. It is safe for concurrent
+// use.
+func (interceptor *AuthInterceptor) Token() string {
+	interceptor.mu.RLock()
+	defer interceptor.mu.RUnlock()
+	return interceptor.accessToken
+}
+
+func (interceptor *AuthInterceptor) setToken(token string) {
+	interceptor.mu.Lock()
+	defer interceptor.mu.Unlock()
+	interceptor.accessToken = token
+}
+
+// RefreshToken forces a re-authentication with the server and atomically
+// replaces the stored access token. It is used by the RPC client to recover
+// from an expired access token without waiting for the background refresh
+// timer.
+//
+// It is safe to call concurrently. Callers pass the token they last used as
+// staleToken; if another goroutine already refreshed the token in the
+// meantime, the redundant re-authentication is skipped. No token material is
+// logged.
+func (interceptor *AuthInterceptor) RefreshToken(ctx context.Context, staleToken string) error {
+	interceptor.refreshMu.Lock()
+	defer interceptor.refreshMu.Unlock()
+
+	// Another goroutine already obtained a fresh token while we were waiting
+	// for the lock; nothing to do.
+	if staleToken != "" && interceptor.Token() != staleToken {
+		return nil
+	}
+
+	return interceptor.refreshToken(ctx)
 }
 
 func (interceptor *AuthInterceptor) scheduleRefreshToken(ctx context.Context, refreshInterval time.Duration) error {
@@ -89,7 +135,11 @@ func (interceptor *AuthInterceptor) scheduleRefreshToken(ctx context.Context, re
 			case <-ctx.Done():
 				return
 			case <-time.After(wait):
+				// Serialize with on-demand RefreshToken calls so the two
+				// never race to authenticate at the same time.
+				interceptor.refreshMu.Lock()
 				err := interceptor.refreshToken(ctx)
+				interceptor.refreshMu.Unlock()
 				if err != nil {
 					wait = time.Second
 				} else {
@@ -102,13 +152,16 @@ func (interceptor *AuthInterceptor) scheduleRefreshToken(ctx context.Context, re
 	return nil
 }
 
+// refreshToken authenticates with the server and stores the new access token.
+// Callers must hold refreshMu (or be the constructor, before the refresh
+// goroutine is started).
 func (interceptor *AuthInterceptor) refreshToken(ctx context.Context) error {
 	accessToken, _, err := interceptor.authClient.Auth(ctx)
 	if err != nil {
 		return err
 	}
 
-	interceptor.accessToken = accessToken
+	interceptor.setToken(accessToken)
 	log.Trace().Msg("token refreshed")
 
 	return nil

--- a/agent/rpc/auth_recovery_integration_test.go
+++ b/agent/rpc/auth_recovery_integration_test.go
@@ -1,0 +1,266 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"go.woodpecker-ci.org/woodpecker/v3/rpc/proto"
+)
+
+// tokenRegistry records which access tokens the fake server currently accepts.
+// The fake authorizer rejects everything else with codes.Unauthenticated,
+// mirroring how the real server rejects an expired token (see
+// server/rpc/authorizer_test.go for the JWT-level coverage of that rejection).
+type tokenRegistry struct {
+	mu    sync.Mutex
+	valid map[string]bool
+}
+
+func newTokenRegistry() *tokenRegistry {
+	return &tokenRegistry{valid: make(map[string]bool)}
+}
+
+func (r *tokenRegistry) add(token string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.valid[token] = true
+}
+
+func (r *tokenRegistry) isValid(token string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.valid[token]
+}
+
+// authorize mimics server/rpc.Authorizer: it lets the Auth endpoint through
+// unauthenticated and rejects any other call whose token is not (or no longer)
+// valid.
+func (r *tokenRegistry) authorize(ctx context.Context, fullMethod string) error {
+	if fullMethod == proto.WoodpeckerAuth_Auth_FullMethodName {
+		return nil
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "metadata is not provided")
+	}
+	tokens := md.Get("token")
+	if len(tokens) == 0 || !r.isValid(tokens[0]) {
+		return status.Error(codes.Unauthenticated, "access token is invalid: token is expired")
+	}
+	return nil
+}
+
+func (r *tokenRegistry) unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	if err := r.authorize(ctx, info.FullMethod); err != nil {
+		return nil, err
+	}
+	return handler(ctx, req)
+}
+
+// fakeAuthServer hands out access tokens. The first token it issues is never
+// registered as valid, simulating the situation in issue #4144 where the agent
+// ends up holding a dead token; every subsequent token is valid. This lets us
+// assert that the agent re-authenticates and recovers on its own.
+type fakeAuthServer struct {
+	proto.UnimplementedWoodpeckerAuthServer
+
+	registry *tokenRegistry
+	agentID  int64
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *fakeAuthServer) Auth(_ context.Context, _ *proto.AuthRequest) (*proto.AuthResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+
+	token := fmt.Sprintf("token-%d", s.calls)
+	if s.calls > 1 {
+		// Only tokens issued after the first one are accepted by the server.
+		s.registry.add(token)
+	}
+
+	return &proto.AuthResponse{AccessToken: token, AgentId: s.agentID}, nil
+}
+
+func (s *fakeAuthServer) authCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// fakeWoodpeckerServer counts how many ReportHealth calls reached it after
+// passing the authorizer (i.e. with a valid token).
+type fakeWoodpeckerServer struct {
+	proto.UnimplementedWoodpeckerServer
+
+	mu                 sync.Mutex
+	authedHealthChecks int
+}
+
+func (s *fakeWoodpeckerServer) ReportHealth(_ context.Context, _ *proto.ReportHealthRequest) (*proto.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.authedHealthChecks++
+	return &proto.Empty{}, nil
+}
+
+func (s *fakeWoodpeckerServer) healthChecks() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authedHealthChecks
+}
+
+// testServer is an in-process gRPC server (over bufconn) that wires a fake
+// authorizer in front of a fake Woodpecker service, plus a fake auth service.
+type testServer struct {
+	auth   *fakeAuthServer
+	wp     *fakeWoodpeckerServer
+	dialer func(context.Context, string) (net.Conn, error)
+}
+
+func startTestServer(t *testing.T) *testServer {
+	t.Helper()
+
+	registry := newTokenRegistry()
+	ts := &testServer{
+		auth: &fakeAuthServer{registry: registry, agentID: 42},
+		wp:   &fakeWoodpeckerServer{},
+	}
+
+	lis := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(registry.unaryInterceptor))
+	proto.RegisterWoodpeckerAuthServer(grpcServer, ts.auth)
+	proto.RegisterWoodpeckerServer(grpcServer, ts.wp)
+
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+	t.Cleanup(grpcServer.Stop)
+
+	ts.dialer = func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}
+	return ts
+}
+
+func (ts *testServer) dial(t *testing.T, opts ...grpc.DialOption) *grpc.ClientConn {
+	t.Helper()
+	base := []grpc.DialOption{
+		grpc.WithContextDialer(ts.dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	conn, err := grpc.NewClient("passthrough:///bufnet", append(base, opts...)...)
+	require.NoError(t, err)
+	return conn
+}
+
+// TestExpiredTokenRecovery is the regression test for issue #4144: an agent that
+// starts out holding a rejected (expired) access token must re-authenticate and
+// retry the failed RPC instead of staying stuck.
+func TestExpiredTokenRecovery(t *testing.T) {
+	ts := startTestServer(t)
+	ctx := t.Context()
+
+	authConn := ts.dial(t)
+	defer authConn.Close()
+
+	authClient := NewAuthGrpcClient(authConn, "agent-secret", 42)
+	// Long refresh interval so the background timer never fires during the
+	// test; recovery must come purely from the on-demand refresh path.
+	interceptor, err := NewAuthInterceptor(ctx, authClient, time.Hour)
+	require.NoError(t, err)
+
+	// The interceptor authenticated once during construction and is now holding
+	// the token the server will reject.
+	require.Equal(t, 1, ts.auth.authCalls())
+	expired := interceptor.Token()
+	require.NotEmpty(t, expired)
+
+	mainConn := ts.dial(
+		t,
+		grpc.WithUnaryInterceptor(interceptor.Unary()),
+		grpc.WithStreamInterceptor(interceptor.Stream()),
+	)
+	defer mainConn.Close()
+
+	client := NewGrpcClient(
+		ctx, mainConn,
+		SetConnectionRetryTimeout(30*time.Second),
+		SetAuthRefresher(interceptor),
+	)
+
+	// This RPC initially carries the rejected token. The client must
+	// transparently re-authenticate and retry.
+	err = client.ReportHealth(ctx)
+	require.NoError(t, err, "ReportHealth should succeed after re-authentication")
+
+	// The agent re-authenticated (a second Auth call happened) and replaced the
+	// dead token, and the retried RPC reached the server.
+	assert.GreaterOrEqual(t, ts.auth.authCalls(), 2, "expected a re-authentication")
+	assert.NotEqual(t, expired, interceptor.Token(), "expired token should have been replaced")
+	assert.GreaterOrEqual(t, ts.wp.healthChecks(), 1, "an authenticated ReportHealth should reach the server")
+}
+
+// TestRefreshTokenDedup proves that concurrent RefreshToken calls sharing the
+// same stale token collapse into a single re-authentication, so a burst of
+// RPCs failing at once does not stampede the auth server.
+func TestRefreshTokenDedup(t *testing.T) {
+	ts := startTestServer(t)
+	ctx := t.Context()
+
+	authConn := ts.dial(t)
+	defer authConn.Close()
+
+	authClient := NewAuthGrpcClient(authConn, "agent-secret", 42)
+	interceptor, err := NewAuthInterceptor(ctx, authClient, time.Hour)
+	require.NoError(t, err)
+
+	stale := interceptor.Token()
+	require.Equal(t, 1, ts.auth.authCalls())
+
+	// Fire many concurrent refreshes that all observed the same stale token.
+	// Exactly one of them should reach the server; the rest see the token has
+	// already changed and skip.
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, interceptor.RefreshToken(ctx, stale))
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 2, ts.auth.authCalls(), "concurrent stale refreshes should collapse into one re-auth")
+	assert.NotEqual(t, stale, interceptor.Token())
+}

--- a/agent/rpc/auth_refresh_test.go
+++ b/agent/rpc/auth_refresh_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeRefresher is a test double for the auth interceptor. Each RefreshToken
+// call hands out a new, unique token value.
+type fakeRefresher struct {
+	mu         sync.Mutex
+	token      string
+	gen        int
+	refreshN   int
+	refreshErr error
+}
+
+func (f *fakeRefresher) Token() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.token
+}
+
+func (f *fakeRefresher) RefreshToken(_ context.Context, staleToken string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.refreshN++
+	if f.refreshErr != nil {
+		return f.refreshErr
+	}
+	// Mimic the real dedup: only rotate when the caller's token is still current.
+	if staleToken == "" || staleToken == f.token {
+		f.gen++
+		f.token = fmt.Sprintf("token-%d", f.gen)
+	}
+	return nil
+}
+
+func (f *fakeRefresher) refreshCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.refreshN
+}
+
+func isPermanent(err error) bool {
+	var perm *backoff.PermanentError
+	return errors.As(err, &perm)
+}
+
+func TestWithAuthRefresh(t *testing.T) {
+	unauth := status.Error(codes.Unauthenticated, "token is expired")
+
+	t.Run("recovers after one refresh", func(t *testing.T) {
+		fr := &fakeRefresher{token: "token-0"}
+		c := &client{auth: fr}
+
+		var calls int
+		op := func() (int, error) {
+			calls++
+			if calls == 1 {
+				return 0, unauth // first attempt: expired token
+			}
+			return 7, nil // after refresh: success
+		}
+
+		wrapped := withAuthRefresh(context.Background(), c, "test", op)
+
+		// First invocation hits the expired token, triggers a refresh, and
+		// returns a retryable error so backoff will call us again.
+		_, err := wrapped()
+		require.Error(t, err)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+		assert.False(t, isPermanent(err))
+		assert.Equal(t, 1, fr.refreshCalls())
+
+		// Second invocation succeeds with the refreshed token.
+		res, err := wrapped()
+		require.NoError(t, err)
+		assert.Equal(t, 7, res)
+		assert.Equal(t, 1, fr.refreshCalls(), "should not refresh again on success")
+	})
+
+	t.Run("gives up after maxAuthRefreshes", func(t *testing.T) {
+		fr := &fakeRefresher{token: "token-0"}
+		c := &client{auth: fr}
+
+		op := func() (int, error) { return 0, unauth } // never accepted
+
+		wrapped := withAuthRefresh(context.Background(), c, "test", op)
+
+		// The first maxAuthRefreshes failures stay retryable and each refreshes.
+		for i := 0; i < maxAuthRefreshes; i++ {
+			_, err := wrapped()
+			require.Error(t, err)
+			assert.False(t, isPermanent(err), "attempt %d should still be retryable", i)
+		}
+		assert.Equal(t, maxAuthRefreshes, fr.refreshCalls())
+
+		// The next failure exhausts the budget and becomes permanent so the
+		// RPC returns instead of looping forever on a dead token.
+		_, err := wrapped()
+		require.Error(t, err)
+		assert.True(t, isPermanent(err), "should be permanent once refreshes are exhausted")
+		assert.Equal(t, maxAuthRefreshes, fr.refreshCalls(), "no further refresh after giving up")
+	})
+
+	t.Run("keeps retrying when refresh itself fails", func(t *testing.T) {
+		fr := &fakeRefresher{token: "token-0", refreshErr: errors.New("server down")}
+		c := &client{auth: fr}
+
+		op := func() (int, error) { return 0, unauth }
+		wrapped := withAuthRefresh(context.Background(), c, "test", op)
+
+		// A failing refresh must not make the error permanent before the budget
+		// is exhausted — backoff should wait and try again.
+		_, err := wrapped()
+		require.Error(t, err)
+		assert.False(t, isPermanent(err))
+		assert.Equal(t, 1, fr.refreshCalls())
+	})
+
+	t.Run("passes non-auth errors through untouched", func(t *testing.T) {
+		fr := &fakeRefresher{token: "token-0"}
+		c := &client{auth: fr}
+
+		other := status.Error(codes.Unavailable, "try later")
+		op := func() (int, error) { return 0, other }
+		wrapped := withAuthRefresh(context.Background(), c, "test", op)
+
+		_, err := wrapped()
+		assert.Equal(t, other, err)
+		assert.Equal(t, 0, fr.refreshCalls(), "non-auth errors must not trigger a refresh")
+	})
+
+	t.Run("nil refresher makes unauthenticated permanent", func(t *testing.T) {
+		c := &client{} // no auth refresher configured
+
+		op := func() (int, error) { return 0, unauth }
+		wrapped := withAuthRefresh(context.Background(), c, "test", op)
+
+		_, err := wrapped()
+		require.Error(t, err)
+		assert.True(t, isPermanent(err))
+	})
+}
+
+// TestAuthInterceptorTokenConcurrency exercises Token()/setToken under the race
+// detector to prove access to the stored token is concurrency-safe.
+func TestAuthInterceptorTokenConcurrency(t *testing.T) {
+	interceptor := &AuthInterceptor{accessToken: "initial"}
+
+	var wg sync.WaitGroup
+	var writes int64
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 1000 {
+				interceptor.setToken(fmt.Sprintf("token-%d", i))
+				atomic.AddInt64(&writes, 1)
+			}
+		}()
+	}
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 1000 {
+				_ = interceptor.Token()
+				_ = interceptor.attachToken(context.Background())
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int64(8000), writes)
+	assert.NotEmpty(t, interceptor.Token())
+}

--- a/agent/rpc/client_grpc.go
+++ b/agent/rpc/client_grpc.go
@@ -50,12 +50,35 @@ const (
 	// Maximum amount of time between sending consecutive batched log messages.
 	// Controls the delay between the CI job generating a log record, and web users receiving it.
 	maxLogFlushPeriod time.Duration = time.Second
+
+	// Maximum number of times a single RPC will re-authenticate and retry after
+	// the server rejects its access token with codes.Unauthenticated. It
+	// prevents an infinite refresh/retry loop when re-authentication does not
+	// resolve the rejection (e.g. a revoked agent secret) — even when
+	// connectionRetryTimeout is infinite.
+	maxAuthRefreshes int = 2
 )
+
+// tokenRefresher lets the RPC client force a re-authentication after the
+// server rejects the current access token (most commonly because it expired).
+// It is implemented by *AuthInterceptor.
+type tokenRefresher interface {
+	// Token returns the access token currently in use.
+	Token() string
+	// RefreshToken re-authenticates and replaces the stored access token.
+	// staleToken is the token the caller last used; if the stored token has
+	// already changed, the refresh is skipped.
+	RefreshToken(ctx context.Context, staleToken string) error
+}
 
 type client struct {
 	client proto.WoodpeckerClient
 	conn   *grpc.ClientConn
 	logs   chan *proto.LogEntry
+	// auth re-authenticates the agent when an RPC fails with
+	// codes.Unauthenticated. It may be nil (e.g. in tests), in which case
+	// Unauthenticated errors are treated as permanent.
+	auth tokenRefresher
 	// connectionRetryTimeout is the maximum time to wait for a connection to be
 	// restored before the agent gives up and exits. Zero means infinite.
 	// Maps directly onto backoff.WithMaxElapsedTime.
@@ -85,6 +108,14 @@ func SetConnectionRetryTimeout(d time.Duration) ClientOption {
 	}
 	return func(c *client) {
 		c.connectionRetryTimeout = d
+	}
+}
+
+// SetAuthRefresher wires the auth interceptor into the client so that RPCs
+// rejected with codes.Unauthenticated trigger a re-authentication and retry.
+func SetAuthRefresher(a tokenRefresher) ClientOption {
+	return func(c *client) {
+		c.auth = a
 	}
 }
 
@@ -141,7 +172,7 @@ func (c *client) retryOpts(op string) []backoff.RetryOption {
 //   - returning backoff.Permanent(err) for unrecoverable gRPC codes
 //   - returning the raw error for retryable codes (Aborted/DataLoss/...)
 func retryRPC[T any](ctx context.Context, c *client, opName string, op backoff.Operation[T]) (T, error) {
-	res, err := backoff.Retry(ctx, op, c.retryOpts(opName)...)
+	res, err := backoff.Retry(ctx, withAuthRefresh(ctx, c, opName, op), c.retryOpts(opName)...)
 	if err == nil {
 		return res, nil
 	}
@@ -165,6 +196,58 @@ func retryRPC[T any](ctx context.Context, c *client, opName string, op backoff.O
 	return zero, err
 }
 
+// withAuthRefresh wraps an RPC operation so that, when it fails with
+// codes.Unauthenticated (typically an expired access token), the client
+// re-authenticates and lets backoff retry the call. Without this, an expired
+// token would never be replaced on demand and the agent would stay stuck
+// retrying with a dead token (see issue #4144).
+//
+// Re-authentication is attempted at most maxAuthRefreshes times per RPC; once
+// exhausted the error is made permanent so the call returns and the failure
+// surfaces to the caller (and ultimately the agent's supervisor). If no
+// refresher is configured, the wrapper is a no-op and Unauthenticated stays
+// permanent.
+func withAuthRefresh[T any](ctx context.Context, c *client, opName string, op backoff.Operation[T]) backoff.Operation[T] {
+	if c.auth == nil {
+		// Without a refresher there is no way to recover from an auth
+		// rejection, so keep codes.Unauthenticated permanent (the behavior
+		// before on-demand refresh existed).
+		return func() (T, error) {
+			res, err := op()
+			if err != nil && status.Code(err) == codes.Unauthenticated {
+				return res, backoff.Permanent(err)
+			}
+			return res, err
+		}
+	}
+
+	refreshes := 0
+	return func() (T, error) {
+		res, err := op()
+		if err == nil || status.Code(err) != codes.Unauthenticated {
+			return res, err
+		}
+
+		if refreshes >= maxAuthRefreshes {
+			log.Error().Msgf("grpc: %s(): access token still rejected after %d re-authentication attempts, giving up", opName, refreshes)
+			return res, backoff.Permanent(err)
+		}
+		refreshes++
+
+		staleToken := c.auth.Token()
+		log.Warn().Msgf("grpc: %s(): access token rejected by server, re-authenticating (attempt %d/%d)", opName, refreshes, maxAuthRefreshes)
+		if rerr := c.auth.RefreshToken(ctx, staleToken); rerr != nil {
+			// Re-auth itself failed (e.g. server briefly unreachable); keep the
+			// error retryable so backoff waits and we try again on the next
+			// iteration, up to maxAuthRefreshes.
+			log.Error().Err(rerr).Msgf("grpc: %s(): re-authentication failed", opName)
+		}
+		// Return the original (retryable) error so backoff retries the RPC,
+		// this time with the refreshed token attached by the interceptor.
+		return res, err
+	}
+}
+
 // classifyRPCErr inspects a gRPC error and returns either the same error (for
 // retryable codes) or a backoff.Permanent wrapping it (for fatal codes). It is
 // the single source of truth for which gRPC codes are worth retrying.
@@ -181,6 +264,11 @@ func classifyRPCErr(ctx context.Context, err error) error {
 			return backoff.Permanent(ctx.Err())
 		}
 		return backoff.Permanent(err)
+	case codes.Unauthenticated:
+		// The access token was rejected, most commonly because it expired.
+		// Keep it retryable so withAuthRefresh can re-authenticate and retry;
+		// the retry count there bounds how long we keep trying.
+		return err
 	case codes.Aborted,
 		codes.DataLoss,
 		codes.DeadlineExceeded,

--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -137,6 +137,9 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 	client := agent_rpc.NewGrpcClient(
 		ctx, agentConn.MainConn,
 		agent_rpc.SetConnectionRetryTimeout(c.Duration("retry-timeout")),
+		// Allow RPCs to re-authenticate and retry if the server rejects an
+		// expired access token, instead of getting stuck (issue #4144).
+		agent_rpc.SetAuthRefresher(agentConn.AuthInterceptor),
 	)
 	agentConfigPersisted := atomic.Bool{}
 


### PR DESCRIPTION
## Summary

Fixes an issue where an agent could get permanently stuck using an expired gRPC access token.

The agent stored its access token as a plain string refreshed only on a 30-minute timer. When the server rejected a token with `codes.Unauthenticated` (typically because it expired), there was no recovery path: the error was classified as **permanent**, so the agent's RPC loops (`next()`, `report_health()`, workflow init/wait, …) kept retrying with the dead token and never recovered, orphaning queued/pending workflows. The token field was also read and written across goroutines without synchronization.

## Changes

- **`agent/rpc/auth_interceptor.go`** — the access token is now guarded by a `sync.RWMutex` (`Token()` / `setToken()`). A new exported `RefreshToken(ctx, staleToken)` forces re-authentication; a `refreshMu` serializes it with the background refresh timer, and the `staleToken` check collapses a burst of concurrent refreshes into a single `Auth` call (no stampede). No token material is logged.
- **`agent/rpc/client_grpc.go`** — new optional `tokenRefresher` wired via `SetAuthRefresher`. `classifyRPCErr` now treats `codes.Unauthenticated` as retryable, and `withAuthRefresh` re-authenticates and lets backoff retry with the fresh token, bounded by `maxAuthRefreshes` so a genuinely bad/revoked secret cannot loop forever (even with an infinite connection-retry timeout). When no refresher is configured the code stays permanent — preserving previous behavior.
- **`cmd/agent/core/agent.go`** — wires the auth interceptor into the client.

## Behavior / config

No public configuration changes. The existing 30-minute refresh timer still handles the normal case; this adds a **reactive** safety net for cases the timer path missed (e.g. server restart during a refresh window).

## Tests

- `TestExpiredTokenRecovery` — over an in-process gRPC server, an agent starting with a rejected (expired) token re-authenticates and the retried RPC succeeds.
- `TestRefreshTokenDedup` — concurrent refreshes sharing a stale token collapse into a single re-auth.
- `TestWithAuthRefresh` — recovery-after-refresh, give-up-after-budget, refresh-failure-stays-retryable, non-auth-errors pass through, nil-refresher stays permanent.
- `TestAuthInterceptorTokenConcurrency` — token access is race-free under `-race`.

All pass under `make test-agent` and `make lint` (golangci-lint) is clean.

Closes #4144