### PR TITLE
Harden agent rpc to check agentID on workflow

### DIFF
--- a/server/rpc/errors.go
+++ b/server/rpc/errors.go
@@ -22,6 +22,6 @@ var (
 
 	ErrAgentIllegalLogStreaming = errors.New("agent can not append logs to a step that is marked not running")
 
-	ErrAgentIllegalRepo           = errors.New("agent is not allowed to interact with repo")
-	ErrAgentIllegalWorflowAgentID = errors.New("agent is not allowed to interact with workflow where it's id is not already locked")
+	ErrAgentIllegalRepo            = errors.New("agent is not allowed to interact with repo")
+	ErrAgentIllegalWorkflowAgentID = errors.New("agent is not allowed to interact with workflow where it's id is not already locked")
 )

--- a/server/rpc/errors.go
+++ b/server/rpc/errors.go
@@ -22,5 +22,6 @@ var (
 
 	ErrAgentIllegalLogStreaming = errors.New("agent can not append logs to a step that is marked not running")
 
-	ErrAgentIllegalRepo = errors.New("agent is not allowed to interact with repo")
+	ErrAgentIllegalRepo           = errors.New("agent is not allowed to interact with repo")
+	ErrAgentIllegalWorflowAgentID = errors.New("agent is not allowed to interact with workflow where it's id is not already locked")
 )

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -83,10 +83,16 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 
 	log.Trace().Msgf("Agent %s[%d] tries to pull task with labels: %v", agent.Name, agent.ID, agentFilter.Labels)
 
-	return s.scheduler.Poll(c, agent.ID, agentFilter, func(taskID string) error {
+	rpcWorkflow, err := s.scheduler.Poll(c, agent.ID, agentFilter, func(taskID string) error {
 		// a skipped workflow is finalized through the regular Done flow
 		return s.Done(c, taskID, rpc.WorkflowState{})
 	})
+
+	if err := s.lockAgentToWorkflow(c, agent, rpcWorkflow.ID); err != nil {
+		return nil, err
+	}
+
+	return rpcWorkflow, nil
 }
 
 // Wait blocks until the workflow with the given ID is completed or got canceled.
@@ -240,8 +246,6 @@ func (s *RPC) Init(c context.Context, strWorkflowID string, state rpc.WorkflowSt
 	if err != nil {
 		return err
 	}
-
-	workflow.AgentID = agent.ID
 
 	currentPipeline, err := s.store.GetPipeline(workflow.PipelineID)
 	if err != nil {

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -84,7 +84,12 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 	log.Trace().Msgf("Agent %s[%d] tries to pull task with labels: %v", agent.Name, agent.ID, agentFilter.Labels)
 
 	rpcWorkflow, err := s.scheduler.Poll(c, agent.ID, agentFilter, func(taskID string) error {
-		// a skipped workflow is finalized through the regular Done flow
+		// a skipped workflow is finalized through the regular Done flow; it
+		// was never initialized by an agent, so lock it to this agent first
+		// to satisfy the workflow ownership check.
+		if err := s.lockAgentToWorkflow(c, agent, taskID); err != nil {
+			return err
+		}
 		return s.Done(c, taskID, rpc.WorkflowState{})
 	})
 	if err != nil || rpcWorkflow == nil {

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -434,8 +434,14 @@ func (s *RPC) Log(c context.Context, stepUUID string, rpcLogEntries []*rpc.LogEn
 		return err
 	}
 
+	workflow, err := s.store.WorkflowByStep(step)
+	if err != nil {
+		log.Error().Err(err).Msgf("cannot find workflow for step uuid %s", stepUUID)
+		return err
+	}
+
 	// check before agent can alter some state
-	if err := s.checkAgentPermissionByWorkflow(c, agent, "", currentPipeline, nil); err != nil {
+	if err := s.checkAgentPermissionByWorkflow(c, agent, strconv.FormatInt(workflow.ID, 10), currentPipeline, nil); err != nil {
 		return err
 	}
 

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -87,6 +87,9 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 		// a skipped workflow is finalized through the regular Done flow
 		return s.Done(c, taskID, rpc.WorkflowState{})
 	})
+	if err != nil || rpcWorkflow == nil {
+		return nil, err
+	}
 
 	if err := s.lockAgentToWorkflow(c, agent, rpcWorkflow.ID); err != nil {
 		return nil, err

--- a/server/rpc/rpc_integration_test.go
+++ b/server/rpc/rpc_integration_test.go
@@ -99,6 +99,7 @@ func defaultWorkflow(state model.StatusValue) *model.Workflow {
 	return &model.Workflow{
 		ID:         30,
 		PipelineID: 20,
+		AgentID:    1,
 		State:      state,
 		Name:       "test-workflow",
 	}

--- a/server/rpc/rpc_integration_test.go
+++ b/server/rpc/rpc_integration_test.go
@@ -577,6 +577,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusRunning)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -606,6 +608,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusSuccess)         // but step already finished
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -633,6 +637,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusRunning)       // but step is still running
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -660,6 +666,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusSuccess)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -682,6 +690,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusSuccess)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -704,6 +714,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusFailure)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -725,6 +737,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusPending)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -747,6 +761,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusSuccess)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -768,6 +784,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusKilled)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -794,6 +812,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusRunning)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(1)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
@@ -819,6 +839,8 @@ func TestRPCLog(t *testing.T) {
 		step := defaultStep(model.StatusRunning)
 
 		mockStore.On("StepByUUID", "step-uuid-123").Return(step, nil)
+		mockStore.On("WorkflowByStep", mock.Anything).Return(defaultWorkflow(model.StatusRunning), nil)
+		mockStore.On("WorkflowLoad", int64(30)).Return(defaultWorkflow(model.StatusRunning), nil)
 		mockStore.On("AgentFind", int64(2)).Return(agent, nil)
 		mockStore.On("GetPipeline", int64(20)).Return(pipeline, nil)
 		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)

