### PR TITLE
server should drop stale queue tasks already missing in database

### DIFF
--- a/server/queue/persistent.go
+++ b/server/queue/persistent.go
@@ -67,6 +67,17 @@ func (q *persistentQueue) Poll(c context.Context, agentID int64, f func(*model.T
 	if task != nil {
 		log.Debug().Msgf("pull queue item: %s: remove from backup", task.ID)
 		if deleteErr := q.store.TaskDelete(task.ID); deleteErr != nil {
+			if errors.Is(deleteErr, types.ErrRecordNotExist) {
+				// The task is no longer in the backup store, which means it was
+				// already finished/removed (e.g. its workflow was canceled) and
+				// only lingered in the in-memory queue. Handing it to the agent
+				// would loop forever, so drop it from the queue instead.
+				log.Error().Err(deleteErr).Msgf("pull queue item: %s: not found in backup, dropping stale task", task.ID)
+				if dropErr := q.Queue.Error(c, task.ID, deleteErr); dropErr != nil {
+					log.Error().Err(dropErr).Msgf("pull queue item: %s: failed to drop stale task", task.ID)
+				}
+				return nil, nil
+			}
 			log.Error().Err(deleteErr).Msgf("pull queue item: %s: failed to remove from backup", task.ID)
 		} else {
 			log.Debug().Msgf("pull queue item: %s: successfully removed from backup", task.ID)

--- a/server/queue/persistent_test.go
+++ b/server/queue/persistent_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
+)
+
+// A task that lingers in the in-memory queue but is already gone from the
+// backup store must be dropped on Poll instead of being handed to the agent,
+// otherwise it loops forever (re-poll, illegal-instruction, resubmit).
+func TestPersistentQueuePollDropsStaleTask(t *testing.T) {
+	ctx, cancel, q := setupTestQueue(t)
+	defer cancel(nil)
+
+	store := store_mocks.NewMockStore(t)
+	store.EXPECT().TaskDelete("1").Return(types.ErrRecordNotExist).Once()
+
+	pq := &persistentQueue{Queue: q, store: store}
+
+	task := genDummyTask()
+	assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{task}))
+
+	got, err := pq.Poll(ctx, 1, filterFnTrue)
+	assert.NoError(t, err)
+	assert.Nil(t, got, "stale task must not be returned to the agent")
+
+	info := q.Info(ctx)
+	assert.Equal(t, 0, info.Stats.Pending, "stale task must be removed from pending")
+	assert.Equal(t, 0, info.Stats.Running, "stale task must be removed from running")
+}
+
+// A task that is still present in the backup store is polled normally.
+func TestPersistentQueuePollReturnsLiveTask(t *testing.T) {
+	ctx, cancel, q := setupTestQueue(t)
+	defer cancel(nil)
+
+	store := store_mocks.NewMockStore(t)
+	store.EXPECT().TaskDelete("1").Return(nil).Once()
+
+	pq := &persistentQueue{Queue: q, store: store}
+
+	task := genDummyTask()
+	assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{task}))
+
+	got, err := pq.Poll(ctx, 1, filterFnTrue)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, "1", got.ID)
+}


### PR DESCRIPTION
A task could linger in the in-memory queue after its backup-store row was already removed (e.g. its workflow was canceled/finished). On Poll the backup delete returned ErrRecordNotExist, the task was still handed to the agent, rejected by the workflow-state guard ("workflow was already marked as finished"), then resubmitted on deadline, looping forever. The lingering task also broke the queue info endpoint (missing pipeline/agent reference), which took down the UI queue page and stalled the autoscaler.

When the backup delete reports the task no longer exists, drop it from the queue instead of returning it to the agent.
