### PR TITLE
fix(github): resolve tag pagination loop in release hook

### DIFF
--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -787,10 +787,10 @@ func (c *client) getTagCommitSHA(ctx context.Context, repo *model.Repo, tagName 
 		return "", err
 	}
 
-	page := 1
+	opts := &github.ListOptions{Page: 1}
 	var tag *github.RepositoryTag
-	for {
-		tags, _, err := gh.Repositories.ListTags(ctx, repo.Owner, repo.Name, &github.ListOptions{Page: page})
+	for opts.Page > 0 {
+		tags, resp, err := gh.Repositories.ListTags(ctx, repo.Owner, repo.Name, opts)
 		if err != nil {
 			return "", err
 		}
@@ -804,6 +804,8 @@ func (c *client) getTagCommitSHA(ctx context.Context, repo *model.Repo, tagName 
 		if tag != nil {
 			break
 		}
+
+		opts.Page = resp.NextPage
 	}
 	if tag == nil {
 		return "", fmt.Errorf("could not find tag %s", tagName)

--- a/server/forge/github/github_test.go
+++ b/server/forge/github/github_test.go
@@ -325,3 +325,57 @@ func TestHook(t *testing.T) {
 		assert.Empty(t, pipeline.ChangedFiles)
 	})
 }
+
+func TestGetTagCommitSHA(t *testing.T) {
+	// Tags API paginates 30 per page; put the target tag on the second page
+	// to exercise pagination instead of a first-page match.
+	mockedHTTPClient := github_mock.NewMockedHTTPClient(
+		github_mock.WithRequestMatchPages(
+			github_mock.GetReposTagsByOwnerByRepo,
+			[]github.RepositoryTag{
+				{Name: github.Ptr("v1.0.0")},
+				{Name: github.Ptr("v1.0.1")},
+			},
+			[]github.RepositoryTag{
+				{Name: github.Ptr("v1.0.2")},
+				{
+					Name:   github.Ptr("v1.0.3"),
+					Commit: &github.Commit{SHA: github.Ptr("deadbeefcafe")},
+				},
+			},
+		),
+	)
+
+	gh, err := github.NewClient(github.WithHTTPClient(mockedHTTPClient))
+	require.NoError(t, err)
+
+	ctx := context.WithValue(context.Background(), githubClientKey, gh)
+
+	mockStore := store_mocks.NewMockStore(t)
+	mockStore.On("GetUser", mock.Anything).Return(&model.User{
+		ID:          1,
+		Login:       "6543",
+		AccessToken: "token",
+	}, nil)
+	mockStore.On("GetRepoNameFallback", mock.Anything, mock.Anything, mock.Anything).Return(&model.Repo{
+		ID:            1,
+		ForgeRemoteID: "1",
+		Owner:         "6543",
+		Name:          "hello-world",
+		UserID:        1,
+	}, nil)
+	ctx = store.InjectToContext(ctx, mockStore)
+
+	c := &client{API: defaultAPI, url: defaultURL}
+
+	t.Run("finds a tag beyond the first page", func(t *testing.T) {
+		sha, err := c.getTagCommitSHA(ctx, &model.Repo{ForgeRemoteID: "1", FullName: "6543/hello-world"}, "v1.0.3")
+		require.NoError(t, err)
+		assert.Equal(t, "deadbeefcafe", sha)
+	})
+
+	t.Run("returns an error instead of looping forever when the tag does not exist", func(t *testing.T) {
+		_, err := c.getTagCommitSHA(ctx, &model.Repo{ForgeRemoteID: "1", FullName: "6543/hello-world"}, "does-not-exist")
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Bug

When Woodpecker receives a GitHub `release` webhook, `getTagCommitSHA` in `server/forge/github/github.go` resolves the release tag to a commit SHA by paging through `Repositories.ListTags`. If the tag isn't on the first page (GitHub returns 30 tags per page by default), the lookup never terminates: it keeps re-requesting the first page until the webhook delivery times out or the REST rate limit is exhausted. No release pipeline is created, and the webhook handler surfaces a generic `failure to parse hook` error that makes the failure look like a payload parsing issue rather than what it actually is.

## Root cause

```go
page := 1
var tag *github.RepositoryTag
for {
    tags, _, err := gh.Repositories.ListTags(ctx, repo.Owner, repo.Name, &github.ListOptions{Page: page})
    ...
    if tag != nil {
        break
    }
    // page is never incremented, and there's no exit when tags is exhausted
}
```

`page` is initialized to `1` and never advanced. The discarded pagination response (`_`) also means there's no way to detect that the tag list has been exhausted, so a nonexistent tag would loop forever too.

## Fix

Mirror the pagination pattern already used a few lines above in the same file (`loadChangedFilesFromPullRequest`): keep `opts.Page` and advance it to `resp.NextPage` after each request, looping while `opts.Page > 0`. GitHub's REST API returns `NextPage == 0` on the last page, so the loop is now bounded by the actual number of tag pages and returns a descriptive `could not find tag %s` error if the tag genuinely doesn't exist.

```go
opts := &github.ListOptions{Page: 1}
var tag *github.RepositoryTag
for opts.Page > 0 {
    tags, resp, err := gh.Repositories.ListTags(ctx, repo.Owner, repo.Name, opts)
    ...
    if tag != nil {
        break
    }
    opts.Page = resp.NextPage
}
```

## Verification

- Added `TestGetTagCommitSHA` in `server/forge/github/github_test.go`, using `github_mock.WithRequestMatchPages` to mock a two-page tags response with the target tag on page 2 (reproducing the reported scenario of a tag beyond the first page).
  - **Before the fix**: running this test against the unpatched code with `go test -run TestGetTagCommitSHA -timeout 8s` reliably times out — the goroutine dump confirms it's stuck inside the `for {}` loop at the `ListTags` call, i.e. it never advances past page 1.
  - **After the fix**: the same test passes in ~2s, both for a tag found on the second page and for a nonexistent tag (which now returns an error instead of looping).
- `go test ./server/forge/github/...` — all tests pass (existing `TestHook`, `Test_parseHook`, `FuzzParseHookPayload`, plus the new test).
- `golangci-lint run ./server/forge/github/...` (pinned repo version v2.12.2) — 0 issues.
- `go build ./server/forge/github/...` — builds cleanly.

Fixes #6869