--- a/server/rpc/sanitize.go
+++ b/server/rpc/sanitize.go
@@ -30,19 +30,18 @@ import (
 const logStreamDelayAllowed = 5 * time.Minute
 
 func (s *RPC) checkAgentPermissionByWorkflow(_ context.Context, agent *model.Agent, strWorkflowID string, p *model.Pipeline, repo *model.Repo) error {
-	var err error
+	workflowID, err := strconv.ParseInt(strWorkflowID, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	workflow, err := s.store.WorkflowLoad(workflowID)
+	if err != nil {
+		log.Error().Err(err).Msgf("cannot find workflow with id %d", workflowID)
+		return err
+	}
+
 	if repo == nil && p == nil {
-		workflowID, err := strconv.ParseInt(strWorkflowID, 10, 64)
-		if err != nil {
-			return err
-		}
-
-		workflow, err := s.store.WorkflowLoad(workflowID)
-		if err != nil {
-			log.Error().Err(err).Msgf("cannot find workflow with id %d", workflowID)
-			return err
-		}
-
 		p, err = s.store.GetPipeline(workflow.PipelineID)
 		if err != nil {
 			log.Error().Err(err).Msgf("cannot find pipeline with id %d", workflow.PipelineID)
@@ -58,12 +57,33 @@ func (s *RPC) checkAgentPermissionByWorkflow(_ context.Context, agent *model.Age
 		}
 	}
 
-	if agent.CanAccessRepo(repo) {
-		return nil
+	if !agent.CanAccessRepo(repo) {
+		log.Error().Err(ErrAgentIllegalRepo).Int64("agentID", agent.ID).Int64("repoId", repo.ID).Send()
+		return fmt.Errorf("%w: agentId=%d repoID=%d", ErrAgentIllegalRepo, agent.ID, repo.ID)
 	}
 
-	log.Error().Err(ErrAgentIllegalRepo).Int64("agentID", agent.ID).Int64("repoId", repo.ID).Send()
-	return fmt.Errorf("%w: agentId=%d repoID=%d", ErrAgentIllegalRepo, agent.ID, repo.ID)
+	if workflow.AgentID != agent.ID {
+		log.Error().Err(ErrAgentIllegalWorflowAgentID).Int64("agentID", agent.ID).Int64("workflowAgentId", workflow.AgentID).Send()
+		return fmt.Errorf("%w: agentId=%d workflowAgentId=%d", ErrAgentIllegalWorflowAgentID, agent.ID, workflow.AgentID)
+	}
+
+	return nil
+}
+
+func (s *RPC) lockAgentToWorkflow(_ context.Context, agent *model.Agent, strWorkflowID string) error {
+	workflowID, err := strconv.ParseInt(strWorkflowID, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	workflow, err := s.store.WorkflowLoad(workflowID)
+	if err != nil {
+		log.Error().Err(err).Msgf("cannot find workflow with id %d", workflowID)
+		return err
+	}
+
+	workflow.AgentID = agent.ID
+	return s.store.WorkflowUpdate(workflow)
 }
 
 // isActiveState returns true for states where work is in progress or not yet started.

--- a/server/rpc/sanitize.go
+++ b/server/rpc/sanitize.go
@@ -63,8 +63,8 @@ func (s *RPC) checkAgentPermissionByWorkflow(_ context.Context, agent *model.Age
 	}
 
 	if workflow.AgentID != agent.ID {
-		log.Error().Err(ErrAgentIllegalWorflowAgentID).Int64("agentID", agent.ID).Int64("workflowAgentId", workflow.AgentID).Send()
-		return fmt.Errorf("%w: agentId=%d workflowAgentId=%d", ErrAgentIllegalWorflowAgentID, agent.ID, workflow.AgentID)
+		log.Error().Err(ErrAgentIllegalWorkflowAgentID).Int64("agentID", agent.ID).Int64("workflowAgentId", workflow.AgentID).Send()
+		return fmt.Errorf("%w: agentId=%d workflowAgentId=%d", ErrAgentIllegalWorkflowAgentID, agent.ID, workflow.AgentID)
 	}
 
 	return nil

--- a/server/store/datastore/workflow.go
+++ b/server/store/datastore/workflow.go
@@ -127,6 +127,16 @@ func (s storage) WorkflowLoad(id int64) (*model.Workflow, error) {
 	return workflow, wrapGet(s.engine.ID(id).Get(workflow))
 }
 
+// WorkflowByStep returns the workflow a step belongs to. A step's parent
+// positional id (PPID) equals the workflow's PID within the same pipeline.
+func (s storage) WorkflowByStep(step *model.Step) (*model.Workflow, error) {
+	workflow := new(model.Workflow)
+	return workflow, wrapGet(s.engine.
+		Where("pipeline_id = ?", step.PipelineID).
+		Where("pid = ?", step.PPID).
+		Get(workflow))
+}
+
 func (s storage) WorkflowUpdate(workflow *model.Workflow) error {
 	_, err := s.engine.ID(workflow.ID).AllCols().Update(workflow)
 	return err

--- a/server/store/mocks/mock_Store.go
+++ b/server/store/mocks/mock_Store.go
@@ -6398,6 +6398,68 @@ func (_c *MockStore_WorkflowGetTree_Call) RunAndReturn(run func(pipeline *model.
 }
 
 // WorkflowLoad provides a mock function for the type MockStore
+// WorkflowByStep provides a mock function for the type MockStore
+func (_mock *MockStore) WorkflowByStep(step *model.Step) (*model.Workflow, error) {
+	ret := _mock.Called(step)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WorkflowByStep")
+	}
+
+	var r0 *model.Workflow
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*model.Step) (*model.Workflow, error)); ok {
+		return returnFunc(step)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*model.Step) *model.Workflow); ok {
+		r0 = returnFunc(step)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Workflow)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(*model.Step) error); ok {
+		r1 = returnFunc(step)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_WorkflowByStep_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WorkflowByStep'
+type MockStore_WorkflowByStep_Call struct {
+	*mock.Call
+}
+
+// WorkflowByStep is a helper method to define mock.On call
+//   - step *model.Step
+func (_e *MockStore_Expecter) WorkflowByStep(step interface{}) *MockStore_WorkflowByStep_Call {
+	return &MockStore_WorkflowByStep_Call{Call: _e.mock.On("WorkflowByStep", step)}
+}
+
+func (_c *MockStore_WorkflowByStep_Call) Run(run func(step *model.Step)) *MockStore_WorkflowByStep_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *model.Step
+		if args[0] != nil {
+			arg0 = args[0].(*model.Step)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_WorkflowByStep_Call) Return(workflow *model.Workflow, err error) *MockStore_WorkflowByStep_Call {
+	_c.Call.Return(workflow, err)
+	return _c
+}
+
+func (_c *MockStore_WorkflowByStep_Call) RunAndReturn(run func(step *model.Step) (*model.Workflow, error)) *MockStore_WorkflowByStep_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 func (_mock *MockStore) WorkflowLoad(n int64) (*model.Workflow, error) {
 	ret := _mock.Called(n)
 

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -189,6 +189,7 @@ type Store interface {
 	WorkflowsCreate([]*model.Workflow) error
 	WorkflowsReplace(*model.Pipeline, []*model.Workflow) error
 	WorkflowLoad(int64) (*model.Workflow, error)
+	WorkflowByStep(*model.Step) (*model.Workflow, error)
 	WorkflowUpdate(*model.Workflow) error
 
 	// Org


### PR DESCRIPTION
We now assign on Next, right when the agent that got the workflow, the agent ID to the workflow.
Later each call checks that this is still the same.

PS: shout-out to `Yaohui Wang` for finding this edgecase (it is not worth a CVE etc... as the security boundary's stay the same nontheless)