### PR TITLE
fix(forgejo): treat 404 on empty repos as empty pull request list

### DIFF
--- a/server/forge/forgejo/fixtures/handler.go
+++ b/server/forge/forgejo/fixtures/handler.go
@@ -33,6 +33,7 @@ func Handler() http.Handler {
 	e.GET("/api/v1/repos/:owner/:name/hooks", listRepoHooks)
 	e.DELETE("/api/v1/repos/:owner/:name/hooks/:id", deleteRepoHook)
 	e.POST("/api/v1/repos/:owner/:name/statuses/:commit", createRepoCommitStatus)
+	e.GET("/api/v1/repos/:owner/:name/pulls", listRepoPulls)
 	e.GET("/api/v1/repos/:owner/:name/pulls/:index/files", getPRFiles)
 	e.GET("/api/v1/user/repos", getUserRepos)
 	e.GET("/api/v1/version", getVersion)
@@ -137,6 +138,15 @@ func getPRFiles(c *gin.Context) {
 	}
 }
 
+func listRepoPulls(c *gin.Context) {
+	// Repositories without commits answer with an empty list and status code 404
+	if c.Param("name") == "repo_without_commits" {
+		c.String(http.StatusNotFound, "[]")
+		return
+	}
+	c.String(http.StatusOK, listRepoPullsPayload)
+}
+
 const listRepoHookPayloads = `
 [
 	{
@@ -171,6 +181,17 @@ const repoPayload = `
 `
 
 const repoFilePayload = `{ platform: linux/amd64 }`
+
+const listRepoPullsPayload = `
+[
+	{
+		"id": 1,
+		"number": 1,
+		"title": "add feature X",
+		"state": "open"
+	}
+]
+`
 
 const userRepoPayload = `
 [

--- a/server/forge/forgejo/forgejo.go
+++ b/server/forge/forgejo/forgejo.go
@@ -477,12 +477,17 @@ func (c *Forgejo) PullRequests(ctx context.Context, u *model.User, r *model.Repo
 		return nil, err
 	}
 
-	pullRequests, _, err := client.ListRepoPullRequests(r.Owner, r.Name, forgejo.ListPullRequestsOptions{
+	pullRequests, resp, err := client.ListRepoPullRequests(r.Owner, r.Name, forgejo.ListPullRequestsOptions{
 		ListOptions: forgejo.ListOptions{Page: p.Page, PageSize: p.PerPage},
 		State:       forgejo.StateOpen,
 	})
 	if err != nil {
-		return nil, err
+		// Repositories without commits return empty list with status code 404
+		if pullRequests != nil && resp != nil && resp.StatusCode == http.StatusNotFound {
+			err = nil
+		} else {
+			return nil, err
+		}
 	}
 
 	result := make([]*model.PullRequest, len(pullRequests))

--- a/server/forge/forgejo/forgejo_test.go
+++ b/server/forge/forgejo/forgejo_test.go
@@ -98,6 +98,19 @@ func Test_forgejo(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("pull request list", func(t *testing.T) {
+		prs, err := c.PullRequests(ctx, fakeUser, fakeRepo, &model.ListOptions{Page: 1, PerPage: 10})
+		assert.NoError(t, err)
+		assert.Len(t, prs, 1)
+		assert.Equal(t, "add feature X", prs[0].Title)
+	})
+	t.Run("pull request list for repo without commits", func(t *testing.T) {
+		// Forgejo answers with 404 for repos without commits; that must be treated as an empty list, not an error
+		prs, err := c.PullRequests(ctx, fakeUser, fakeRepoEmpty, &model.ListOptions{Page: 1, PerPage: 10})
+		assert.NoError(t, err)
+		assert.Empty(t, prs)
+	})
+
 	t.Run("register repository", func(t *testing.T) {
 		err := c.Activate(ctx, fakeUser, fakeRepo, "http://localhost")
 		assert.NoError(t, err)
@@ -158,6 +171,12 @@ var (
 		Owner:    "test_name",
 		Name:     "repo_not_found",
 		FullName: "test_name/repo_not_found",
+	}
+
+	fakeRepoEmpty = &model.Repo{
+		Owner:    "test_name",
+		Name:     "repo_without_commits",
+		FullName: "test_name/repo_without_commits",
 	}
 
 	fakePipeline = &model.Pipeline{


### PR DESCRIPTION
Closes #6871

Forgejo (like Gitea) answers `GET /repos/{owner}/{repo}/pulls` with **HTTP 404** when a repository has no commits yet. The Gitea forge already treats this as an empty pull request list, but the Forgejo forge discarded the response and returned the error verbatim, so `Forge.PullRequests()` failed for repos without commits — e.g. the UI selector to run a pipeline for a PR errored instead of showing an empty list.

This ports the existing Gitea workaround to the Forgejo forge: capture the response and, when the list call fails with a `404` and a (non-nil) empty list, treat it as success.

### Changes

- `server/forge/forgejo/forgejo.go` — keep the `*Response` from `ListRepoPullRequests` and treat a `404` empty result as an empty list, mirroring `server/forge/gitea/gitea.go`.
- `server/forge/forgejo/fixtures/handler.go` — add a `GET .../pulls` mock route that returns a normal list, and `404` + `[]` for a repo named `repo_without_commits`.
- `server/forge/forgejo/forgejo_test.go` — regression test covering a normal listing and the empty-repo `404` case.

### Verification

`go test ./server/forge/forgejo/...` passes. Reverting only the `forgejo.go` change makes the new `pull request list for repo without commits` subtest fail with `unknown API Error: 404`, confirming it's a genuine regression test.
