### PR TITLE
Agent treat gRPC Internal error as fatal

### DIFF
--- a/agent/rpc/client_grpc.go
+++ b/agent/rpc/client_grpc.go
@@ -186,7 +186,6 @@ func classifyRPCErr(ctx context.Context, err error) error {
 	case codes.Aborted,
 		codes.DataLoss,
 		codes.DeadlineExceeded,
-		codes.Internal,
 		codes.Unavailable:
 		return err
 	default:


### PR DESCRIPTION
Origin of the fix: [quintoandar/woodpecker](https://github.com/quintoandar/woodpecker) dropped codes.Internal

I just pocked around there fork for good ideas ...

a grpc Internal means the server has a fatal grpc-related error and retry does not likely fix it ...