### PR TITLE
Fix issue with deeply nested k8s backend_options

### DIFF
--- a/pipeline/frontend/yaml/parse.go
+++ b/pipeline/frontend/yaml/parse.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	// Set to allow deeply nested k8s backend_options for node affinity
+	// Set to allow deeply nested k8s backend_options for node affinity.
 	maxMergeDepth uint16 = 15
 )
 

--- a/pipeline/frontend/yaml/parse.go
+++ b/pipeline/frontend/yaml/parse.go
@@ -20,10 +20,16 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/yaml/types"
 )
 
+const (
+	// Set to allow deeply nested k8s backend_options for node affinity
+	maxMergeDepth uint16 = 15
+)
+
 // ParseBytes parses the configuration from bytes b.
 func ParseBytes(b []byte) (*types.Workflow, error) {
+	parser := xyaml.NewParser(xyaml.WithDepth(maxMergeDepth))
 	out := new(types.Workflow)
-	err := xyaml.Unmarshal(b, out)
+	err := parser.Unmarshal(b, out)
 	if err != nil {
 		return nil, err
 	}

--- a/pipeline/frontend/yaml/parse_test.go
+++ b/pipeline/frontend/yaml/parse_test.go
@@ -77,6 +77,11 @@ func TestParse(t *testing.T) {
 		assert.Equal(t, "plugins/slack", out.Steps.ContainerList[1].Image)
 		assert.Equal(t, yaml_base_types.StringOrSlice{"push"}, out.Steps.ContainerList[1].When.Constraints[0].Event)
 	})
+
+	t.Run("Should handle deeply nested yaml", func(t *testing.T) {
+		_, err := ParseString(sampleDeepYaml)
+		assert.NoError(t, err)
+	})
 }
 
 func TestMatch(t *testing.T) {
@@ -243,6 +248,30 @@ steps:
     environment:
       DRIVER: next
       PLATFORM: linux
+`
+
+var sampleDeepYaml = `
+image: hello-world
+when:
+  - branch:
+    - tester
+steps:
+  test:
+    image: golang
+    commands:
+      - go install
+      - go test
+    backend_options:
+      kubernetes:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: accelerator
+                      operator: In
+                      values:
+                        - nvidia-tesla-v100
 `
 
 func TestReSerialize(t *testing.T) {


### PR DESCRIPTION
Hello Woodpecker team,

this PR fixes #6493.

It also adds a UT using the [nodeAffinity example from the docs](https://woodpecker-ci.org/docs/administration/configuration/backends/kubernetes#example-node-affinity-for-gpu-workloads).

I chose the current max depth value of `15` because that's the value necessary to make the UT pass.  

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
