### PR TITLE
fix(server): record step, workflow and pipeline times from the server clock

### DIFF
--- a/server/pipeline/step_status.go
+++ b/server/pipeline/step_status.go
@@ -31,10 +31,23 @@ import (
 func CalcStepStatus(step model.Step, state rpc.StepState) (_ *model.Step, cancelPipelineFromStep bool, _ error) {
 	log.Debug().Str("StepUUID", step.UUID).Msgf("Update step %#v state %#v", step, state)
 
+	// now is the server clock. We use it as the single authoritative source
+	// for the persisted Started and Finished timestamps instead of trusting
+	// the agent-supplied state.Started/state.Finished. Previously the start
+	// time was recorded from the server clock (state.Started is 0 on the
+	// "started" trace) while the finish time was copied from the agent clock,
+	// so clock skew between agent and server produced wrong or even negative
+	// step durations (#6808). The agent-reported timestamps are still used as
+	// presence flags (0 vs non-0) to decide the state transition, but never as
+	// stored values. Relative in-step/log timing stays agent-sourced.
+	now := time.Now().Unix()
+
 	switch step.State {
 	case model.StatusPending:
 		// Handle skip before anything else — skipped steps never started,
-		// so we must not set Started or transition through Running.
+		// so we must not set Started or transition through Running. A skipped
+		// step never ran (Started stays 0), so there is no start/finish pair
+		// that could be skewed; keep the agent value here as-is.
 		if state.Skipped {
 			step.State = model.StatusSkipped
 			if state.Finished != 0 {
@@ -47,17 +60,11 @@ func CalcStepStatus(step model.Step, state rpc.StepState) (_ *model.Step, cancel
 		if state.Finished == 0 {
 			step.State = model.StatusRunning
 		}
-		step.Started = state.Started
-		if step.Started == 0 {
-			step.Started = time.Now().Unix()
-		}
+		step.Started = now
 
 		// Handle direct transition to finished if step setup error happened
 		if state.Exited || state.Error != "" {
-			step.Finished = state.Finished
-			if step.Finished == 0 {
-				step.Finished = time.Now().Unix()
-			}
+			step.Finished = now
 			step.ExitCode = state.ExitCode
 			step.Error = state.Error
 
@@ -75,10 +82,7 @@ func CalcStepStatus(step model.Step, state rpc.StepState) (_ *model.Step, cancel
 	case model.StatusRunning:
 		// Already running, check if it finished
 		if state.Exited || state.Error != "" {
-			step.Finished = state.Finished
-			if step.Finished == 0 {
-				step.Finished = time.Now().Unix()
-			}
+			step.Finished = now
 			step.ExitCode = state.ExitCode
 			step.Error = state.Error
 
@@ -101,7 +105,7 @@ func CalcStepStatus(step model.Step, state rpc.StepState) (_ *model.Step, cancel
 	if state.Canceled && step.State != model.StatusKilled {
 		step.State = model.StatusKilled
 		if step.Finished == 0 {
-			step.Finished = time.Now().Unix()
+			step.Finished = now
 		}
 	}
 

--- a/server/pipeline/step_status_test.go
+++ b/server/pipeline/step_status_test.go
@@ -16,9 +16,11 @@ package pipeline
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline"
 	"go.woodpecker-ci.org/woodpecker/v3/rpc"
@@ -42,16 +44,21 @@ func TestUpdateStepStatus(t *testing.T) {
 		t.Run("TransitionToRunning", func(t *testing.T) {
 			t.Parallel()
 
-			t.Run("WithStartTime", func(t *testing.T) {
+			t.Run("IgnoresAgentStartTime", func(t *testing.T) {
 				t.Parallel()
+				before := time.Now().Unix()
 				step := &model.Step{State: model.StatusPending}
+				// The agent reports a start time, but the server must ignore it
+				// and stamp its own clock so Started/Finished share one time
+				// source (#6808).
 				state := rpc.StepState{Started: 42, Finished: 0}
 
 				err := UpdateStepStatus(t.Context(), mockStoreStep(t), step, state)
 
 				assert.NoError(t, err)
 				assert.Equal(t, model.StatusRunning, step.State)
-				assert.Equal(t, int64(42), step.Started)
+				assert.NotEqual(t, int64(42), step.Started)
+				assert.GreaterOrEqual(t, step.Started, before)
 				assert.Equal(t, int64(0), step.Finished)
 			})
 
@@ -71,8 +78,9 @@ func TestUpdateStepStatus(t *testing.T) {
 		t.Run("DirectToSuccess", func(t *testing.T) {
 			t.Parallel()
 
-			t.Run("WithFinishTime", func(t *testing.T) {
+			t.Run("IgnoresAgentTimes", func(t *testing.T) {
 				t.Parallel()
+				before := time.Now().Unix()
 				step := &model.Step{State: model.StatusPending}
 				state := rpc.StepState{Started: 42, Exited: true, Finished: 100, ExitCode: 0, Error: ""}
 
@@ -80,8 +88,10 @@ func TestUpdateStepStatus(t *testing.T) {
 
 				assert.NoError(t, err)
 				assert.Equal(t, model.StatusSuccess, step.State)
-				assert.Equal(t, int64(42), step.Started)
-				assert.Equal(t, int64(100), step.Finished)
+				assert.NotEqual(t, int64(42), step.Started)
+				assert.NotEqual(t, int64(100), step.Finished)
+				assert.GreaterOrEqual(t, step.Started, before)
+				assert.GreaterOrEqual(t, step.Finished, step.Started)
 			})
 
 			t.Run("WithoutFinishTime", func(t *testing.T) {
@@ -121,16 +131,20 @@ func TestUpdateStepStatus(t *testing.T) {
 		t.Run("ToSuccess", func(t *testing.T) {
 			t.Parallel()
 
-			t.Run("WithFinishTime", func(t *testing.T) {
+			t.Run("UsesServerFinishTime", func(t *testing.T) {
 				t.Parallel()
+				before := time.Now().Unix()
 				step := &model.Step{State: model.StatusRunning, Started: 42}
+				// Agent-reported finish time is ignored; the server stamps its
+				// own clock instead (#6808).
 				state := rpc.StepState{Exited: true, Finished: 100, ExitCode: 0, Error: ""}
 
 				err := UpdateStepStatus(t.Context(), mockStoreStep(t), step, state)
 
 				assert.NoError(t, err)
 				assert.Equal(t, model.StatusSuccess, step.State)
-				assert.Equal(t, int64(100), step.Finished)
+				assert.NotEqual(t, int64(100), step.Finished)
+				assert.GreaterOrEqual(t, step.Finished, before)
 			})
 
 			t.Run("WithoutFinishTime", func(t *testing.T) {
@@ -152,13 +166,15 @@ func TestUpdateStepStatus(t *testing.T) {
 			t.Run("WithExitCode137", func(t *testing.T) {
 				t.Parallel()
 				step := &model.Step{State: model.StatusRunning, Started: 42}
+				before := time.Now().Unix()
 				state := rpc.StepState{Exited: true, Finished: 34, ExitCode: pipeline.ExitCodeKilled, Error: "an error"}
 
 				err := UpdateStepStatus(t.Context(), mockStoreStep(t), step, state)
 
 				assert.NoError(t, err)
 				assert.Equal(t, model.StatusFailure, step.State)
-				assert.Equal(t, int64(34), step.Finished)
+				assert.NotEqual(t, int64(34), step.Finished)
+				assert.GreaterOrEqual(t, step.Finished, before)
 				assert.Equal(t, pipeline.ExitCodeKilled, step.ExitCode)
 			})
 
@@ -205,6 +221,7 @@ func TestUpdateStepStatus(t *testing.T) {
 
 		t.Run("WithExitedAndFinishTime", func(t *testing.T) {
 			t.Parallel()
+			before := time.Now().Unix()
 			step := &model.Step{State: model.StatusRunning, Started: 42}
 			state := rpc.StepState{Canceled: true, Exited: true, Finished: 100, ExitCode: 1, Error: "canceled"}
 
@@ -212,7 +229,8 @@ func TestUpdateStepStatus(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, model.StatusKilled, step.State)
-			assert.Equal(t, int64(100), step.Finished)
+			assert.NotEqual(t, int64(100), step.Finished)
+			assert.GreaterOrEqual(t, step.Finished, before)
 			assert.Equal(t, 1, step.ExitCode)
 			assert.Equal(t, "canceled", step.Error)
 		})
@@ -282,6 +300,35 @@ func TestUpdateStepStatus(t *testing.T) {
 		assert.Contains(t, err.Error(), "does not expect rpc state updates")
 		assert.Equal(t, model.StatusKilled, step.State)
 	})
+}
+
+// TestStepStatusSkewedAgentClock reproduces #6808: a step is started (server
+// records its own clock) and then finished by an agent whose clock is skewed
+// far into the past. Before the fix the finish time was copied from the agent
+// clock, so step.Finished < step.Started and the reported duration was
+// negative. With the server-authoritative fix both timestamps come from the
+// server clock, so the duration is always non-negative.
+func TestStepStatusSkewedAgentClock(t *testing.T) {
+	t.Parallel()
+
+	store := mockStoreStep(t)
+	step := &model.Step{State: model.StatusPending}
+
+	// Phase 1 — "started" trace: the agent sends Started=0, so the server
+	// stamps its own clock.
+	require.NoError(t, UpdateStepStatus(t.Context(), store, step, rpc.StepState{Started: 0, Finished: 0}))
+	require.Equal(t, model.StatusRunning, step.State)
+	require.Greater(t, step.Started, int64(0))
+
+	// Phase 2 — "finished" trace with a badly skewed agent clock (far in the
+	// past relative to the server). The old behaviour would set
+	// step.Finished = 1000 < step.Started -> negative duration.
+	const skewedAgentFinish = int64(1000)
+	require.NoError(t, UpdateStepStatus(t.Context(), store, step, rpc.StepState{Exited: true, Finished: skewedAgentFinish, ExitCode: 0}))
+
+	assert.Equal(t, model.StatusSuccess, step.State)
+	assert.NotEqual(t, skewedAgentFinish, step.Finished)
+	assert.GreaterOrEqual(t, step.Finished, step.Started, "duration must never be negative")
 }
 
 func TestUpdateStepToStatusSkipped(t *testing.T) {

--- a/server/pipeline/workflow_status.go
+++ b/server/pipeline/workflow_status.go
@@ -15,6 +15,8 @@
 package pipeline
 
 import (
+	"time"
+
 	"go.woodpecker-ci.org/woodpecker/v3/rpc"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	"go.woodpecker-ci.org/woodpecker/v3/server/store"
@@ -33,8 +35,13 @@ func WorkflowStatus(steps []*model.Step) model.StatusValue {
 	return status
 }
 
-func UpdateWorkflowStatusToRunning(store store.Store, workflow model.Workflow, state rpc.WorkflowState) (*model.Workflow, error) {
-	workflow.Started = state.Started
+func UpdateWorkflowStatusToRunning(store store.Store, workflow model.Workflow, _ rpc.WorkflowState) (*model.Workflow, error) {
+	// Record the workflow start time from the server clock rather than the
+	// agent-supplied state.Started, so that Started and Finished share a single
+	// clock and durations stay correct even when the agent clock is skewed
+	// (#6808). This also keeps pipeline/workflow times consistent across a
+	// multi-agent pipeline where different workflows run on different agents.
+	workflow.Started = time.Now().Unix()
 	workflow.State = model.StatusRunning
 	return &workflow, store.WorkflowUpdate(&workflow)
 }
@@ -45,7 +52,10 @@ func UpdateWorkflowToStatusSkipped(store store.Store, workflow model.Workflow) (
 }
 
 func UpdateWorkflowStatusToDone(store store.Store, workflow model.Workflow, state rpc.WorkflowState) (*model.Workflow, error) {
-	workflow.Finished = state.Finished
+	// Record the finish time from the server clock (see UpdateWorkflowStatusToRunning
+	// and #6808). state.Started is still consulted below purely as a presence
+	// flag to detect a workflow that was never started (skipped).
+	workflow.Finished = time.Now().Unix()
 	workflow.Error = state.Error
 	if state.Started == 0 {
 		workflow.State = model.StatusSkipped

--- a/server/pipeline/workflow_status_test.go
+++ b/server/pipeline/workflow_status_test.go
@@ -16,6 +16,7 @@ package pipeline
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -180,25 +181,29 @@ func TestWorkflowStatus(t *testing.T) {
 }
 
 func TestUpdateWorkflowStatusToRunning(t *testing.T) {
-	t.Run("should update workflow to running status", func(t *testing.T) {
+	t.Run("should update workflow to running status using the server clock", func(t *testing.T) {
+		before := time.Now().Unix()
 		workflow := model.Workflow{
 			ID:    1,
 			State: model.StatusPending,
 		}
+		// Agent reports a start time; the server must ignore it and record its
+		// own clock instead (#6808).
 		state := rpc.WorkflowState{
 			Started: 1234567890,
 		}
 
 		mockStore := store_mocks.NewMockStore(t)
 		mockStore.On("WorkflowUpdate", mock.MatchedBy(func(w *model.Workflow) bool {
-			return w.ID == 1 && w.State == model.StatusRunning && w.Started == 1234567890
+			return w.ID == 1 && w.State == model.StatusRunning && w.Started >= before
 		})).Return(nil)
 
 		result, err := UpdateWorkflowStatusToRunning(mockStore, workflow, state)
 
 		assert.NoError(t, err)
 		assert.Equal(t, model.StatusRunning, result.State)
-		assert.Equal(t, int64(1234567890), result.Started)
+		assert.NotEqual(t, int64(1234567890), result.Started)
+		assert.GreaterOrEqual(t, result.Started, before)
 		mockStore.AssertCalled(t, "WorkflowUpdate", mock.Anything)
 	})
 }
@@ -225,6 +230,7 @@ func TestUpdateWorkflowToStatusSkipped(t *testing.T) {
 
 func TestUpdateWorkflowStatusToDone(t *testing.T) {
 	t.Run("should mark as skipped when not started", func(t *testing.T) {
+		before := time.Now().Unix()
 		workflow := model.Workflow{
 			ID:       3,
 			State:    model.StatusRunning,
@@ -238,14 +244,17 @@ func TestUpdateWorkflowStatusToDone(t *testing.T) {
 
 		mockStore := store_mocks.NewMockStore(t)
 		mockStore.On("WorkflowUpdate", mock.MatchedBy(func(w *model.Workflow) bool {
-			return w.State == model.StatusSkipped && w.Finished == 1234567900
+			return w.State == model.StatusSkipped && w.Finished >= before
 		})).Return(nil)
 
 		result, err := UpdateWorkflowStatusToDone(mockStore, workflow, state)
 
 		assert.NoError(t, err)
+		// Started==0 still marks the workflow skipped (used as a presence flag)...
 		assert.Equal(t, model.StatusSkipped, result.State)
-		assert.Equal(t, int64(1234567900), result.Finished)
+		// ...but Finished is stamped from the server clock, not the agent value (#6808).
+		assert.NotEqual(t, int64(1234567900), result.Finished)
+		assert.GreaterOrEqual(t, result.Finished, before)
 	})
 
 	t.Run("should mark as failure when error exists", func(t *testing.T) {
@@ -273,6 +282,7 @@ func TestUpdateWorkflowStatusToDone(t *testing.T) {
 	})
 
 	t.Run("should mark as success when all children are successful", func(t *testing.T) {
+		before := time.Now().Unix()
 		successStep := &model.Step{
 			ID:    1,
 			State: model.StatusSuccess,
@@ -295,6 +305,8 @@ func TestUpdateWorkflowStatusToDone(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, model.StatusSuccess, result.State)
-		assert.Equal(t, int64(1234567900), result.Finished)
+		// Finished comes from the server clock, not the agent-supplied value (#6808).
+		assert.NotEqual(t, int64(1234567900), result.Finished)
+		assert.GreaterOrEqual(t, result.Finished, before)
 	})
 }

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -278,7 +278,10 @@ func (s *RPC) Init(c context.Context, strWorkflowID string, state rpc.WorkflowSt
 	}
 
 	if currentPipeline.Status == model.StatusPending {
-		if currentPipeline, err = pipeline.UpdateToStatusRunning(s.store, *currentPipeline, state.Started); err != nil {
+		// Use the server clock for the pipeline start time instead of the
+		// agent-supplied state.Started, matching the step/workflow state
+		// machine, so pipeline duration is not skewed by agent clock drift (#6808).
+		if currentPipeline, err = pipeline.UpdateToStatusRunning(s.store, *currentPipeline, time.Now().Unix()); err != nil {
 			log.Error().Err(err).Msgf("init: cannot update pipeline %d state", currentPipeline.ID)
 		}
 	}
@@ -356,8 +359,10 @@ func (s *RPC) Done(c context.Context, strWorkflowID string, state rpc.WorkflowSt
 	logger.Debug().Msgf("gRPC Done with state: %#v", state)
 
 	// Complete any still-running children (e.g. service containers) before
-	// computing the workflow status, so their final state is reflected.
-	s.completeChildrenIfParentCompleted(workflow, state.Finished)
+	// computing the workflow status, so their final state is reflected. Stamp
+	// their finish time from the server clock rather than the agent-supplied
+	// state.Finished, consistent with the step/workflow state machine (#6808).
+	s.completeChildrenIfParentCompleted(workflow, time.Now().Unix())
 
 	if workflow, err = pipeline.UpdateWorkflowStatusToDone(s.store, *workflow, state); err != nil {
 		logger.Error().Err(err).Msgf("pipeline.UpdateWorkflowStatusToDone: cannot update workflow state: %s", err)


### PR DESCRIPTION
The proper fix, as discussed — following the closure of #6825 (the display-side workaround was rightly rejected as "more a workaround than a proper fix").

### Problem (#6808)

A step's **start** time was recorded from the server clock, but its **finish** time was copied from the **agent** clock. When the agent and server clocks are out of sync (the reporter's was ~14s off), durations came out wrong or negative. The same split exists at the workflow and pipeline levels, where all start/finish times come from the agent's `WorkflowState` — and in a multi-agent pipeline, different workflows can even carry timestamps from *different* agent clocks.

As diagnosed by @qwerty287 and suggested by @6543 ("i would trust the server more ... update the statemachine to use the server time for finished too"), this makes the **server the single authoritative clock** for every persisted `Started`/`Finished` timestamp.

### What now uses server time

- **Step `Started`** — `CalcStepStatus` on the pending→running transition (was `state.Started`; already effectively server time since the "started" trace carries a zero value, now unconditionally so).
- **Step `Finished`** — both finish branches and the cancellation branch (was `state.Finished`). *This is the core bug.*
- **Workflow `Started`** — `UpdateWorkflowStatusToRunning` (was `state.Started`, via `Init`).
- **Workflow `Finished`** — `UpdateWorkflowStatusToDone` (was `state.Finished`, via `Done`).
- **Pipeline `Started`** — `Init` handler call-site (was `state.Started`).
- **Pipeline `Finished`** — inherits the now-server-authoritative `workflow.Finished` (no separate change).
- **Killed service/daemon children** — the `Done` handler stamps server time (was `state.Finished`).

### What deliberately stays agent-sourced

- **Relative in-step / log-line timing** — these are relative offsets (per @qwerty287: "the log times are relative times, not timestamps"), so they stay on the agent. No web-UI or log changes.
- The agent still **sends** its `Started`/`Finished` over RPC — they're used only as **presence flags** (`Finished==0` → still running; `Started==0` → skipped), never persisted as values, so they can't be dropped from the protocol.
- **Skipped steps** keep their (near-always-zero) agent `Finished`: a skipped step never ran (`Started==0`), so there's no start/finish pair to skew.

### Open question for maintainers

@6543 also floated a second option in the issue — keep agent times but **sanitize on the server** (clamp drift beyond the gRPC retry timeout, override `end < start`). That subthread ended without resolution. This PR implements the simpler server-authoritative direction; if you prefer the drift-clamping variant instead, say so and I'll re-cut it — the server-time baseline here is a natural foundation to layer clamping onto later.

### Tests

Updated the `server/pipeline` unit tests to assert server-clock behavior and added `TestStepStatusSkewedAgentClock`, a two-phase test that starts a step and then finishes it with a badly skewed agent clock; it fails on `main` (negative duration) and passes here. `go test ./server/pipeline/ ./server/rpc/` passes, `go vet` clean.

Fixes #6808
