### PR TITLE
Make matrix axis permutation order deterministic

### DIFF
--- a/pipeline/frontend/yaml/matrix/matrix.go
+++ b/pipeline/frontend/yaml/matrix/matrix.go
@@ -15,6 +15,7 @@
 package matrix
 
 import (
+	"sort"
 	"strings"
 
 	"codeberg.org/6543/xyaml/v2"
@@ -79,6 +80,10 @@ func calc(matrix Matrix) []Axis {
 		}
 		tags = append(tags, k)
 	}
+	// map iteration order is random: sort the tags so the permutation order
+	// is deterministic and derived workflow numbering is stable across
+	// repeated compilations of the same pipeline.
+	sort.Strings(tags)
 
 	// structure to hold the transformed result set
 	var axisList []Axis

--- a/pipeline/frontend/yaml/matrix/matrix_test.go
+++ b/pipeline/frontend/yaml/matrix/matrix_test.go
@@ -72,3 +72,17 @@ matrix:
     - go_version: 1.6
       python_version: 3.4
 `
+
+func TestMatrixDeterministicOrder(t *testing.T) {
+	// the axis permutation order must be stable across parses: workflow
+	// PIDs derived from it have to match when a pipeline is compiled more
+	// than once (e.g. again at agent fetch time).
+	first, err := ParseString(fakeMatrix)
+	assert.NoError(t, err)
+
+	for i := 0; i < 20; i++ {
+		again, err := ParseString(fakeMatrix)
+		assert.NoError(t, err)
+		assert.EqualValues(t, first, again)
+	}
+}


### PR DESCRIPTION
calc iterated the matrix map directly, so the axis permutation order (and with it the derived workflow PID/AxisID numbering) was random on every compilation. Sort the tags first.

picked from https://github.com/woodpecker-ci/woodpecker/pull/6840