### PR TITLE
Document woodpecker-cli configuration files

### DIFF
--- a/cmd/cli/docs.go
+++ b/cmd/cli/docs.go
@@ -22,6 +22,35 @@ import (
 	docs "github.com/urfave/cli-docs/v3"
 )
 
+const configurationDocs = `# CONFIGURATION
+
+The CLI normally uses contexts created by ` + "`woodpecker-cli setup`" + `. Context metadata is JSON in ` + "`woodpecker/contexts.json`" + ` below the platform configuration directory:
+
+- Linux: ` + "`$XDG_CONFIG_HOME/woodpecker/contexts.json`" + ` (defaults to ` + "`~/.config/woodpecker/contexts.json`" + `)
+- macOS: ` + "`~/Library/Application Support/woodpecker/contexts.json`" + `
+- Windows: ` + "`%LOCALAPPDATA%\\woodpecker\\contexts.json`" + `
+
+The file contains ` + "`current_context`" + ` and a ` + "`contexts`" + ` object. Each context has ` + "`name`" + `, ` + "`server_url`" + `, and optionally ` + "`log_level`" + `. Authentication tokens are stored in the operating-system keyring, not in this file. For example:
+
+` + "```json" + `
+{
+  "current_context": "production",
+  "contexts": {
+    "production": {
+      "name": "production",
+      "server_url": "https://ci.example.com",
+      "log_level": "info"
+    }
+  }
+}
+` + "```" + `
+
+The ` + "`--config`" + ` / ` + "`-c`" + ` flag and ` + "`WOODPECKER_CONFIG`" + ` select a legacy JSON configuration file. It is consulted only when no usable current context exists. Without the flag, its platform-relative path is ` + "`woodpecker/config.json`" + ` in the same configuration directory. It accepts ` + "`server_url`" + ` and ` + "`log_level`" + `; tokens are not read from JSON.
+
+Command-line flags and their matching environment variables take precedence over file values. In particular, the CLI can be used without a context or config file by setting ` + "`WOODPECKER_SERVER`" + ` and ` + "`WOODPECKER_TOKEN`" + `. ` + "`WOODPECKER_LOG_LEVEL`" + ` controls the log level. Only one platform configuration location is used; files are not merged across locations.
+
+`
+
 func main() {
 	app := newApp()
 	md, err := docs.ToMarkdown(app)
@@ -34,7 +63,7 @@ func main() {
 		panic(err)
 	}
 	defer fi.Close()
-	if _, err := fi.WriteString("# CLI\n\n" + md); err != nil {
+	if _, err := fi.WriteString("# CLI\n\n" + configurationDocs + md); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
The generated CLI reference now explains:

- platform-specific context and legacy config paths
- both JSON formats and the values stored in each
- token storage in the OS keyring
- config, flag, and environment-variable precedence
- config-free use with `WOODPECKER_SERVER` and `WOODPECKER_TOKEN`

The text lives in the CLI documentation generator so regeneration preserves it.

Verification:
- `go generate ./cmd/cli`
- `go test ./cmd/cli ./cli/internal/config`
- `go vet ./cmd/cli ./cli/internal/config`

Closes #6885