### PR TITLE
fix(web): clamp negative durations to avoid garbled time display

### DIFF
--- a/web/src/compositions/useDate.test.ts
+++ b/web/src/compositions/useDate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { useDate } from './useDate';
+
+const { durationAsNumber, prettyDuration } = useDate();
+
+describe('useDate', () => {
+  describe('durationAsNumber', () => {
+    it('formats sub-minute durations', () => {
+      expect(durationAsNumber(0)).toBe('00:00');
+      expect(durationAsNumber(5000)).toBe('00:05');
+    });
+
+    it('formats minutes and hours', () => {
+      expect(durationAsNumber(65000)).toBe('01:05');
+      expect(durationAsNumber(3665000)).toBe('01:01:05');
+    });
+
+    // Regression for #6808: start and end can come from different clocks
+    // (browser/server/agent), so skew may yield a negative duration. It must
+    // never render as a garbled value like `-1:-5`.
+    it('clamps negative durations to zero', () => {
+      expect(durationAsNumber(-5000)).toBe('00:00');
+      expect(durationAsNumber(-3665000)).toBe('00:00');
+    });
+  });
+
+  describe('prettyDuration', () => {
+    it('formats positive durations', () => {
+      expect(prettyDuration(5000)).toBe('5 seconds');
+    });
+
+    // Regression for #6808: negative durations must not render as `-5 seconds`.
+    it('clamps negative durations to zero', () => {
+      expect(prettyDuration(-5000)).toBe('0 seconds');
+    });
+  });
+});

--- a/web/src/compositions/useDate.ts
+++ b/web/src/compositions/useDate.ts
@@ -3,7 +3,13 @@ import { useI18n } from 'vue-i18n';
 let currentLocale = 'en';
 
 function splitDuration(durationMs: number) {
-  const totalSeconds = durationMs / 1000;
+  // Clamp negative durations to zero. Start and end timestamps can come from
+  // different clocks (browser, server, agent), so skew between them can produce
+  // a negative value which would otherwise render as garbled output like
+  // `00:-5` or `-5 seconds`.
+  const clampedMs = Math.max(0, durationMs);
+
+  const totalSeconds = clampedMs / 1000;
   const totalMinutes = totalSeconds / 60;
   const totalHours = totalMinutes / 60;
 


### PR DESCRIPTION
## What

Step and pipeline durations occasionally render as garbled values such as `-1:-5` or `-5 seconds` in the UI (see #6808).

A duration is computed from a start and an end timestamp that can come from different clocks:
- the browser (`Date.now()`) for still-running items,
- the server for the step/pipeline start,
- the agent for the step/pipeline finish.

Any skew between these clocks can make the duration negative. `splitDuration` passed that straight through, so `durationAsNumber` produced `-1:-5` and `prettyDuration` produced `-5 seconds`.

## How

Clamp the duration to zero in `splitDuration`, the single helper both formatters funnel through, so the UI always shows a sane value. This also covers running items whose negative offset is pure browser/server clock skew, which can't be corrected server-side.

Adds unit tests for `durationAsNumber`/`prettyDuration`, including the negative (skewed-clock) regression cases (they fail without the clamp).

This addresses the "negative time is printed wrong" part of #6808. The underlying single-time-source question (aligning the server/agent step timestamps) is still being discussed on the issue, so this intentionally only makes the display robust and does not change how the timestamps are recorded.

Refs #6808
