### PR TITLE
Kubernetes: increase memory limit for init container

### DIFF
--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -39,6 +39,8 @@ const (
 	TaskUUIDLabel         = "woodpecker-ci.org/task-uuid"
 	podPrefix             = "wp-"
 	defaultFSGroup  int64 = 1000
+	// Because of https://docs.redhat.com/en/documentation/openshift_container_platform/4.10/html/nodes/working-with-clusters
+	initContainerMemLimit = "12Mi"
 )
 
 func mkPod(step *types.Step, config *config, podName, goos string, options BackendOptions, taskUUID string) (*kube_core_v1.Pod, error) {
@@ -335,11 +337,11 @@ func podInitContainer(config *config, podSpec *kube_core_v1.PodSpec, container *
 		Resources: kube_core_v1.ResourceRequirements{
 			Requests: kube_core_v1.ResourceList{
 				kube_core_v1.ResourceCPU:    resource.MustParse("5m"),
-				kube_core_v1.ResourceMemory: resource.MustParse("12Mi"),
+				kube_core_v1.ResourceMemory: resource.MustParse(initContainerMemLimit),
 			},
 			Limits: kube_core_v1.ResourceList{
 				kube_core_v1.ResourceCPU:    resource.MustParse("5m"),
-				kube_core_v1.ResourceMemory: resource.MustParse("12Mi"),
+				kube_core_v1.ResourceMemory: resource.MustParse(initContainerMemLimit),
 			},
 		},
 		VolumeMounts: volumeMounts,

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -335,11 +335,11 @@ func podInitContainer(config *config, podSpec *kube_core_v1.PodSpec, container *
 		Resources: kube_core_v1.ResourceRequirements{
 			Requests: kube_core_v1.ResourceList{
 				kube_core_v1.ResourceCPU:    resource.MustParse("5m"),
-				kube_core_v1.ResourceMemory: resource.MustParse("5Mi"),
+				kube_core_v1.ResourceMemory: resource.MustParse("12Mi"),
 			},
 			Limits: kube_core_v1.ResourceList{
 				kube_core_v1.ResourceCPU:    resource.MustParse("5m"),
-				kube_core_v1.ResourceMemory: resource.MustParse("5Mi"),
+				kube_core_v1.ResourceMemory: resource.MustParse("12Mi"),
 			},
 		},
 		VolumeMounts: volumeMounts,

--- a/pipeline/backend/kubernetes/pod_test.go
+++ b/pipeline/backend/kubernetes/pod_test.go
@@ -1407,11 +1407,11 @@ func TestInitContainer(t *testing.T) {
 		"resources": {
 			"requests": {
 				"cpu": "5m",
-				"memory": "5Mi"
+				"memory": "12Mi"
 			},
 			"limits": {
 				"cpu": "5m",
-				"memory": "5Mi"
+				"memory": "12Mi"
 			}
 		},
 		"securityContext": {


### PR DESCRIPTION
### Problem
The working directory permission init container is hardcoded with the following resource limits: `cpu: 5m, memory: 5Mi`
On OpenShift, this causes pod creation failures with the following error:
`set memory limit 5Mi is too low; should be at least 12Mi`.
OpenShift documentation states:
`The minimum memory limit for a deployment is 12 MB. If a container fails to start due to a Cannot allocate memory pod event, the memory limit is too low. Either increase or remove the memory limit.`
As a result, workloads using the permission init container cannot run on OpenShift clusters with the current resource limits. 

### Context
This PR builds on:
 [Kubernetes: precreate workingDir as nonroot when required (#6322)](https://github.com/woodpecker-ci/woodpecker/pull/6322#issue-4131798381), which introduced an init container to pre-create and fix permissions on the working directory when needed, and
[Kubernetes: allow custom image when precreating workingDir as nonroot (#6771)](https://github.com/woodpecker-ci/woodpecker/pull/6771), which allows to customize the init container image.

### Solution
Increase the default resource limits for the permission init container to meet OpenShift’s minimum requirements (12Mi) while keeping the container lightweight. 
This ensures compatibility with OpenShift without introducing additional configuration complexity.

### Related issues and PRs
Extends [Kubernetes workingDir permission fix (#6322)
](https://github.com/woodpecker-ci/woodpecker/pull/6322#issue-4131798381)
And [Kubernetes: allow custom image when precreating workingDir as nonroot (#6771)](https://github.com/woodpecker-ci/woodpecker/pull/6771)