### PR TITLE
WebUI: Fixes three bugs around component unmount and reset in compositions

### DIFF
--- a/web/src/compositions/useFavicon.test.ts
+++ b/web/src/compositions/useFavicon.test.ts
@@ -1,0 +1,111 @@
+import { shallowMount } from '@vue/test-utils';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+
+import type { PipelineStatus } from '~/lib/api/types';
+
+import { useFavicon } from './useFavicon';
+
+// eslint-disable-next-line promise/prefer-await-to-callbacks
+const mountComposition = (cb: () => void) => {
+  const wrapper = shallowMount({
+    setup() {
+      // eslint-disable-next-line promise/prefer-await-to-callbacks
+      cb();
+      return {};
+    },
+    template: '<div />',
+  });
+
+  return wrapper;
+};
+
+function mountConsumer(status: PipelineStatus) {
+  let favicon = null as unknown as ReturnType<typeof useFavicon>;
+  const wrapper = mountComposition(() => {
+    favicon = useFavicon();
+    favicon.updateStatus(status);
+  });
+  return { wrapper, favicon };
+}
+
+function faviconHref(): string {
+  return (document.getElementById('favicon-png') as HTMLLinkElement).href;
+}
+
+describe('useFavicon', () => {
+  beforeAll(() => {
+    const png = document.createElement('link');
+    png.id = 'favicon-png';
+    const svg = document.createElement('link');
+    svg.id = 'favicon-svg';
+    document.head.append(png, svg);
+  });
+
+  beforeEach(async () => {
+    // start every test from a clean default state
+    useFavicon().updateStatus('default');
+    await nextTick();
+  });
+
+  it('reflects the pipeline status in the favicon', async () => {
+    const { wrapper } = mountConsumer('running');
+    await nextTick();
+
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-pending\.png$/);
+
+    wrapper.unmount();
+  });
+
+  it('maps failure statuses to the error favicon', async () => {
+    const { wrapper } = mountConsumer('failure');
+    await nextTick();
+
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-error\.png$/);
+
+    wrapper.unmount();
+  });
+
+  it('resets to the default favicon when the consuming component unmounts', async () => {
+    // real world: user opens a failing pipeline, then navigates back to the
+    // repo list — the error favicon must not stick around globally
+    const { wrapper } = mountConsumer('failure');
+    await nextTick();
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-error\.png$/);
+
+    wrapper.unmount();
+    await nextTick();
+
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-default\.png$/);
+  });
+
+  it('keeps the status of a still-mounted consumer when another one unmounts', async () => {
+    // real world: overlapping consumers during a route transition
+    const first = mountConsumer('running');
+    const second = mountConsumer('success');
+    await nextTick();
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-success\.png$/);
+
+    first.wrapper.unmount();
+    await nextTick();
+
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-success\.png$/);
+
+    second.wrapper.unmount();
+    await nextTick();
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-default\.png$/);
+  });
+
+  it('can be used outside a component scope without registering cleanup', async () => {
+    // real world: imperative update from non-component code
+    const favicon = useFavicon();
+    favicon.updateStatus('running');
+    await nextTick();
+
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-pending\.png$/);
+
+    favicon.updateStatus('default');
+    await nextTick();
+    expect(faviconHref()).toMatch(/favicon-(light|dark)-default\.png$/);
+  });
+});

--- a/web/src/compositions/useFavicon.ts
+++ b/web/src/compositions/useFavicon.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch } from 'vue';
+import { computed, getCurrentScope, onScopeDispose, ref, watch } from 'vue';
 
 import useConfig from '~/compositions/useConfig';
 import { useTheme } from '~/compositions/useTheme';
@@ -47,7 +47,23 @@ function convertStatus(status: PipelineStatus): Status {
   return 'default';
 }
 
