### PR TITLE
Gate Kubernetes serviceAccountName backend step config behind agent config

### DIFF
--- a/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
+++ b/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
@@ -81,6 +81,12 @@ steps:
 
 To give steps access to the Kubernetes API via service account, take a look at [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
 
+By default, setting `serviceAccountName` from a step's backend options is **not allowed** for security reasons, as it would let any user with push access run pipeline pods under an arbitrary service account and inherit its permissions. To enable it, set [`WOODPECKER_BACKEND_K8S_SERVICE_ACCOUNT_NAME_ALLOW_FROM_STEP`](#backend_k8s_service_account_name_allow_from_step) on the agent.
+
+:::warning
+Enabling `WOODPECKER_BACKEND_K8S_SERVICE_ACCOUNT_NAME_ALLOW_FROM_STEP` in multi-tenant environments allows pipeline authors to run pods as any service account in the namespace, which may lead to privilege escalation. Only enable it if you trust everyone with push access.
+:::
+
 ### Workspace volume
 
 `workspaceVolume` controls whether the default workspace volume is mounted into a service Pod. It only affects service
@@ -634,3 +640,12 @@ Which [Kubernetes PriorityClass](https://kubernetes.io/docs/reference/kubernetes
 - Default: 'busybox:stable-musl'
 
 Container image used for the workspace permission init container, which is used to create the workspace directory and ensure correct permissions when running steps as non-root users.
+
+---
+
+### BACKEND_K8S_SERVICE_ACCOUNT_NAME_ALLOW_FROM_STEP
+
+- Name: `WOODPECKER_BACKEND_K8S_SERVICE_ACCOUNT_NAME_ALLOW_FROM_STEP`
+- Default: `false`
+
+Determines if the Pod `serviceAccountName` can be defined from a step's backend options. Disabled by default, as it would otherwise allow any user with push access to run pods under an arbitrary service account and escalate privileges.

--- a/pipeline/backend/kubernetes/flags.go
+++ b/pipeline/backend/kubernetes/flags.go
@@ -122,6 +122,12 @@ var Flags = []cli.Flag{
 		Usage:   "whether to allow existing Kubernetes secrets to be referenced from steps",
 		Value:   false,
 	},
+	&cli.BoolFlag{
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_SERVICE_ACCOUNT_NAME_ALLOW_FROM_STEP"),
+		Name:    "backend-k8s-service-account-name-allow-from-step",
+		Usage:   "whether to allow using service account name from step's backend options",
+		Value:   false,
+	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_BACKEND_K8S_PRIORITY_CLASS"),
 		Name:    "backend-k8s-priority-class",

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -59,26 +59,27 @@ type kube struct {
 }
 
 type config struct {
-	Namespace                   string
-	EnableNamespacePerOrg       bool
-	StorageClass                string
-	VolumeSize                  string
-	StorageRwx                  bool
-	PodLabels                   map[string]string
-	PodLabelsAllowFromStep      bool
-	PodAnnotations              map[string]string
-	PodAnnotationsAllowFromStep bool
-	PodNodeSelector             map[string]string
-	PodTolerationsAllowFromStep bool
-	PodTolerations              []Toleration
-	PodAffinity                 *kube_core_v1.Affinity
-	PodAffinityAllowFromStep    bool
-	ImagePullSecretNames        []string
-	SecurityContext             SecurityContextConfig
-	NativeSecretsAllowFromStep  bool
-	PriorityClassName           string
-	StopTimeout                 int64
-	PermissionInitImage         string
+	Namespace                       string
+	EnableNamespacePerOrg           bool
+	StorageClass                    string
+	VolumeSize                      string
+	StorageRwx                      bool
+	PodLabels                       map[string]string
+	PodLabelsAllowFromStep          bool
+	PodAnnotations                  map[string]string
+	PodAnnotationsAllowFromStep     bool
+	PodNodeSelector                 map[string]string
+	PodTolerationsAllowFromStep     bool
+	PodTolerations                  []Toleration
+	PodAffinity                     *kube_core_v1.Affinity
+	PodAffinityAllowFromStep        bool
+	ImagePullSecretNames            []string
+	SecurityContext                 SecurityContextConfig
+	NativeSecretsAllowFromStep      bool
+	ServiceAccountNameAllowFromStep bool
+	PriorityClassName               string
+	StopTimeout                     int64
+	PermissionInitImage             string
 }
 
 func (c *config) GetNamespace(orgID int64) string {
@@ -124,9 +125,10 @@ func configFromCliContext(ctx context.Context) (*config, error) {
 					RunAsNonRoot: c.Bool("backend-k8s-secctx-nonroot"), // cspell:words secctx nonroot
 					FSGroup:      newInt64(defaultFSGroup),
 				},
-				NativeSecretsAllowFromStep: c.Bool("backend-k8s-allow-native-secrets"),
-				StopTimeout:                c.Int64("backend-k8s-stop-timeout"),
-				PermissionInitImage:        c.String("backend-k8s-permission-init-image"),
+				NativeSecretsAllowFromStep:      c.Bool("backend-k8s-allow-native-secrets"),
+				ServiceAccountNameAllowFromStep: c.Bool("backend-k8s-service-account-name-allow-from-step"),
+				StopTimeout:                     c.Int64("backend-k8s-stop-timeout"),
+				PermissionInitImage:             c.String("backend-k8s-permission-init-image"),
 			}
 			// Unmarshal label and annotation settings here to ensure they're valid on startup
 			if labels := c.String("backend-k8s-pod-labels"); labels != "" {

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -184,19 +184,23 @@ func podSpec(step *types.Step, config *config, options BackendOptions, nsp nativ
 	}
 
 	spec := kube_core_v1.PodSpec{
-		RestartPolicy:      kube_core_v1.RestartPolicyNever,
-		RuntimeClassName:   options.RuntimeClassName,
-		ServiceAccountName: options.ServiceAccountName,
-		PriorityClassName:  config.PriorityClassName,
-		HostAliases:        hostAliases(step.ExtraHosts),
-		Hostname:           getHostnameOrEmpty(step.Name),
-		Subdomain:          subdomain,
-		DNSConfig:          dnsConfig(config.GetNamespace(step.OrgID), subdomain),
-		NodeSelector:       nodeSelector(options.NodeSelector, config.PodNodeSelector, step.Environment["CI_SYSTEM_PLATFORM"]),
-		Tolerations:        tolerations(options.Tolerations),
-		Affinity:           affinity(options.Affinity, config.PodAffinity, config.PodAffinityAllowFromStep),
-		SecurityContext:    podSecurityContext(options.SecurityContext, config.SecurityContext, step.Privileged, options.HostUsers),
-		HostUsers:          options.HostUsers,
+		RestartPolicy:     kube_core_v1.RestartPolicyNever,
+		RuntimeClassName:  options.RuntimeClassName,
+		PriorityClassName: config.PriorityClassName,
+		HostAliases:       hostAliases(step.ExtraHosts),
+		Hostname:          getHostnameOrEmpty(step.Name),
+		Subdomain:         subdomain,
+		DNSConfig:         dnsConfig(config.GetNamespace(step.OrgID), subdomain),
+		NodeSelector:      nodeSelector(options.NodeSelector, config.PodNodeSelector, step.Environment["CI_SYSTEM_PLATFORM"]),
+		Tolerations:       tolerations(options.Tolerations),
+		Affinity:          affinity(options.Affinity, config.PodAffinity, config.PodAffinityAllowFromStep),
+		SecurityContext:   podSecurityContext(options.SecurityContext, config.SecurityContext, step.Privileged, options.HostUsers),
+		HostUsers:         options.HostUsers,
+	}
+
+	// Only allow the step to set the service account name if explicitly enabled by the admin.
+	if config.ServiceAccountNameAllowFromStep {
+		spec.ServiceAccountName = options.ServiceAccountName
 	}
 
 	// If there are tolerations and they are allowed

--- a/pipeline/backend/kubernetes/pod_test.go
+++ b/pipeline/backend/kubernetes/pod_test.go
@@ -458,15 +458,16 @@ func TestFullPod(t *testing.T) {
 			Password: "bar",
 		},
 	}, &config{
-		Namespace:                   "woodpecker",
-		ImagePullSecretNames:        []string{"regcred", "another-pull-secret"},
-		PodLabels:                   map[string]string{"app": "test"},
-		PodLabelsAllowFromStep:      true,
-		PodAnnotations:              map[string]string{"apps.kubernetes.io/pod-index": "0"},
-		PodAnnotationsAllowFromStep: true,
-		PodTolerationsAllowFromStep: true,
-		PodNodeSelector:             map[string]string{"topology.kubernetes.io/region": "eu-central-1"},
-		SecurityContext:             SecurityContextConfig{RunAsNonRoot: false},
+		Namespace:                       "woodpecker",
+		ImagePullSecretNames:            []string{"regcred", "another-pull-secret"},
+		PodLabels:                       map[string]string{"app": "test"},
+		PodLabelsAllowFromStep:          true,
+		PodAnnotations:                  map[string]string{"apps.kubernetes.io/pod-index": "0"},
+		PodAnnotationsAllowFromStep:     true,
+		PodTolerationsAllowFromStep:     true,
+		PodNodeSelector:                 map[string]string{"topology.kubernetes.io/region": "eu-central-1"},
+		SecurityContext:                 SecurityContextConfig{RunAsNonRoot: false},
+		ServiceAccountNameAllowFromStep: true,
 	},
 		"wp-01he8bebctabr3kgk0qj36d2me-0",
 		"linux/amd64",
@@ -997,6 +998,33 @@ func TestPodTolerationsAllowFromStep(t *testing.T) {
 
 	ja = jsonassert.New(t)
 	ja.Assertf(string(podJSON), expectedAllow)
+}
+
+func TestServiceAccountNameAllowFromStep(t *testing.T) {
+	step := &types.Step{
+		Name:  "sa-test",
+		Image: "alpine",
+		UUID:  "01he8bebctabr3kgk0qj36d2me-0",
+	}
+
+	// When disabled (default), a step-provided service account name must be ignored.
+	pod, err := mkPod(step, &config{
+		Namespace: "woodpecker",
+	}, "wp-01he8bebctabr3kgk0qj36d2me-0", "linux/amd64", BackendOptions{
+		ServiceAccountName: "privileged-sa",
+	}, taskUUID)
+	assert.NoError(t, err)
+	assert.Empty(t, pod.Spec.ServiceAccountName)
+
+	// When explicitly enabled by the admin, the step value is honored.
+	pod, err = mkPod(step, &config{
+		Namespace:                       "woodpecker",
+		ServiceAccountNameAllowFromStep: true,
+	}, "wp-01he8bebctabr3kgk0qj36d2me-0", "linux/amd64", BackendOptions{
+		ServiceAccountName: "privileged-sa",
+	}, taskUUID)
+	assert.NoError(t, err)
+	assert.Equal(t, "privileged-sa", pod.Spec.ServiceAccountName)
 }
 
 func TestStepSecret(t *testing.T) {


### PR DESCRIPTION
Previously any user with push access could set an arbitrary serviceAccountName in a step's backend_options, running pipeline pods under that service account and inheriting its RBAC permissions (privilege escalation, GHSA-qf34-295c-26v8).

The value is now only applied when the new
WOODPECKER_BACKEND_K8S_SERVICE_ACCOUNT_NAME_ALLOW_FROM_STEP flag is enabled (default false), matching the existing *AllowFromStep gating pattern used for labels, annotations, tolerations, affinity and native secrets. When disabled, the step value is ignored and the namespace default service account is used.
