### PR TITLE
server queue api should ignore missing agent

### DIFF
--- a/server/api/queue.go
+++ b/server/api/queue.go
@@ -138,7 +138,7 @@ func processQueueTasks(store store.Store, tasks []*model.Task, agentNameMap map[
 		if task.AgentID != 0 {
 			name, ok := getAgentName(store, agentNameMap, task.AgentID)
 			if !ok {
-				return nil, fmt.Errorf("agent not found for task %s", task.ID)
+				log.Error().Msgf("agent not found for task %s", task.ID)
 			}
 
 			taskResponse.AgentName = name

--- a/server/api/queue.go
+++ b/server/api/queue.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"

--- a/server/api/queue_test.go
+++ b/server/api/queue_test.go
@@ -130,7 +130,7 @@ func TestGetQueueInfo(t *testing.T) {
 		assert.Empty(t, got.WaitingOnDeps)
 	})
 
-	t.Run("unknown agent returns internal error", func(t *testing.T) {
+	t.Run("unknown agent is ignored", func(t *testing.T) {
 		pipe := seedPipeline(t, s, repo.ID)
 		info := queue.InfoT{Running: []*model.Task{
 			{ID: "1", AgentID: 99999, PipelineID: pipe.ID, RepoID: repo.ID},
@@ -142,8 +142,12 @@ func TestGetQueueInfo(t *testing.T) {
 		tc := newTestContext(t, s)
 		GetQueueInfo(tc.Ctx)
 
-		assert.Equal(t, http.StatusInternalServerError, tc.Recorder.Code)
-		assert.Contains(t, tc.Recorder.Body.String(), "agent not found")
+		require.Equal(t, http.StatusOK, tc.Recorder.Code)
+		var got model.QueueInfo
+		tc.decodeJSON(t, &got)
+		require.Len(t, got.Running, 1)
+		assert.Equal(t, "1", got.Running[0].ID)
+		assert.Empty(t, got.Running[0].AgentName)
 	})
 
 	t.Run("unknown pipeline returns internal error", func(t *testing.T) {


### PR DESCRIPTION
close #6615

agents can be deleted ... so ignore missing ones for a hard api fail.

still an agent should not be able to be deleted as long as an task is assigned ... well...