### PR TITLE
Fix CreatePipeline retry

### DIFF
--- a/server/store/datastore/helper.go
+++ b/server/store/datastore/helper.go
@@ -53,8 +53,11 @@ func wrapDelete(c int64, err error) error {
 
 func wrapInsert(c int64, err error) error {
 	if err != nil {
-		if errMsg := err.Error(); strings.HasPrefix(errMsg, "UNIQUE constraint failed") ||
-			strings.HasPrefix(errMsg, "pq: duplicate key value violates unique constraint") ||
+		// Common unique constraint violation patterns across the supported drivers.
+		if errMsg := err.Error(); strings.Contains(errMsg, "UNIQUE constraint failed") ||
+			strings.Contains(errMsg, "UNIQUE violation") ||
+			strings.Contains(errMsg, "duplicate key") ||
+			strings.Contains(errMsg, "unique constraint") ||
 			strings.Contains(errMsg, "Duplicate entry") {
 			return types.ErrInsertDuplicateDetected
 		}

--- a/server/store/datastore/helper_test.go
+++ b/server/store/datastore/helper_test.go
@@ -50,4 +50,20 @@ func TestWrapInsert(t *testing.T) {
 
 	// test insert witch should fail because of unique constraint
 	assert.ErrorIs(t, wrapInsert(store.engine.Insert(cron)), types.ErrInsertDuplicateDetected)
+
+	// The store above only exercises the sqlite wording. Cover the other drivers too: callers rely on
+	// errors.Is(err, ErrInsertDuplicateDetected) instead of matching driver strings themselves, so a
+	// pattern missing here silently breaks them (e.g. the retry in CreatePipeline, #6067).
+	for _, driverErr := range []string{
+		`pq: duplicate key value violates unique constraint "UQE_pipelines_s"`, // postgres
+		"Error 1062: Duplicate entry '1-2' for key 'UQE_pipelines_s'",          // mysql
+		"UNIQUE violation",
+		"unique constraint",
+	} {
+		assert.ErrorIs(t, wrapInsert(0, errors.New(driverErr)), types.ErrInsertDuplicateDetected, driverErr)
+	}
+
+	// Everything else passes through untouched.
+	other := errors.New("connection refused")
+	assert.Equal(t, other, wrapInsert(0, other))
 }

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"xorm.io/xorm"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
 )
 
 func (s storage) GetPipeline(id int64) (*model.Pipeline, error) {
@@ -196,6 +198,16 @@ func (s storage) CreatePipeline(pipeline *model.Pipeline, stepList ...*model.Ste
 func isUniqueConstraintError(err error) bool {
 	if err == nil {
 		return false
+	}
+
+	// The inserts in CreatePipeline go through wrapInsert, which normalizes driver-specific unique
+	// constraint violations into types.ErrInsertDuplicateDetected. Its message ("on insert duplicate
+	// based on constraints was detected") matches none of the raw driver patterns below, so without
+	// this check the retry added in #6067 never triggers and CreatePipeline fails permanently on the
+	// first collision. Keep the raw string checks too: this function is also reachable with errors
+	// that did not go through wrapInsert.
+	if errors.Is(err, types.ErrInsertDuplicateDetected) {
+		return true
 	}
 
 	errStr := err.Error()

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -17,7 +17,6 @@ package datastore
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v7"
@@ -171,7 +170,7 @@ func (s storage) CreatePipeline(pipeline *model.Pipeline, stepList ...*model.Ste
 		pipeline.Created = time.Now().UTC().Unix()
 		// only Insert set auto created ID back to object
 		if err := wrapInsert(sess.Insert(pipeline)); err != nil {
-			if isUniqueConstraintError(err) {
+			if errors.Is(err, types.ErrInsertDuplicateDetected) {
 				return struct{}{}, err
 			}
 			return struct{}{}, backoff.Permanent(err)
@@ -181,7 +180,7 @@ func (s storage) CreatePipeline(pipeline *model.Pipeline, stepList ...*model.Ste
 			stepList[i].PipelineID = pipeline.ID
 			// only Insert set auto created ID back to object
 			if err := wrapInsert(sess.Insert(stepList[i])); err != nil {
-				if isUniqueConstraintError(err) {
+				if errors.Is(err, types.ErrInsertDuplicateDetected) {
 					return struct{}{}, err
 				}
 				return struct{}{}, backoff.Permanent(err)
@@ -192,26 +191,6 @@ func (s storage) CreatePipeline(pipeline *model.Pipeline, stepList ...*model.Ste
 	}, backoff.WithBackOff(exponentialBackoff), backoff.WithMaxTries(maxRetries))
 
 	return err
-}
-
-// isUniqueConstraintError checks if an error is a unique constraint violation error.
-func isUniqueConstraintError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// Check wrapInsert normalized error.
-	if errors.Is(err, types.ErrInsertDuplicateDetected) {
-		return true
-	}
-
-	errStr := err.Error()
-	// Check for common unique constraint error patterns across different databases
-	return strings.Contains(errStr, "duplicate key") ||
-		strings.Contains(errStr, "Duplicate entry") ||
-		strings.Contains(errStr, "UNIQUE constraint failed") ||
-		strings.Contains(errStr, "unique constraint") ||
-		strings.Contains(errStr, "UNIQUE violation")
 }
 
 func (s storage) UpdatePipeline(pipeline *model.Pipeline) error {

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -200,12 +200,7 @@ func isUniqueConstraintError(err error) bool {
 		return false
 	}
 
-	// The inserts in CreatePipeline go through wrapInsert, which normalizes driver-specific unique
-	// constraint violations into types.ErrInsertDuplicateDetected. Its message ("on insert duplicate
-	// based on constraints was detected") matches none of the raw driver patterns below, so without
-	// this check the retry added in #6067 never triggers and CreatePipeline fails permanently on the
-	// first collision. Keep the raw string checks too: this function is also reachable with errors
-	// that did not go through wrapInsert.
+	// Check wrapInsert normalized error.
 	if errors.Is(err, types.ErrInsertDuplicateDetected) {
 		return true
 	}

--- a/server/store/datastore/pipeline_test.go
+++ b/server/store/datastore/pipeline_test.go
@@ -16,7 +16,6 @@
 package datastore
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -281,17 +280,4 @@ func TestDeletePipeline(t *testing.T) {
 	count, err = store.engine.Count(new(model.Config))
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, count)
-}
-
-func TestIsUniqueConstraintError(t *testing.T) {
-	// Without this, the retry in CreatePipeline is dead code (#6067).
-	assert.True(t, isUniqueConstraintError(types.ErrInsertDuplicateDetected))
-
-	// Raw driver errors, for callers that don't go through wrapInsert.
-	assert.True(t, isUniqueConstraintError(errors.New(`pq: duplicate key value violates unique constraint "UQE_pipelines_s"`)))
-	assert.True(t, isUniqueConstraintError(errors.New("UNIQUE constraint failed: pipelines.repo_id")))
-	assert.True(t, isUniqueConstraintError(errors.New("Error 1062: Duplicate entry '1-2' for key 'UQE_pipelines_s'")))
-
-	assert.False(t, isUniqueConstraintError(nil))
-	assert.False(t, isUniqueConstraintError(errors.New("connection refused")))
 }

--- a/server/store/datastore/pipeline_test.go
+++ b/server/store/datastore/pipeline_test.go
@@ -218,6 +218,31 @@ func TestPipelineIncrement(t *testing.T) {
 	assert.EqualValues(t, 1, pipelineC.Number)
 }
 
+// Duplicates must surface as ErrInsertDuplicateDetected so the retry sees them as retryable (#6067).
+func TestCreatePipelineDuplicateIsRetryable(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Repo), new(model.Step), new(model.Pipeline))
+	defer closer()
+
+	require.NoError(t, store.CreateRepo(&model.Repo{ID: 1, Owner: "1", Name: "1", FullName: "1/1", ForgeRemoteID: "1"}))
+
+	// Duplicate step: UNIQUE(pipeline_id, pid).
+	err := store.CreatePipeline(&model.Pipeline{RepoID: 1},
+		&model.Step{PID: 1, Name: "clone"},
+		&model.Step{PID: 1, Name: "dup"},
+	)
+	assert.ErrorIs(t, err, types.ErrInsertDuplicateDetected)
+
+	// Every attempt rolled back.
+	count, err := store.GetPipelineCount()
+	assert.NoError(t, err)
+	assert.Zero(t, count)
+
+	// Same for the pipeline insert. Forced through the PK: the number is MAX+1, it can't collide on demand.
+	existing := &model.Pipeline{RepoID: 1}
+	require.NoError(t, store.CreatePipeline(existing))
+	assert.ErrorIs(t, store.CreatePipeline(&model.Pipeline{ID: existing.ID, RepoID: 1}), types.ErrInsertDuplicateDetected)
+}
+
 func TestDeletePipeline(t *testing.T) {
 	store, closer := newTestStore(t, new(model.Pipeline), new(model.Repo), new(model.Workflow),
 		new(model.Step), new(model.LogEntry), new(model.PipelineConfig), new(model.Config))

--- a/server/store/datastore/pipeline_test.go
+++ b/server/store/datastore/pipeline_test.go
@@ -16,6 +16,7 @@
 package datastore
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -280,4 +281,22 @@ func TestDeletePipeline(t *testing.T) {
 	count, err = store.engine.Count(new(model.Config))
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, count)
+}
+
+func TestIsUniqueConstraintError(t *testing.T) {
+	// The inserts in CreatePipeline go through wrapInsert, which normalizes driver errors into
+	// types.ErrInsertDuplicateDetected. If isUniqueConstraintError does not recognize that sentinel,
+	// the retry added in #6067 is dead code: CreatePipeline hits backoff.Permanent on the first
+	// collision and the webhook gets a 500, so the pipeline is never created.
+	assert.True(t, isUniqueConstraintError(types.ErrInsertDuplicateDetected),
+		"the sentinel returned by wrapInsert must be retryable, otherwise the retry never runs")
+
+	// Raw driver errors must keep working: this function is also reachable with errors that did not
+	// go through wrapInsert.
+	assert.True(t, isUniqueConstraintError(errors.New(`pq: duplicate key value violates unique constraint "UQE_pipelines_s"`)))
+	assert.True(t, isUniqueConstraintError(errors.New("UNIQUE constraint failed: pipelines.repo_id")))
+	assert.True(t, isUniqueConstraintError(errors.New("Error 1062: Duplicate entry '1-2' for key 'UQE_pipelines_s'")))
+
+	assert.False(t, isUniqueConstraintError(nil))
+	assert.False(t, isUniqueConstraintError(errors.New("connection refused")))
 }

--- a/server/store/datastore/pipeline_test.go
+++ b/server/store/datastore/pipeline_test.go
@@ -284,15 +284,10 @@ func TestDeletePipeline(t *testing.T) {
 }
 
 func TestIsUniqueConstraintError(t *testing.T) {
-	// The inserts in CreatePipeline go through wrapInsert, which normalizes driver errors into
-	// types.ErrInsertDuplicateDetected. If isUniqueConstraintError does not recognize that sentinel,
-	// the retry added in #6067 is dead code: CreatePipeline hits backoff.Permanent on the first
-	// collision and the webhook gets a 500, so the pipeline is never created.
-	assert.True(t, isUniqueConstraintError(types.ErrInsertDuplicateDetected),
-		"the sentinel returned by wrapInsert must be retryable, otherwise the retry never runs")
+	// Without this, the retry in CreatePipeline is dead code (#6067).
+	assert.True(t, isUniqueConstraintError(types.ErrInsertDuplicateDetected))
 
-	// Raw driver errors must keep working: this function is also reachable with errors that did not
-	// go through wrapInsert.
+	// Raw driver errors, for callers that don't go through wrapInsert.
 	assert.True(t, isUniqueConstraintError(errors.New(`pq: duplicate key value violates unique constraint "UQE_pipelines_s"`)))
 	assert.True(t, isUniqueConstraintError(errors.New("UNIQUE constraint failed: pipelines.repo_id")))
 	assert.True(t, isUniqueConstraintError(errors.New("Error 1062: Duplicate entry '1-2' for key 'UQE_pipelines_s'")))


### PR DESCRIPTION
## The bug

The retry added in #6067 to work around the pipeline-number race **never runs**.

`CreatePipeline` inserts go through `wrapInsert()`, which normalizes every driver-specific unique constraint violation into a sentinel:

```go
// server/store/types/errors.go
ErrInsertDuplicateDetected = errors.New("on insert duplicate based on constraints was detected")
```

`isUniqueConstraintError()` then string-matches the **raw driver** messages. The sentinel's text matches **none** of them — note it says `constraints`, not `unique constraint`:

| pattern checked | matches the sentinel? |
|---|---|
| `duplicate key` | ❌ |
| `Duplicate entry` | ❌ |
| `UNIQUE constraint failed` | ❌ |
| `unique constraint` | ❌ |
| `UNIQUE violation` | ❌ |

So it always falls through to `backoff.Permanent(err)`: `CreatePipeline` gives up on the **first** collision, the webhook gets a **500**, and the pipeline is **never created**. GitHub does not retry webhooks, so the push is silently lost — no red build, nothing to look at.

## How it regressed

- #6067 (2026-02-05) added the retry and closed #3884.
- #6259 (2026-03-19) introduced `wrapInsert` and applied it inside `CreatePipeline`, silently defeating it.

Affected: **v3.14.0 → `main`** (verified per tag). v3.13.0 had no retry at all, so there is no version to downgrade to either.

## Measured in production

Self-hosted, Postgres, kubernetes backend, v3.16.0: **17 × HTTP 500 in 24 h across 10 repos**, each one a lost pipeline.

A PR merge fires two push webhooks ~130 ms apart (merge commit + branch deletion), which hits the race reliably:

```
13:08:29.348  push → 200
13:08:29.477  push → 500
```

Server log:

```json
{"level":"error","error":"backoff: permanent error (last error: on insert duplicate based on constraints was detected)","message":"failed to save pipeline for x/y"}
{"level":"error","error":"Error #01: failed to save pipeline for x/y","method":"POST","path":"/api/hook","status":500}
```

That `backoff: permanent error` line is the proof: it is the sentinel, verbatim, on the code path that was supposed to retry.

## The change

Recognize the sentinel with `errors.Is()`, **keeping** the raw string checks — `isUniqueConstraintError` is also reachable with errors that did not go through `wrapInsert`.

## Scope

This only revives the **mitigation**. The underlying race is still there (`CreatePipeline` does `SELECT MAX(number)` + `INSERT` without a lock) and **#5534 is the real fix** — this is not a substitute for it, just a restoration of the safety net that was silently lost.

## Tests

Adds `TestIsUniqueConstraintError`, verified in **both** directions:

```
against current main:  --- FAIL: TestIsUniqueConstraintError
                           Should be true
                           the sentinel returned by wrapInsert must be retryable

with this change:      ok   .../server/store/datastore   0.004s
```

`go build` and `go test ./server/store/datastore/` pass; `gofmt` clean.

Refs #3884, #6067, #6259, #5534