### PR TITLE
Stamp trusted commit-branch and event pod labels

### DIFF
--- a/pipeline/const.go
+++ b/pipeline/const.go
@@ -29,6 +29,8 @@ const (
 	LabelRepoFullName   string = InternalLabelPrefix + "/repo-full-name"
 	LabelBranch         string = InternalLabelPrefix + "/branch"
 	LabelOrgID          string = InternalLabelPrefix + "/org-id"
+	LabelCommitBranch   string = InternalLabelPrefix + "/commit-branch"
+	LabelEvent          string = InternalLabelPrefix + "/event"
 	LabelFilterOrg      string = "org-id"
 	LabelFilterRepo     string = "repo"
 	LabelFilterPlatform string = "platform"

--- a/pipeline/frontend/builder/builder.go
+++ b/pipeline/frontend/builder/builder.go
@@ -202,6 +202,8 @@ func (b *PipelineBuilder) genItemForWorkflow(workflow *Workflow, axis matrix.Axi
 	item.Labels[pipeline.LabelRepoFullName] = workflowMetadata.Repo.Owner + "/" + workflowMetadata.Repo.Name
 	item.Labels[pipeline.LabelBranch] = workflowMetadata.Repo.Branch
 	item.Labels[pipeline.LabelOrgID] = strconv.FormatInt(workflowMetadata.Repo.OrgID, 10)
+	item.Labels[pipeline.LabelCommitBranch] = workflowMetadata.Curr.Commit.Branch
+	item.Labels[pipeline.LabelEvent] = string(workflowMetadata.Curr.Event)
 
 	return item, errorsAndWarnings
 }

--- a/pipeline/frontend/builder/builder_test.go
+++ b/pipeline/frontend/builder/builder_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/errors"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/metadata"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/yaml/compiler"
@@ -901,4 +902,34 @@ func (t *testMetadata) GetWorkflowMetadata(w *Workflow) metadata.Metadata {
 			},
 		},
 	}
+}
+
+func TestInternalCommitBranchAndEventLabels(t *testing.T) {
+	t.Parallel()
+
+	m := &testMetadata{
+		pipelineEvent: "push",
+		branch:        "main",
+	}
+
+	b := PipelineBuilder{
+		GetWorkflowMetadata: m.GetWorkflowMetadata,
+		RepoTrusted:         &metadata.TrustedConfiguration{},
+		Yamls: []*YamlFile{
+			{Data: []byte(`
+when:
+  event: push
+steps:
+  - name: build
+    image: scratch
+`)},
+		},
+	}
+
+	items, err := b.Build()
+	assert.NoError(t, err)
+	assert.Len(t, items, 1)
+
+	assert.Equal(t, "main", items[0].Labels[pipeline.LabelCommitBranch])
+	assert.Equal(t, "push", items[0].Labels[pipeline.LabelEvent])
 }


### PR DESCRIPTION
Add woodpecker-ci.org/commit-branch and woodpecker-ci.org/event internal labels from the pipeline builder. These reflect the triggering ref/event, enabling admission-control and routing keyed on them.

For reference, my goal with this is to gate (with a Kubernetes `ValidationAdmissionPolicy`) access to specific `ServiceAccount`s holding credentials to more sensitive things, so no pipeline running on a PR/against another branch than e.g. `main` can access those credentials. The current branch label unfortunately only holds the default branch of the repo, not the branch that triggered the event.

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
