### PR TITLE
migration: "update-pipeline-structure_tags-releases" should have stable order

### DIFF
--- a/server/store/datastore/migration/028_update_pipeline_structure_tags_releases.go
+++ b/server/store/datastore/migration/028_update_pipeline_structure_tags_releases.go
@@ -85,7 +85,10 @@ var updatePipelineStructureTagsReleases = xormigrate.Migration{
 		for {
 			oldPipelines = oldPipelines[:0]
 
-			err := sess.Limit(perPage, page*perPage).Where(builder.In("event", model.EventRelease, model.EventTag)).Find(&oldPipelines)
+			err := sess.Limit(perPage, page*perPage).
+				OrderBy("id ASC").
+				Where(builder.In("event", model.EventRelease, model.EventTag)).
+				Find(&oldPipelines)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
as per comment https://github.com/woodpecker-ci/woodpecker/pull/6779#issuecomment-4818811041

it should not be an issue but we should just not assume DBMS order always the same way if not specified ...

regression of https://github.com/woodpecker-ci/woodpecker/pull/6774