### PR TITLE
Fix pipeline queue default template data

### DIFF
--- a/cli/pipeline/queue_test.go
+++ b/cli/pipeline/queue_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+func TestPipelineQueueDefaultTemplateRendersFeed(t *testing.T) {
+	tmpl, err := template.New("_").Parse(tmplPipelineQueue)
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	err = tmpl.Execute(&out, &woodpecker.Feed{
+		FullName: "octocat/hello-world",
+		Number:   42,
+		Status:   "running",
+		Event:    "push",
+		Commit:   "abc123",
+		Branch:   "main",
+		Ref:      "refs/heads/main",
+		Author:   "Mona",
+		Email:    "mona@example.com",
+		Message:  "build it",
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "octocat/hello-world #42")
+}

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -4801,6 +4801,9 @@ const docTemplate = `{
                 "finished": {
                     "type": "integer"
                 },
+                "full_name": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "integer"
                 },

--- a/server/model/feed.go
+++ b/server/model/feed.go
@@ -20,6 +20,7 @@ import "fmt"
 // Feed represents an item in the user's feed or timeline.
 type Feed struct {
 	RepoID   int64        `json:"repo_id"                 xorm:"repo_id"`
+	FullName string       `json:"full_name,omitempty"     xorm:"repo_full_name"`
 	ID       int64        `json:"id,omitempty"            xorm:"pipeline_id"`
 	Number   int64        `json:"number,omitempty"        xorm:"pipeline_number"`
 	Event    WebhookEvent `json:"event,omitempty"         xorm:"pipeline_event"`

--- a/server/store/datastore/feed.go
+++ b/server/store/datastore/feed.go
@@ -24,6 +24,7 @@ import (
 
 func (s storage) getFeedSelect() string {
 	const feedTemplate = `repos.id as repo_id,
+repos.full_name as repo_full_name,
 pipelines.id as pipeline_id,
 pipelines.number as pipeline_number,
 pipelines.event as pipeline_event,

--- a/server/store/datastore/feed_test.go
+++ b/server/store/datastore/feed_test.go
@@ -68,6 +68,7 @@ func TestGetPipelineQueue(t *testing.T) {
 
 	feedItem := feed[0]
 	assert.Equal(t, repo1.ID, feedItem.RepoID)
+	assert.Equal(t, repo1.FullName, feedItem.FullName)
 	assert.Equal(t, pipeline1.ID, feedItem.ID)
 	assert.Equal(t, pipeline1.Number, feedItem.Number)
 	assert.EqualValues(t, pipeline1.Event, feedItem.Event)

--- a/woodpecker-go/woodpecker/types.go
+++ b/woodpecker-go/woodpecker/types.go
@@ -196,6 +196,7 @@ type (
 	// Feed represents an item in the user's feed or timeline.
 	Feed struct {
 		RepoID   int64  `json:"repo_id"`
+		FullName string `json:"full_name,omitempty"`
 		ID       int64  `json:"id,omitempty"`
 		Number   int64  `json:"number,omitempty"`
 		Event    string `json:"event,omitempty"`


### PR DESCRIPTION
## Summary

Fix `woodpecker-cli pipeline queue` so its default template has the data it expects. The command renders queue entries as `woodpecker.Feed`, but the default format starts with `.FullName`; the feed API and SDK now include `full_name` from the joined repository row.

Add a CLI regression test that renders the default queue template against a real `woodpecker.Feed`, and extend the datastore test to prove queued feed rows carry the repository full name.

Closes woodpecker-ci/woodpecker#6905

## Testing

```sh
go test ./cli/pipeline -run TestPipelineQueueDefaultTemplateRendersFeed -count=1
go test ./server/store/datastore -run TestGetPipelineQueue -count=1
make generate-openapi
make test-cli
make test-server-datastore
mkdir -p web/dist && printf 'test' > web/dist/index.html && PATH="$(go env GOPATH)/bin:$PATH" make lint
git diff --check
```
