### PR TITLE
frontend/linter: export SchemaDefinition for external reuse

### DIFF
--- a/pipeline/frontend/yaml/linter/schema/schema.go
+++ b/pipeline/frontend/yaml/linter/schema/schema.go
@@ -28,11 +28,11 @@ import (
 )
 
 //go:embed schema.json
-var schemaDefinition []byte
+var SchemaDefinition []byte
 
 // Lint lints an io.Reader against the Woodpecker `schema.json`.
 func Lint(r io.Reader) ([]gojsonschema.ResultError, error) {
-	schemaLoader := gojsonschema.NewBytesLoader(schemaDefinition)
+	schemaLoader := gojsonschema.NewBytesLoader(SchemaDefinition)
 
 	// read yaml config
 	rBytes, err := io.ReadAll(r)


### PR DESCRIPTION
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->
Exports `SchemaDefinition` from the linter package so it can be reused by extensions.