### PR TITLE
Add step type label to step-level Prometheus metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -163,6 +163,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/dsig v1.0.0 // indirect

--- a/server/metric/metrics_server.go
+++ b/server/metric/metrics_server.go
@@ -83,7 +83,7 @@ func StartMetricsCollector(ctx context.Context, c *cli.Command, _store store.Sto
 				Name:      "step_failures_total",
 				Help:      "Total number of pipeline step failures.",
 			},
-			[]string{"workflow", "repo", "step"},
+			[]string{"workflow", "repo", "step", "type"},
 		)
 
 		StepDurationRecord = promauto.NewHistogramVec(
@@ -93,7 +93,7 @@ func StartMetricsCollector(ctx context.Context, c *cli.Command, _store store.Sto
 				Help:      "Step duration in seconds.",
 				Buckets:   []float64{1, 5, 10, 30, 60, 300, 600, 1800, 3600},
 			},
-			[]string{"workflow", "repo", "step"},
+			[]string{"workflow", "repo", "step", "type"},
 		)
 	}
 	go func() {

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -214,7 +214,7 @@ func (s *RPC) Update(c context.Context, strWorkflowID string, state rpc.StepStat
 		(step.State == model.StatusFailure ||
 			step.State == model.StatusKilled ||
 			step.State == model.StatusError) {
-		metric.FailurePipelineStepInfoCount.WithLabelValues(workflow.Name, repo.FullName, step.Name).Inc()
+		metric.FailurePipelineStepInfoCount.WithLabelValues(workflow.Name, repo.FullName, step.Name, string(step.Type)).Inc()
 	}
 
 	if metric.StepDurationRecord != nil && state.Exited && step.Started > 0 && step.Finished >= step.Started {
@@ -223,6 +223,7 @@ func (s *RPC) Update(c context.Context, strWorkflowID string, state rpc.StepStat
 			workflow.Name,
 			repo.FullName,
 			step.Name,
+			string(step.Type),
 		).Observe(float64(duration))
 	}
 	if state.Exited {

--- a/server/rpc/rpc_integration_test.go
+++ b/server/rpc/rpc_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/rpc"
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/logging"
+	"go.woodpecker-ci.org/woodpecker/v3/server/metric"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	"go.woodpecker-ci.org/woodpecker/v3/server/pubsub/memory"
 	"go.woodpecker-ci.org/woodpecker/v3/server/queue"
@@ -912,5 +914,191 @@ func TestRPCWait(t *testing.T) {
 		_, err := rpcInst.Wait(ctx, "30")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not allowed to interact")
+	})
+}
+
+func TestRPCUpdateStepTypeMetric(t *testing.T) {
+	t.Run("failure counter uses type=commands for a commands step", func(t *testing.T) {
+		// Each subtest gets its own unregistered metric instances so counters
+		// do not bleed between subtests.
+		origFailure := metric.FailurePipelineStepInfoCount
+		origDuration := metric.StepDurationRecord
+		t.Cleanup(func() {
+			metric.FailurePipelineStepInfoCount = origFailure
+			metric.StepDurationRecord = origDuration
+		})
+		metric.FailurePipelineStepInfoCount = prometheus.NewCounterVec(
+			prometheus.CounterOpts{Namespace: "woodpecker_test", Name: "step_failures_commands", Help: "test"},
+			[]string{"workflow", "repo", "step", "type"},
+		)
+		metric.StepDurationRecord = prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Namespace: "woodpecker_test", Name: "step_duration_commands", Help: "test"},
+			[]string{"workflow", "repo", "step", "type"},
+		)
+
+		mockStore := store_mocks.NewMockStore(t)
+		mockLogStore := log_mocks.NewMockService(t)
+		origLogStore := server.Config.Services.LogStore
+		server.Config.Services.LogStore = mockLogStore
+		t.Cleanup(func() { server.Config.Services.LogStore = origLogStore })
+
+		workflow := defaultWorkflow(model.StatusRunning)
+		step := &model.Step{
+			ID:         50,
+			UUID:       "step-uuid-commands",
+			PipelineID: 20,
+			Name:       "build",
+			State:      model.StatusRunning,
+			Started:    100,
+			Type:       model.StepTypeCommands,
+		}
+
+		mockStore.On("WorkflowLoad", int64(30)).Return(workflow, nil)
+		mockStore.On("GetPipeline", int64(20)).Return(defaultPipeline(model.StatusRunning), nil)
+		mockStore.On("AgentFind", int64(1)).Return(defaultAgent(), nil)
+		mockStore.On("StepByUUID", "step-uuid-commands").Return(step, nil)
+		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
+		mockStore.On("StepUpdate", mock.Anything).Return(nil)
+		mockStore.On("WorkflowGetTree", mock.Anything).Return([]*model.Workflow{workflow}, nil)
+		mockLogStore.On("StepFinished", mock.Anything).Return()
+
+		rpcInst := newTestRPC(t, mockStore, nil)
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
+
+		err := rpcInst.Update(ctx, "30", rpc.StepState{
+			StepUUID: "step-uuid-commands",
+			Exited:   true,
+			Finished: 200,
+			ExitCode: 1,
+		})
+		require.NoError(t, err)
+
+		cStep, err := metric.FailurePipelineStepInfoCount.GetMetricWithLabelValues(workflow.Name, defaultRepo().FullName, step.Name, "commands")
+		require.NoError(t, err)
+		assert.Equal(t, float64(1), testutil.ToFloat64(cStep))
+
+		cSvc, err := metric.FailurePipelineStepInfoCount.GetMetricWithLabelValues(workflow.Name, defaultRepo().FullName, step.Name, "service")
+		require.NoError(t, err)
+		assert.Zero(t, testutil.ToFloat64(cSvc))
+	})
+
+	t.Run("failure counter uses type=service for a service step", func(t *testing.T) {
+		origFailure := metric.FailurePipelineStepInfoCount
+		origDuration := metric.StepDurationRecord
+		t.Cleanup(func() {
+			metric.FailurePipelineStepInfoCount = origFailure
+			metric.StepDurationRecord = origDuration
+		})
+		metric.FailurePipelineStepInfoCount = prometheus.NewCounterVec(
+			prometheus.CounterOpts{Namespace: "woodpecker_test", Name: "step_failures_service", Help: "test"},
+			[]string{"workflow", "repo", "step", "type"},
+		)
+		metric.StepDurationRecord = prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Namespace: "woodpecker_test", Name: "step_duration_service", Help: "test"},
+			[]string{"workflow", "repo", "step", "type"},
+		)
+
+		mockStore := store_mocks.NewMockStore(t)
+		mockLogStore := log_mocks.NewMockService(t)
+		origLogStore := server.Config.Services.LogStore
+		server.Config.Services.LogStore = mockLogStore
+		t.Cleanup(func() { server.Config.Services.LogStore = origLogStore })
+
+		workflow := defaultWorkflow(model.StatusRunning)
+		step := &model.Step{
+			ID:         51,
+			UUID:       "step-uuid-service",
+			PipelineID: 20,
+			Name:       "redis",
+			State:      model.StatusRunning,
+			Started:    100,
+			Type:       model.StepTypeService,
+		}
+
+		mockStore.On("WorkflowLoad", int64(30)).Return(workflow, nil)
+		mockStore.On("GetPipeline", int64(20)).Return(defaultPipeline(model.StatusRunning), nil)
+		mockStore.On("AgentFind", int64(1)).Return(defaultAgent(), nil)
+		mockStore.On("StepByUUID", "step-uuid-service").Return(step, nil)
+		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
+		mockStore.On("StepUpdate", mock.Anything).Return(nil)
+		mockStore.On("WorkflowGetTree", mock.Anything).Return([]*model.Workflow{workflow}, nil)
+		mockLogStore.On("StepFinished", mock.Anything).Return()
+
+		rpcInst := newTestRPC(t, mockStore, nil)
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
+
+		err := rpcInst.Update(ctx, "30", rpc.StepState{
+			StepUUID: "step-uuid-service",
+			Exited:   true,
+			Finished: 200,
+			ExitCode: 1,
+		})
+		require.NoError(t, err)
+
+		cSvc, err := metric.FailurePipelineStepInfoCount.GetMetricWithLabelValues(workflow.Name, defaultRepo().FullName, step.Name, "service")
+		require.NoError(t, err)
+		assert.Equal(t, float64(1), testutil.ToFloat64(cSvc))
+
+		cStep, err := metric.FailurePipelineStepInfoCount.GetMetricWithLabelValues(workflow.Name, defaultRepo().FullName, step.Name, "commands")
+		require.NoError(t, err)
+		assert.Zero(t, testutil.ToFloat64(cStep))
+	})
+
+	t.Run("failure counter is not incremented when step exits successfully", func(t *testing.T) {
+		origFailure := metric.FailurePipelineStepInfoCount
+		origDuration := metric.StepDurationRecord
+		t.Cleanup(func() {
+			metric.FailurePipelineStepInfoCount = origFailure
+			metric.StepDurationRecord = origDuration
+		})
+		metric.FailurePipelineStepInfoCount = prometheus.NewCounterVec(
+			prometheus.CounterOpts{Namespace: "woodpecker_test", Name: "step_failures_success_exit", Help: "test"},
+			[]string{"workflow", "repo", "step", "type"},
+		)
+		metric.StepDurationRecord = prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Namespace: "woodpecker_test", Name: "step_duration_success_exit", Help: "test"},
+			[]string{"workflow", "repo", "step", "type"},
+		)
+
+		mockStore := store_mocks.NewMockStore(t)
+		mockLogStore := log_mocks.NewMockService(t)
+		origLogStore := server.Config.Services.LogStore
+		server.Config.Services.LogStore = mockLogStore
+		t.Cleanup(func() { server.Config.Services.LogStore = origLogStore })
+
+		workflow := defaultWorkflow(model.StatusRunning)
+		step := &model.Step{
+			ID:         52,
+			UUID:       "step-uuid-success",
+			PipelineID: 20,
+			Name:       "test",
+			State:      model.StatusRunning,
+			Started:    100,
+			Type:       model.StepTypeCommands,
+		}
+
+		mockStore.On("WorkflowLoad", int64(30)).Return(workflow, nil)
+		mockStore.On("GetPipeline", int64(20)).Return(defaultPipeline(model.StatusRunning), nil)
+		mockStore.On("AgentFind", int64(1)).Return(defaultAgent(), nil)
+		mockStore.On("StepByUUID", "step-uuid-success").Return(step, nil)
+		mockStore.On("GetRepo", int64(10)).Return(defaultRepo(), nil)
+		mockStore.On("StepUpdate", mock.Anything).Return(nil)
+		mockStore.On("WorkflowGetTree", mock.Anything).Return([]*model.Workflow{workflow}, nil)
+		mockLogStore.On("StepFinished", mock.Anything).Return()
+
+		rpcInst := newTestRPC(t, mockStore, nil)
+		ctx := context.WithValue(t.Context(), agentIDKey, int64(1))
+
+		err := rpcInst.Update(ctx, "30", rpc.StepState{
+			StepUUID: "step-uuid-success",
+			Exited:   true,
+			Finished: 200,
+			ExitCode: 0,
+		})
+		require.NoError(t, err)
+
+		c, err := metric.FailurePipelineStepInfoCount.GetMetricWithLabelValues(workflow.Name, defaultRepo().FullName, step.Name, "step")
+		require.NoError(t, err)
+		assert.Zero(t, testutil.ToFloat64(c))
 	})
 }


### PR DESCRIPTION
woodpecker_step_duration_seconds and woodpecker_step_failures_total now
include a `type` label with values `"step"` or `"service"`, allowing
dashboards and alerting rules to filter out service containers (e.g.
`redis`, `postgres`) from actual pipeline build steps.

## Problem

Service containers (defined under `services:` in a pipeline) run for the
entire duration of the pipeline. This caused them to appear as the
"slowest" or "most failing" steps in Prometheus/Grafana dashboards, even
though they are background dependencies, not build steps.

## Solution

The `type` label is derived from `model.StepType` at metric recording time
in `rpc.go`:
- `type="step"` for commands, plugins, clone and cache steps
- `type="service"` for service containers

This allows users to filter cleanly with `{type="step"}` instead of
maintaining a fragile regex exclusion list.