+// number of component/effect scopes currently consuming the favicon status;
+// the status is global, so it is reset once the last consumer is disposed
+let activeScopes = 0;
+
 export function useFavicon() {
+  if (getCurrentScope()) {
+    activeScopes += 1;
+    onScopeDispose(() => {
+      activeScopes -= 1;
+      if (activeScopes === 0) {
+        // no consumer left (e.g. user navigated away from the pipeline
+        // view), so the status must not stick around globally
+        faviconStatus.value = 'default';
+      }
+    });
+  }
+
   return {
     updateStatus(status?: PipelineStatus | 'default') {
       if (status === undefined || status === 'default') {

--- a/web/src/compositions/useInterval.test.ts
+++ b/web/src/compositions/useInterval.test.ts
@@ -1,0 +1,128 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInterval } from './useInterval';
+
+// eslint-disable-next-line promise/prefer-await-to-callbacks
+const mountComposition = (cb: () => void) => {
+  const wrapper = shallowMount({
+    setup() {
+      // eslint-disable-next-line promise/prefer-await-to-callbacks
+      cb();
+      return {};
+    },
+    template: '<div />',
+  });
+
+  return wrapper;
+};
+
+describe('useInterval', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('runs the function once immediately on mount', async () => {
+    const fn = vi.fn(async () => {});
+
+    mountComposition(() => {
+      useInterval(fn, 1000);
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps polling at the given interval while mounted', async () => {
+    const fn = vi.fn(async () => {});
+
+    mountComposition(() => {
+      useInterval(fn, 1000);
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(3000);
+
+    // 1 immediate + 3 interval ticks
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  it('stops polling after unmount', async () => {
+    const fn = vi.fn(async () => {});
+
+    const wrapper = mountComposition(() => {
+      useInterval(fn, 1000);
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+    const callsAtUnmount = fn.mock.calls.length;
+
+    wrapper.unmount();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(fn).toHaveBeenCalledTimes(callsAtUnmount);
+  });
+
+  it('does not start the interval when unmounted while the first call is still in flight', async () => {
+    // real world: user opens a pipeline page (first API fetch is slow) and
+    // navigates away before it resolves
+    let resolveFirstCall: () => void = () => {};
+    const fn = vi.fn(
+      async () =>
+        new Promise<void>((resolve) => {
+          resolveFirstCall = resolve;
+        }),
+    );
+
+    const wrapper = mountComposition(() => {
+      useInterval(fn, 1000);
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // unmount while the initial fetch is still pending
+    wrapper.unmount();
+    resolveFirstCall();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // if an interval was still registered, it would fire here forever
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak intervals across quick remounts', async () => {
+    // real world: fast tab switching back and forth between views polling the API
+    let resolveCall: () => void = () => {};
+    const fn = vi.fn(
+      async () =>
+        new Promise<void>((resolve) => {
+          resolveCall = resolve;
+        }),
+    );
+
+    const first = mountComposition(() => {
+      useInterval(fn, 1000);
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    first.unmount();
+    resolveCall();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const second = mountComposition(() => {
+      useInterval(fn, 1000);
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    resolveCall();
+    await vi.advanceTimersByTimeAsync(0);
+    second.unmount();
+
+    const calls = fn.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // no interval from either mount may survive
+    expect(fn).toHaveBeenCalledTimes(calls);
+  });
+});

--- a/web/src/compositions/useInterval.ts
+++ b/web/src/compositions/useInterval.ts
@@ -2,15 +2,22 @@ import { onBeforeUnmount, onMounted, ref } from 'vue';
 
 export function useInterval(fn: () => void | Promise<void>, ms: number): void {
   const id = ref<number>();
+  let unmounted = false;
 
   onMounted(async () => {
     await fn(); // run once immediately
+    if (unmounted) {
+      // component was unmounted while the first call was in flight,
+      // starting the interval now would leak it forever
+      return;
+    }
     id.value = window.setInterval(() => {
       void fn();
     }, ms);
   });
 
   onBeforeUnmount(() => {
+    unmounted = true;
     if (id.value != null) {
       window.clearInterval(id.value);
     }

--- a/web/src/compositions/usePaginate.test.ts
+++ b/web/src/compositions/usePaginate.test.ts
@@ -1,6 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
-import { watch } from 'vue';
+import { nextTick, watch } from 'vue';
 import type { Ref } from 'vue';
 
 import { usePagination } from './usePaginate';
@@ -154,5 +154,156 @@ describe('usePaginate', () => {
     await waitForState(usePaginationComposition.loading, false);
     expect(usePaginationComposition.hasMore.value).toBe(false);
     expect(usePaginationComposition.data.value.length).toBe(6);
+  });
+
+  describe('reset while a request is in flight', () => {
+    interface Deferred {
+      page: number;
+      resolve: (items: { name: string }[]) => void;
+    }
+
+    function useControlledPagination(pageSize = 3) {
+      const calls: Deferred[] = [];
+      let usePaginationComposition = null as unknown as ReturnType<typeof usePagination<{ name: string }>>;
+
+      mountComposition(() => {
+        usePaginationComposition = usePagination<{ name: string }>(
+          async (page) =>
+            new Promise<{ name: string }[]>((resolve) => {
+              calls.push({ page, resolve });
+            }),
+          () => true,
+          { pageSize },
+        );
+      });
+
+      return { calls, composition: usePaginationComposition };
+    }
+
+    const flush = async () => {
+      // let pending promise callbacks and (pre-flush) watchers run
+      await nextTick();
+      await nextTick();
+    };
+
+    it('discards a stale response that resolves after resetPage', async () => {
+      // real world: user scrolls to page 2, then switches the branch filter
+      // while the page 2 request is still in flight
+      const { calls, composition } = useControlledPagination();
+
+      await flush();
+      calls[0].resolve([{ name: 'old1' }, { name: 'old2' }, { name: 'old3' }]);
+      await waitForState(composition.loading, false);
+
+      composition.nextPage();
+      await flush();
+      expect(calls[1].page).toBe(2);
+
+      // switch filter: reset while page 2 request still pending
+      void composition.resetPage();
+      await flush();
+
+      const freshCall = calls.at(-1)!;
+      expect(freshCall.page).toBe(1);
+      freshCall.resolve([{ name: 'new1' }, { name: 'new2' }, { name: 'new3' }]);
+      await flush();
+
+      // stale page 2 response arrives last
+      calls[1].resolve([{ name: 'stale1' }, { name: 'stale2' }, { name: 'stale3' }]);
+      await flush();
+
+      expect(composition.data.value.map(({ name }) => name)).toStrictEqual(['new1', 'new2', 'new3']);
+    });
+
+    it('does not let a stale response overwrite hasMore', async () => {
+      const { calls, composition } = useControlledPagination();
+
+      await flush();
+      calls[0].resolve([{ name: 'old1' }, { name: 'old2' }, { name: 'old3' }]);
+      await waitForState(composition.loading, false);
+
+      composition.nextPage();
+      await flush();
+
+      void composition.resetPage();
+      await flush();
+
+      const freshCall = calls.at(-1)!;
+      freshCall.resolve([{ name: 'new1' }, { name: 'new2' }, { name: 'new3' }]);
+      await flush();
+
+      // stale response is a short (last) page and would clear hasMore
+      calls[1].resolve([{ name: 'stale1' }]);
+      await flush();
+
+      expect(composition.hasMore.value).toBe(true);
+      expect(composition.data.value.map(({ name }) => name)).toStrictEqual(['new1', 'new2', 'new3']);
+    });
+
+    it('reloads page 1 when resetPage is called while the initial request is in flight', async () => {
+      // real world: user switches the filter twice quickly while still on page 1
+      const { calls, composition } = useControlledPagination();
+
+      await flush();
+      expect(calls[0].page).toBe(1);
+
+      void composition.resetPage();
+      await flush();
+
+      expect(calls.length).toBe(2);
+      const freshCall = calls.at(-1)!;
+      expect(freshCall.page).toBe(1);
+
+      freshCall.resolve([{ name: 'new1' }, { name: 'new2' }, { name: 'new3' }]);
+      await flush();
+
+      // stale initial response arrives last
+      calls[0].resolve([{ name: 'stale1' }, { name: 'stale2' }, { name: 'stale3' }]);
+      await flush();
+
+      expect(composition.data.value.map(({ name }) => name)).toStrictEqual(['new1', 'new2', 'new3']);
+      expect(composition.loading.value).toBe(false);
+    });
+
+    it('keeps loading consistent so the next page can still be fetched after a stale response', async () => {
+      const { calls, composition } = useControlledPagination();
+
+      await flush();
+      calls[0].resolve([{ name: 'old1' }, { name: 'old2' }, { name: 'old3' }]);
+      await waitForState(composition.loading, false);
+
+      composition.nextPage();
+      await flush();
+
+      void composition.resetPage();
+      await flush();
+
+      const freshCall = calls.at(-1)!;
+
+      // stale page 2 response resolves while the fresh page 1 request is in flight;
+      // it must not flip loading back to false mid-request
+      calls[1].resolve([{ name: 'stale1' }, { name: 'stale2' }, { name: 'stale3' }]);
+      await flush();
+      expect(composition.loading.value).toBe(true);
+
+      freshCall.resolve([{ name: 'new1' }, { name: 'new2' }, { name: 'new3' }]);
+      await waitForState(composition.loading, false);
+
+      composition.nextPage();
+      await flush();
+      const page2Call = calls.at(-1)!;
+      expect(page2Call.page).toBe(2);
+      page2Call.resolve([{ name: 'new4' }, { name: 'new5' }, { name: 'new6' }]);
+      await waitForState(composition.loading, false);
+
+      expect(composition.data.value.map(({ name }) => name)).toStrictEqual([
+        'new1',
+        'new2',
+        'new3',
+        'new4',
+        'new5',
+        'new6',
+      ]);
+    });
   });
 });

--- a/web/src/compositions/usePaginate.ts
+++ b/web/src/compositions/usePaginate.ts
@@ -38,6 +38,9 @@ export function usePagination<T, S = unknown>(
   const data = ref<T[]>([]) as Ref<T[]>;
   const loading = ref(false);
   const each = ref([...(_each ?? [])]);
+  // incremented on every resetPage; a response started under an older
+  // generation is stale and must not touch any state
+  let generation = 0;
 
   async function loadData() {
     if (loading.value === true || hasMore.value === false) {
@@ -45,7 +48,13 @@ export function usePagination<T, S = unknown>(
     }
 
     loading.value = true;
+    const requestGeneration = generation;
     const newData = (await _loadData(page.value, each.value?.[0] as S)) ?? [];
+    if (requestGeneration !== generation) {
+      // resetPage was called while this request was in flight; a fresh
+      // request owns the state now, so discard this response entirely
+      return;
+    }
     hasMore.value = newData.length >= pageSize.value && newData.length > 0;
     if (newData.length > 0) {
       data.value.push(...newData);
@@ -81,6 +90,7 @@ export function usePagination<T, S = unknown>(
   async function resetPage() {
     const _page = page.value;
 
+    generation += 1;
     page.value = 1;
     hasMore.value = true;
     data.value = [];

--- a/web/src/views/repo/pipeline/PipelineWrapper.vue
+++ b/web/src/views/repo/pipeline/PipelineWrapper.vue
@@ -128,7 +128,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onBeforeUnmount, onMounted, ref, toRef, watch } from 'vue';
+import { computed, onMounted, ref, toRef, watch } from 'vue';
 import type { Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -220,9 +220,6 @@ const { doSubmit: restartPipeline, isLoading: isRestartingPipeline } = useAsyncA
 
 onMounted(loadPipeline);
 watch([repositoryId, pipelineId], loadPipeline);
-onBeforeUnmount(() => {
-  favicon.updateStatus('default');
-});
 
 const goBack = useRouteBack({ name: 'repo' });
 </script>


### PR DESCRIPTION
Fixes three bugs around component unmount and reset in the web UI compositions.

| Composition | Symptom | Fix |
|---|---|---|
| `useInterval` | Unmount during the initial fetch leaked the interval: endless API polling and state writes on a dead component | Track unmount state, skip interval registration after unmount |
| `usePagination` | Fast filter/branch switching showed duplicated or wrong list entries because a stale in-flight response resolved after `resetPage()` | Generation token; stale responses return without touching state |
| `useFavicon` | Error/pending favicon could stick globally because resetting was left to callers | Auto-reset via `onScopeDispose` once the last consumer unmounts |

All fixes were developed test-first; 14 new unit tests cover the races, including unmount-mid-fetch, rapid remounts, reset-while-loading and overlapping favicon consumers.