### PR TITLE
adds git-pages plugin

### DIFF
--- a/docs/plugins/woodpecker-plugins/plugins.json
+++ b/docs/plugins/woodpecker-plugins/plugins.json
@@ -329,6 +329,11 @@
       "name": "Podman",
       "docs": "https://codeberg.org/head1328/woodpecker-ci-plugin-podman/raw/branch/main/docs.md",
       "verified": false
+    },
+    {
+      "name": "Git-pages",
+      "docs": "https://codeberg.org/gedankenstuecke/git-pages-woodpecker-plugin/raw/branch/main/README.md",
+      "verified": false
     }
   ]
 }


### PR DESCRIPTION
Adds a `git-pages` plugin which allows pushing the outputs of a build into a git-pages server, as deployed e.g. on https://grebedoc.dev/ or Codeberg Pages, mostly mirroring the functionality of [the forgejo action](https://codeberg.org/git-pages/action)
