### PR TITLE
Use toLabelValue instead of toDNSName in Kubernetes step label

### DIFF
--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -140,11 +140,11 @@ func podLabels(step *types.Step, config *config, options BackendOptions, taskUUI
 	if isService(step) {
 		labels[ServiceLabel], _ = serviceName(step)
 	}
-	labels[StepLabelLegacy], err = stepLabel(step)
+	labels[StepLabelLegacy], err = toDNSName(step.Name)
 	if err != nil {
 		return labels, err
 	}
-	labels[StepLabel], err = stepLabel(step)
+	labels[StepLabel], err = toDNSName(step.Name)
 	if err != nil {
 		return labels, err
 	}
@@ -154,10 +154,6 @@ func podLabels(step *types.Step, config *config, options BackendOptions, taskUUI
 	}
 
 	return labels, nil
-}
-
-func stepLabel(step *types.Step) (string, error) {
-	return toLabelValue(step.Name)
 }
 
 func podAnnotations(config *config, options BackendOptions) map[string]string {

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -140,11 +140,11 @@ func podLabels(step *types.Step, config *config, options BackendOptions, taskUUI
 	if isService(step) {
 		labels[ServiceLabel], _ = serviceName(step)
 	}
-	labels[StepLabelLegacy], err = toDNSName(step.Name)
+	labels[StepLabelLegacy], err = toLabelValue(step.Name)
 	if err != nil {
 		return labels, err
 	}
-	labels[StepLabel], err = toDNSName(step.Name)
+	labels[StepLabel], err = toLabelValue(step.Name)
 	if err != nil {
 		return labels, err
 	}

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -157,7 +157,7 @@ func podLabels(step *types.Step, config *config, options BackendOptions, taskUUI
 }
 
 func stepLabel(step *types.Step) (string, error) {
-	return toDNSName(step.Name)
+	return toLabelValue(step.Name)
 }
 
 func podAnnotations(config *config, options BackendOptions) map[string]string {

--- a/pipeline/backend/kubernetes/pod_test.go
+++ b/pipeline/backend/kubernetes/pod_test.go
@@ -16,6 +16,7 @@ package kubernetes
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/kinbiko/jsonassert"
@@ -123,6 +124,10 @@ func TestStepLabel(t *testing.T) {
 	name, err = stepLabel(&types.Step{Name: ".build.image"})
 	assert.NoError(t, err)
 	assert.EqualValues(t, "build.image", name)
+
+	name, err = stepLabel(&types.Step{Name: strings.Repeat("a", 100)})
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, len(name), 63)
 }
 
 func TestPodHostnameSanitized(t *testing.T) {

--- a/pipeline/backend/kubernetes/pod_test.go
+++ b/pipeline/backend/kubernetes/pod_test.go
@@ -16,7 +16,6 @@ package kubernetes
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/kinbiko/jsonassert"
@@ -114,20 +113,6 @@ func TestPodMeta(t *testing.T) {
 	}, BackendOptions{}, "wp-01he8bebctabr3kg-0", taskUUID)
 	assert.NoError(t, err)
 	assert.EqualValues(t, "", meta.Labels[ServiceLabel])
-}
-
-func TestStepLabel(t *testing.T) {
-	name, err := stepLabel(&types.Step{Name: "Build image"})
-	assert.NoError(t, err)
-	assert.EqualValues(t, "build-image", name)
-
-	name, err = stepLabel(&types.Step{Name: ".build.image"})
-	assert.NoError(t, err)
-	assert.EqualValues(t, "build.image", name)
-
-	name, err = stepLabel(&types.Step{Name: strings.Repeat("a", 100)})
-	assert.NoError(t, err)
-	assert.LessOrEqual(t, len(name), 63)
 }
 
 func TestPodHostnameSanitized(t *testing.T) {

--- a/pipeline/backend/kubernetes/pod_test.go
+++ b/pipeline/backend/kubernetes/pod_test.go
@@ -16,6 +16,7 @@ package kubernetes
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/kinbiko/jsonassert"
@@ -113,6 +114,80 @@ func TestPodMeta(t *testing.T) {
 	}, BackendOptions{}, "wp-01he8bebctabr3kg-0", taskUUID)
 	assert.NoError(t, err)
 	assert.EqualValues(t, "", meta.Labels[ServiceLabel])
+}
+
+// TestStepNameAsLabel verifies that step names are correctly converted to valid
+// Kubernetes label values via toLabelValue (replaces the old stepLabel wrapper).
+func TestStepNameAsLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		stepName string
+		want     string
+	}{
+		{
+			name:     "spaces converted to dashes and lowercased",
+			stepName: "Build image",
+			want:     "build-image",
+		},
+		{
+			name:     "leading dot stripped",
+			stepName: ".build.image",
+			want:     "build.image",
+		},
+		{
+			name:     "simple lowercase name unchanged",
+			stepName: "test",
+			want:     "test",
+		},
+		{
+			name:     "underscores preserved",
+			stepName: "run_tests",
+			want:     "run_tests",
+		},
+		{
+			name:     "mixed special characters",
+			stepName: "Deploy (production)",
+			want:     "deploy-production",
+		},
+		{
+			name:     "consecutive spaces single dash",
+			stepName: "step   name",
+			want:     "step-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toLabelValue(tt.stepName)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestStepNameAsLabelInPod verifies that step labels in a pod use toLabelValue
+// and produce valid values that Kubernetes accepts.
+func TestStepNameAsLabelInPod(t *testing.T) {
+	step := &types.Step{
+		Name:        "Build & Deploy (staging)",
+		Image:       "alpine:latest",
+		UUID:        "01he8bebctabr3kgk0qj36d2me-1",
+		WorkingDir:  "/woodpecker/src",
+		Environment: map[string]string{},
+	}
+	meta, err := podMeta(step, &config{Namespace: "woodpecker"}, BackendOptions{}, "wp-01he8bebctabr3kgk0qj36d2me-1", taskUUID)
+	assert.NoError(t, err)
+	assert.Equal(t, "build-deploy-staging", meta.Labels[StepLabel])
+	assert.Equal(t, "build-deploy-staging", meta.Labels[StepLabelLegacy])
+}
+
+// TestStepNameAsLabelLongName verifies that long step names are truncated
+// to 63 characters (Kubernetes label value limit).
+func TestStepNameAsLabelLongName(t *testing.T) {
+	longName := strings.Repeat("a", 100)
+	got, err := toLabelValue(longName)
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, len(got), 63)
 }
 
 func TestPodHostnameSanitized(t *testing.T) {

--- a/pipeline/backend/kubernetes/secrets.go
+++ b/pipeline/backend/kubernetes/secrets.go
@@ -270,11 +270,11 @@ func registrySecretLabels(step *types.Step, config *config) (map[string]string, 
 	if step.Type == types.StepTypeService {
 		labels[ServiceLabel], _ = serviceName(step)
 	}
-	labels[StepLabelLegacy], err = stepLabel(step)
+	labels[StepLabelLegacy], err = toDNSName(step.Name)
 	if err != nil {
 		return labels, err
 	}
-	labels[StepLabel], err = stepLabel(step)
+	labels[StepLabel], err = toDNSName(step.Name)
 	if err != nil {
 		return labels, err
 	}

--- a/pipeline/backend/kubernetes/secrets.go
+++ b/pipeline/backend/kubernetes/secrets.go
@@ -270,11 +270,11 @@ func registrySecretLabels(step *types.Step, config *config) (map[string]string, 
 	if step.Type == types.StepTypeService {
 		labels[ServiceLabel], _ = serviceName(step)
 	}
-	labels[StepLabelLegacy], err = toDNSName(step.Name)
+	labels[StepLabelLegacy], err = toLabelValue(step.Name)
 	if err != nil {
 		return labels, err
 	}
-	labels[StepLabel], err = toDNSName(step.Name)
+	labels[StepLabel], err = toLabelValue(step.Name)
 	if err != nil {
 		return labels, err
 	}


### PR DESCRIPTION
Follow up on #6855 / #6827, as the `test` and `woodpecker-ci.org/step` labels still use `toDNSName()` instead of `toLabelValue()`.

<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->

cc @xoxys.
