### PR TITLE
feat(server): add unix socket permission option

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -75,6 +75,11 @@ var flags = append([]cli.Flag{
 		Value:   ":8000",
 	},
 	&cli.StringFlag{
+		Sources: cli.EnvVars("WOODPECKER_UNIX_SOCKET_PERMISSION"),
+		Name:    "unix-socket-permission",
+		Usage:   "file mode for the HTTP unix socket, for example 660 or 666",
+	},
+	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_SERVER_ADDR_TLS"),
 		Name:    "server-addr-tls",
 		Usage:   "port https with tls (:443)",

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -269,13 +269,7 @@ func run(ctx context.Context, c *cli.Command) error {
 				return err
 			}
 			if network == "unix" && c.String("unix-socket-permission") != "" {
-				mode, err := parseUnixSocketPermission(c.String("unix-socket-permission"))
-				if err != nil {
-					stopServerFunc(err)
-					return err
-				}
-				if err := os.Chmod(addr, mode); err != nil {
-					err = fmt.Errorf("could not set unix socket permission: %w", err)
+				if err := setUnixSocketPermission(addr, c.String("unix-socket-permission")); err != nil {
 					stopServerFunc(err)
 					return err
 				}
@@ -336,10 +330,13 @@ func run(ctx context.Context, c *cli.Command) error {
 	return serviceWaitingGroup.Wait()
 }
 
-func parseUnixSocketPermission(permission string) (os.FileMode, error) {
+func setUnixSocketPermission(path, permission string) error {
 	mode, err := strconv.ParseUint(permission, 8, 32)
 	if err != nil {
-		return 0, fmt.Errorf("invalid unix socket permission %q: %w", permission, err)
+		return fmt.Errorf("invalid unix socket permission %q: %w", permission, err)
 	}
-	return os.FileMode(mode), nil
+	if err := os.Chmod(path, os.FileMode(mode)); err != nil {
+		return fmt.Errorf("could not set unix socket permission: %w", err)
+	}
+	return nil
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -267,6 +268,18 @@ func run(ctx context.Context, c *cli.Command) error {
 				stopServerFunc(err)
 				return err
 			}
+			if network == "unix" && c.String("unix-socket-permission") != "" {
+				mode, err := parseUnixSocketPermission(c.String("unix-socket-permission"))
+				if err != nil {
+					stopServerFunc(err)
+					return err
+				}
+				if err := os.Chmod(addr, mode); err != nil {
+					err = fmt.Errorf("could not set unix socket permission: %w", err)
+					stopServerFunc(err)
+					return err
+				}
+			}
 
 			httpServer := &http.Server{
 				Handler: handler,
@@ -321,4 +334,12 @@ func run(ctx context.Context, c *cli.Command) error {
 	}
 
 	return serviceWaitingGroup.Wait()
+}
+
+func parseUnixSocketPermission(permission string) (os.FileMode, error) {
+	mode, err := strconv.ParseUint(permission, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid unix socket permission %q: %w", permission, err)
+	}
+	return os.FileMode(mode), nil
 }

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseUnixSocketPermission(t *testing.T) {
+func TestSetUnixSocketPermission(t *testing.T) {
 	tests := []struct {
 		name       string
 		permission string
@@ -48,14 +48,19 @@ func TestParseUnixSocketPermission(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseUnixSocketPermission(tt.permission)
+			path := t.TempDir() + "/socket"
+			require.NoError(t, os.WriteFile(path, []byte(""), 0o600))
+
+			err := setUnixSocketPermission(path, tt.permission)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, info.Mode().Perm())
 		})
 	}
 }

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUnixSocketPermission(t *testing.T) {
+	tests := []struct {
+		name       string
+		permission string
+		want       os.FileMode
+		wantErr    bool
+	}{
+		{
+			name:       "owner and group read write",
+			permission: "660",
+			want:       0o660,
+		},
+		{
+			name:       "world read write",
+			permission: "666",
+			want:       0o666,
+		},
+		{
+			name:       "rejects non-octal digits",
+			permission: "999",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUnixSocketPermission(tt.permission)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `WOODPECKER_UNIX_SOCKET_PERMISSION` / `--unix-socket-permission` for HTTP listeners using `unix://`, so admins can configure the created socket mode directly.

Closes #6805

## Tests

- `GOMAXPROCS=2 go test -tags external_web -p 1 ./cmd/server -run '^TestParseUnixSocketPermission$' -count=1 -v`
- `GOMAXPROCS=2 go test -tags external_web -p 1 ./cmd/server -count=1`
- `git diff --check`
