### PR TITLE
feat: add AtomGit forge driver

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -478,7 +478,7 @@ var flags = append([]cli.Flag{
 	&cli.StringFlag{
 		Name:    "forge-url",
 		Usage:   "url of the forge",
-		Sources: cli.EnvVars("WOODPECKER_FORGE_URL", "WOODPECKER_GITHUB_URL", "WOODPECKER_GITLAB_URL", "WOODPECKER_GITEA_URL", "WOODPECKER_FORGEJO_URL", "WOODPECKER_BITBUCKET_URL", "WOODPECKER_BITBUCKET_DC_URL"),
+		Sources: cli.EnvVars("WOODPECKER_FORGE_URL", "WOODPECKER_GITHUB_URL", "WOODPECKER_GITLAB_URL", "WOODPECKER_GITEA_URL", "WOODPECKER_FORGEJO_URL", "WOODPECKER_BITBUCKET_URL", "WOODPECKER_BITBUCKET_DC_URL", "WOODPECKER_ATOMGIT_URL"),
 	},
 	&cli.StringFlag{
 		Sources: cli.NewValueSourceChain(
@@ -490,6 +490,7 @@ var flags = append([]cli.Flag{
 				"WOODPECKER_FORGEJO_CLIENT_FILE",
 				"WOODPECKER_BITBUCKET_CLIENT_FILE",
 				"WOODPECKER_BITBUCKET_DC_CLIENT_ID_FILE",
+				"WOODPECKER_ATOMGIT_CLIENT_FILE",
 			)),
 			cli.EnvVar("WOODPECKER_FORGE_CLIENT"),
 			cli.EnvVar("WOODPECKER_GITHUB_CLIENT"),
@@ -498,6 +499,7 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_FORGEJO_CLIENT"),
 			cli.EnvVar("WOODPECKER_BITBUCKET_CLIENT"),
 			cli.EnvVar("WOODPECKER_BITBUCKET_DC_CLIENT_ID"),
+			cli.EnvVar("WOODPECKER_ATOMGIT_CLIENT"),
 		),
 		Name:  "forge-oauth-client",
 		Usage: "oauth2 client id",
@@ -515,6 +517,7 @@ var flags = append([]cli.Flag{
 				"WOODPECKER_FORGEJO_SECRET_FILE",
 				"WOODPECKER_BITBUCKET_SECRET_FILE",
 				"WOODPECKER_BITBUCKET_DC_CLIENT_SECRET_FILE",
+				"WOODPECKER_ATOMGIT_SECRET_FILE",
 			)),
 			cli.EnvVar("WOODPECKER_FORGE_SECRET"),
 			cli.EnvVar("WOODPECKER_GITHUB_SECRET"),
@@ -523,6 +526,7 @@ var flags = append([]cli.Flag{
 			cli.EnvVar("WOODPECKER_FORGEJO_SECRET"),
 			cli.EnvVar("WOODPECKER_BITBUCKET_SECRET"),
 			cli.EnvVar("WOODPECKER_BITBUCKET_DC_CLIENT_SECRET"),
+			cli.EnvVar("WOODPECKER_ATOMGIT_SECRET"),
 		),
 		Name:  "forge-oauth-secret",
 		Usage: "oauth2 client secret",
@@ -582,6 +586,14 @@ var flags = append([]cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_GITEA"),
 		Name:    "gitea",
 		Usage:   "gitea driver is enabled",
+	},
+	//
+	// AtomGit
+	//
+	&cli.BoolFlag{
+		Sources: cli.EnvVars("WOODPECKER_ATOMGIT"),
+		Name:    "atomgit",
+		Usage:   "atomgit driver is enabled",
 	},
 	//
 	// Forgejo

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -6244,6 +6244,7 @@ const docTemplate = `{
                 "forgejo",
                 "bitbucket",
                 "bitbucket-dc",
+                "atomgit",
                 "addon"
             ],
             "x-enum-varnames": [
@@ -6253,6 +6254,7 @@ const docTemplate = `{
                 "ForgeTypeForgejo",
                 "ForgeTypeBitbucket",
                 "ForgeTypeBitbucketDatacenter",
+                "ForgeTypeAtomGit",
                 "ForgeTypeAddon"
             ]
         },

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -379,7 +379,51 @@ func LookupRepo(c *gin.Context) {
 //	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
 //	@Param		repo_id			path	int		true	"the repository id"
 func GetRepo(c *gin.Context) {
-	c.JSON(http.StatusOK, session.Repo(c))
+	repo := session.Repo(c)
+
+	// Lazily backfill forge-derived fields (forge_url, pr_enabled, ...) that
+	// may be missing on repos enabled before the forge driver populated them.
+	// This self-heals stale rows (e.g. AtomGit repos stored without a
+	// forge_url) without requiring a manual repair. Only triggered while the
+	// stored forge_url is empty, so the forge is contacted at most once.
+	if repo.ForgeURL == "" {
+		if err := backfillRepoFromForge(c, repo); err != nil {
+			// Non-fatal: serve the stored repo as-is if the forge is unreachable.
+			log.Trace().Err(err).Msgf("could not backfill repo '%s/%s' from forge", repo.Owner, repo.Name)
+		}
+	}
+
+	c.JSON(http.StatusOK, repo)
+}
+
+// backfillRepoFromForge refreshes forge-derived repository fields from the
+// forge and persists them to the store.
+func backfillRepoFromForge(c *gin.Context, repo *model.Repo) error {
+	_store := store.FromContext(c)
+	_forge, err := server.Config.Services.Manager.ForgeFromRepo(repo)
+	if err != nil {
+		return err
+	}
+	repoUser, err := _store.GetUser(repo.UserID)
+	if err != nil {
+		return err
+	}
+	forge.Refresh(c, _forge, _store, repoUser)
+
+	from, err := _forge.Repo(c, repoUser, repo.ForgeRemoteID, repo.Owner, repo.Name)
+	if err != nil {
+		return err
+	}
+	if from.ForgeURL == "" {
+		return nil
+	}
+	repo.ForgeURL = from.ForgeURL
+	repo.PREnabled = from.PREnabled
+	repo.Clone = from.Clone
+	repo.CloneSSH = from.CloneSSH
+	repo.Branch = from.Branch
+	repo.IsSCMPrivate = from.IsSCMPrivate
+	return _store.UpdateRepo(repo)
 }
 
 // GetRepoPermissions

--- a/server/forge/atomgit/atomgit.go
+++ b/server/forge/atomgit/atomgit.go
@@ -1,0 +1,653 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomgit
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/oauth2"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server"
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge"
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge/common"
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+	"go.woodpecker-ci.org/woodpecker/v3/shared/httputil"
+)
+
+const (
+	defaultPageSize = 50
+
+	authorizeTokenURL = "%s/oauth/authorize"
+	accessTokenURL    = "%s/oauth/token"
+	apiPath           = "/api/v5"
+)
+
+// AtomGit implements the forge.Forge interface for https://atomgit.com.
+type AtomGit struct {
+	id                int64
+	url               string
+	oAuthClientID     string
+	oAuthClientSecret string
+	oAuthHost         string
+	skipVerify        bool
+	pageSize          int
+}
+
+// Opts defines configuration options for the AtomGit driver.
+type Opts struct {
+	URL               string
+	OAuthClientID     string
+	OAuthClientSecret string
+	OAuthHost         string
+	SkipVerify        bool
+}
+
+// New returns a Forge implementation that integrates with AtomGit.
+func New(id int64, opts Opts) (forge.Forge, error) {
+	return &AtomGit{
+		id:                id,
+		url:               opts.URL,
+		oAuthClientID:     opts.OAuthClientID,
+		oAuthClientSecret: opts.OAuthClientSecret,
+		oAuthHost:         opts.OAuthHost,
+		skipVerify:        opts.SkipVerify,
+	}, nil
+}
+
+// Name returns the unique identifier of this driver.
+func (c *AtomGit) Name() string { return "atomgit" }
+
+// URL returns the root url of the configured forge.
+func (c *AtomGit) URL() string { return c.url }
+
+func (c *AtomGit) httpClient() *http.Client {
+	if c.skipVerify {
+		return &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	}
+	return &http.Client{}
+}
+
+func (c *AtomGit) oauth2Config(ctx context.Context) (*oauth2.Config, context.Context) {
+	publicOAuthURL := c.oAuthHost
+	if publicOAuthURL == "" {
+		publicOAuthURL = c.url
+	}
+	return &oauth2.Config{
+			ClientID:     c.oAuthClientID,
+			ClientSecret: c.oAuthClientSecret,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  fmt.Sprintf(authorizeTokenURL, publicOAuthURL),
+				TokenURL: fmt.Sprintf(accessTokenURL, publicOAuthURL),
+			},
+			RedirectURL: fmt.Sprintf("%s/authorize", server.Config.Server.OAuthHost),
+		},
+		context.WithValue(ctx, oauth2.HTTPClient, httputil.WrapClient(c.httpClient(), "forge-atomgit"))
+}
+
+// Login authenticates a user via AtomGit OAuth2.
+func (c *AtomGit) Login(ctx context.Context, req *forge_types.OAuthRequest) (*model.User, string, error) {
+	config, oauth2Ctx := c.oauth2Config(ctx)
+	redirectURL := config.AuthCodeURL(req.State)
+
+	if len(req.Code) == 0 {
+		return nil, redirectURL, nil
+	}
+
+	token, err := config.Exchange(oauth2Ctx, req.Code)
+	if err != nil {
+		return nil, redirectURL, fmt.Errorf("oauth2 config exchange failed: %w", err)
+	}
+
+	account, err := c.getCurrentUser(oauth2Ctx, token.AccessToken)
+	if err != nil {
+		return nil, redirectURL, fmt.Errorf("fetching user info failed: %w", err)
+	}
+
+	return &model.User{
+		AccessToken:   token.AccessToken,
+		RefreshToken:  token.RefreshToken,
+		Expiry:        token.Expiry.UTC().Unix(),
+		Login:         account.Username,
+		Email:         account.Email,
+		ForgeRemoteID: model.ForgeRemoteID(account.ID),
+		Avatar:        expandAvatar(account.HTMLURL, account.AvatarURL),
+	}, redirectURL, nil
+}
+
+// Refresh refreshes the AtomGit oauth2 access token.
+func (c *AtomGit) Refresh(ctx context.Context, user *model.User) (bool, error) {
+	config, oauth2Ctx := c.oauth2Config(ctx)
+	config.RedirectURL = ""
+
+	source := config.TokenSource(oauth2Ctx, &oauth2.Token{
+		AccessToken:  user.AccessToken,
+		RefreshToken: user.RefreshToken,
+		Expiry:       time.Unix(user.Expiry, 0),
+	})
+
+	token, err := source.Token()
+	if err != nil || len(token.AccessToken) == 0 {
+		return false, err
+	}
+
+	user.AccessToken = token.AccessToken
+	user.RefreshToken = token.RefreshToken
+	user.Expiry = token.Expiry.UTC().Unix()
+	return true, nil
+}
+
+func (c *AtomGit) getCurrentUser(ctx context.Context, token string) (*user, error) {
+	out := new(user)
+	apiURL := fmt.Sprintf("%s%s/user", c.url, apiPath)
+	if err := c.get(ctx, token, apiURL, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Teams returns the organizations the user belongs to.
+func (c *AtomGit) Teams(ctx context.Context, u *model.User, p *model.ListOptions) ([]*model.Team, error) {
+	if p.Page != 1 {
+		return nil, nil
+	}
+
+	// AtomGit's /users/orgs returns a bare JSON array (the {"data": [...]} wrapper
+	// only appears in local fixtures).
+	out := make([]*namespace, 0)
+	apiURL := fmt.Sprintf("%s%s/users/orgs", c.url, apiPath)
+	if err := c.get(ctx, u.AccessToken, apiURL, &out); err != nil {
+		return nil, err
+	}
+
+	teams := make([]*model.Team, 0, len(out))
+	for _, org := range out {
+		teams = append(teams, toTeam(org, c.url))
+	}
+	return teams, nil
+}
+
+// Repo fetches a single repository by remote ID or owner/name.
+func (c *AtomGit) Repo(ctx context.Context, u *model.User, remoteID model.ForgeRemoteID, owner, name string) (*model.Repo, error) {
+	// Prefer the full repository lookup by owner/name whenever possible:
+	// GET /repos/:owner/:name is the only endpoint that reliably carries
+	// html_url and has_pull_requests. Resolving by id alone can return an
+	// incomplete payload (no html_url), which would leave forge_url empty.
+	if owner != "" && name != "" {
+		if full, err := c.getRepoByName(ctx, u.AccessToken, owner, name); err == nil {
+			return toRepo(full), nil
+		}
+		// On error, fall through to the remoteID-based resolution below.
+	}
+
+	// AtomGit has no single-repo lookup by numeric id (only /repos/{owner}/{repo}),
+	// so resolve a remoteID by scanning the authenticated user's repositories.
+	if remoteID.IsValid() {
+		if scanned, serr := c.getRepoByIDScan(ctx, u, remoteID); serr == nil {
+			return scanned, nil
+		}
+	}
+
+	if owner != "" && name != "" {
+		out, err := c.getRepoByName(ctx, u.AccessToken, owner, name)
+		if err != nil {
+			return nil, err
+		}
+		return toRepo(out), nil
+	}
+
+	return nil, forge_types.ErrRepoNotFound
+}
+
+// getRepoByIDScan lists the authenticated user's repositories and returns the
+// one whose id matches remoteID. AtomGit does not expose a single-repo lookup
+// by id, so this is how Repo() resolves a remoteID without owner/name.
+func (c *AtomGit) getRepoByIDScan(ctx context.Context, u *model.User, remoteID model.ForgeRemoteID) (*model.Repo, error) {
+	page := 1
+	for {
+		apiURL := fmt.Sprintf("%s%s/user/repos?page=%d&per_page=100", c.url, apiPath, page)
+		repos := make([]*repository, 0)
+		if err := c.get(ctx, u.AccessToken, apiURL, &repos); err != nil {
+			return nil, err
+		}
+		if len(repos) == 0 {
+			break
+		}
+		for _, r := range repos {
+			if string(r.ID) == string(remoteID) {
+				// The /user/repos summary omits fields the UI needs
+				// (html_url, has_pull_requests, ...), so upgrade to the full
+				// repository object via GET /repos/:owner/:name. The summary
+				// does not include a namespace object, so derive owner/name
+				// from the always-present path_with_namespace / full_name.
+				fullName := r.FullName
+				if fullName == "" {
+					fullName = r.PathWithNamespace
+				}
+				owner, name := repoOwnerName(fullName)
+				if owner != "" && name != "" {
+					if full, ferr := c.getRepoByName(ctx, u.AccessToken, owner, name); ferr == nil {
+						return toRepo(full), nil
+					}
+				}
+				return toRepo(r), nil
+			}
+		}
+		if len(repos) < 100 {
+			break
+		}
+		page++
+	}
+	return nil, forge_types.ErrRepoNotFound
+}
+
+func (c *AtomGit) getRepoByName(ctx context.Context, token, owner, name string) (*repository, error) {
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s", c.url, apiPath, owner, name)
+	out := new(repository)
+	if err := c.get(ctx, token, apiURL, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Repos fetches all repositories accessible to the user.
+func (c *AtomGit) Repos(ctx context.Context, u *model.User, p *model.ListOptions) ([]*model.Repo, error) {
+	if p.Page != 1 {
+		return nil, nil
+	}
+
+	// AtomGit's /user/repos returns a bare JSON array of repositories (the
+	// Gitee-style {"data": [...]} wrapper only appears in local fixtures).
+	out := make([]*repository, 0)
+	apiURL := fmt.Sprintf("%s%s/user/repos", c.url, apiPath)
+	if err := c.get(ctx, u.AccessToken, apiURL, &out); err != nil {
+		return nil, err
+	}
+
+	result := make([]*model.Repo, 0, len(out))
+	for _, repo := range out {
+		if repo.Archived.Bool() {
+			continue
+		}
+		result = append(result, toRepo(repo))
+	}
+	return result, nil
+}
+
+// File fetches a single file at a specific commit.
+func (c *AtomGit) File(ctx context.Context, u *model.User, r *model.Repo, b *model.Pipeline, fileName string) ([]byte, error) {
+	encoded := url.PathEscape(fileName)
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s/raw/%s?ref=%s", c.url, apiPath, r.Owner, r.Name, encoded, b.Commit)
+	body, status, err := c.getRaw(ctx, u.AccessToken, apiURL)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusNotFound {
+		return nil, errors.Join(err, &forge_types.ErrConfigNotFound{Configs: []string{fileName}})
+	}
+	if status >= http.StatusBadRequest {
+		return nil, fmt.Errorf("could not fetch file: status %d", status)
+	}
+	return body, nil
+}
+
+// Dir fetches all files in a directory at a specific commit.
+func (c *AtomGit) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model.Pipeline, dirName string) ([]*forge_types.FileMeta, error) {
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s/file_list?ref=%s", c.url, apiPath, r.Owner, r.Name, b.Commit)
+	// AtomGit's /file_list returns a bare JSON array of file path strings
+	// (e.g. [".woodpecker/test.yaml","README.md",...]); the Gitee-style
+	// [{"path":...,"type":...,"name":...}] object form only appears in fixtures.
+	var names []string
+	if err := c.get(ctx, u.AccessToken, apiURL, &names); err != nil {
+		return nil, err
+	}
+
+	var configs []*forge_types.FileMeta
+	for _, name := range names {
+		data, err := c.File(ctx, u, r, b, name)
+		if err != nil {
+			return nil, fmt.Errorf("multi-pipeline cannot get %s: %w", name, err)
+		}
+		configs = append(configs, &forge_types.FileMeta{Name: name, Data: data})
+	}
+	return configs, nil
+}
+
+// Status posts pipeline status to AtomGit. AtomGit does not expose a commit
+// status API, so this is a best-effort no-op that does not block pipelines.
+func (c *AtomGit) Status(_ context.Context, _ *model.User, _ *model.Repo, _ *model.Pipeline, _ *model.Workflow) error {
+	log.Debug().Msg("atomgit does not support commit status updates; skipping")
+	return nil
+}
+
+// Netrc returns netrc credentials for cloning the repository.
+func (c *AtomGit) Netrc(u *model.User, r *model.Repo) (*model.Netrc, error) {
+	login := ""
+	token := ""
+	if u != nil {
+		login = u.Login
+		token = u.AccessToken
+	}
+
+	host, err := common.ExtractHostFromCloneURL(r.Clone)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.Netrc{
+		Login:    login,
+		Password: token,
+		Machine:  host,
+		Type:     model.ForgeTypeAtomGit,
+	}, nil
+}
+
+// Activate registers a webhook pointing to Woodpecker.
+func (c *AtomGit) Activate(ctx context.Context, u *model.User, r *model.Repo, link string) error {
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s/hooks", c.url, apiPath, r.Owner, r.Name)
+	body := map[string]any{
+		"url":                   link,
+		"password":              r.Hash,
+		"push_events":           true,
+		"tag_push_events":       true,
+		"merge_requests_events": true,
+		"issues_events":         false,
+		"note_events":           false,
+	}
+	_, status, err := c.post(ctx, u.AccessToken, apiURL, body)
+	if err != nil {
+		return err
+	}
+	if status >= http.StatusBadRequest {
+		return fmt.Errorf("could not create webhook: status %d", status)
+	}
+	return nil
+}
+
+// Deactivate removes the webhook if present.
+func (c *AtomGit) Deactivate(ctx context.Context, u *model.User, r *model.Repo, link string) error {
+	hooks, err := c.listHooks(ctx, u.AccessToken, r)
+	if err != nil {
+		return err
+	}
+
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return err
+	}
+
+	for _, h := range hooks {
+		hookURL, err := url.Parse(h.URL)
+		if err == nil && hookURL.Host == linkURL.Host && h.Password == r.Hash {
+			delURL := fmt.Sprintf("%s%s/repos/%s/%s/hooks/%s", c.url, apiPath, r.Owner, r.Name, h.ID)
+			if _, status, err := c.delete(ctx, u.AccessToken, delURL); err != nil {
+				return err
+			} else if status >= http.StatusBadRequest {
+				return fmt.Errorf("could not delete webhook: status %d", status)
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func (c *AtomGit) listHooks(ctx context.Context, token string, r *model.Repo) ([]*hook, error) {
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s/hooks", c.url, apiPath, r.Owner, r.Name)
+	// AtomGit's /hooks returns a bare JSON array (the {"data": [...]} wrapper only
+	// appears in local fixtures).
+	out := make([]*hook, 0)
+	if err := c.get(ctx, token, apiURL, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Branches returns all branch names for the repository.
+func (c *AtomGit) Branches(ctx context.Context, u *model.User, r *model.Repo, p *model.ListOptions) ([]string, error) {
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s/branches", c.url, apiPath, r.Owner, r.Name)
+	var branches []*branch
+	if err := c.get(ctx, common.UserToken(ctx, r, u), apiURL, &branches); err != nil {
+		return nil, err
+	}
+	result := make([]string, len(branches))
+	for i, b := range branches {
+		result[i] = b.Name
+	}
+	return result, nil
+}
+
+// BranchHead returns the latest commit SHA for a branch.
+func (c *AtomGit) BranchHead(ctx context.Context, u *model.User, r *model.Repo, branchName string) (*model.Commit, error) {
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s/branches/%s", c.url, apiPath, r.Owner, r.Name, branchName)
+	out := new(branch)
+	if err := c.get(ctx, common.UserToken(ctx, r, u), apiURL, out); err != nil {
+		return nil, err
+	}
+	if out.Commit == nil {
+		return nil, fmt.Errorf("branch %s has no commit", branchName)
+	}
+	return &model.Commit{
+		SHA:      out.Commit.ID,
+		ForgeURL: out.Commit.URL,
+	}, nil
+}
+
+// PullRequests returns open pull requests for the repository.
+func (c *AtomGit) PullRequests(ctx context.Context, u *model.User, r *model.Repo, p *model.ListOptions) ([]*model.PullRequest, error) {
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s/pulls?state=open", c.url, apiPath, r.Owner, r.Name)
+	var prs []*pullRequest
+	if err := c.get(ctx, common.UserToken(ctx, r, u), apiURL, &prs); err != nil {
+		return nil, err
+	}
+	result := make([]*model.PullRequest, len(prs))
+	for i, pr := range prs {
+		result[i] = &model.PullRequest{
+			Index: model.ForgeRemoteID(pr.IID),
+			Title: pr.Title,
+		}
+	}
+	return result, nil
+}
+
+// Hook parses an incoming AtomGit webhook.
+func (c *AtomGit) Hook(ctx context.Context, r *http.Request) (*model.Repo, *model.Pipeline, error) {
+	repo, pipeline, err := parseHook(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if pipeline != nil && pipeline.IsPullRequest() && len(pipeline.ChangedFiles) == 0 {
+		index, err := strconv.ParseInt(strings.Split(pipeline.Ref, "/")[2], 10, 64)
+		if err != nil {
+			return nil, nil, err
+		}
+		pipeline.ChangedFiles, err = c.getChangedFilesForPR(ctx, repo, index)
+		if err != nil {
+			log.Error().Err(err).Msgf("could not get changed files for PR %s#%d", repo.FullName, index)
+		}
+	}
+
+	return repo, pipeline, nil
+}
+
+func (c *AtomGit) getChangedFilesForPR(ctx context.Context, repo *model.Repo, index int64) ([]string, error) {
+	_store, ok := store.TryFromContext(ctx)
+	if !ok {
+		log.Error().Msg("could not get store from context")
+		return []string{}, nil
+	}
+
+	repo, err := _store.GetRepoNameFallback(c.id, repo.ForgeRemoteID, repo.FullName)
+	if err != nil {
+		return nil, err
+	}
+	user, err := _store.GetUser(repo.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	forge.Refresh(ctx, c, _store, user)
+
+	apiURL := fmt.Sprintf("%s%s/repos/%s/%s/pulls/%d/files", c.url, apiPath, repo.Owner, repo.Name, index)
+	var files []*commitFile
+	if err := c.get(ctx, user.AccessToken, apiURL, &files); err != nil {
+		return nil, err
+	}
+
+	changed := make([]string, 0, len(files))
+	for _, f := range files {
+		if f.NewPath != "" {
+			changed = append(changed, f.NewPath)
+		} else if f.OldPath != "" {
+			changed = append(changed, f.OldPath)
+		}
+	}
+	return changed, nil
+}
+
+// OrgMembership checks if the user is a member of the organization.
+func (c *AtomGit) OrgMembership(ctx context.Context, u *model.User, org string) (*model.OrgPerm, error) {
+	apiURL := fmt.Sprintf("%s%s/orgs/%s/members/%s", c.url, apiPath, org, u.Login)
+	_, status, err := c.getRaw(ctx, u.AccessToken, apiURL)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusNotFound {
+		return &model.OrgPerm{}, nil
+	}
+	if status >= http.StatusBadRequest {
+		return &model.OrgPerm{}, nil
+	}
+	// AtomGit does not expose detailed permission levels via this endpoint;
+	// membership is enough to return admin capability conservatively.
+	return &model.OrgPerm{Member: true, Admin: false}, nil
+}
+
+// Org fetches an organization (or user) from AtomGit.
+func (c *AtomGit) Org(ctx context.Context, u *model.User, org string) (*model.Org, error) {
+	apiURL := fmt.Sprintf("%s%s/users/%s", c.url, apiPath, org)
+	out := new(user)
+	if err := c.get(ctx, u.AccessToken, apiURL, out); err != nil {
+		return nil, err
+	}
+	return &model.Org{
+		Name:   out.Username,
+		IsUser: true,
+	}, nil
+}
+
+// --- HTTP helpers ---
+
+func (c *AtomGit) request(ctx context.Context, method, token, apiURL string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, apiURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	client := httputil.WrapClient(c.httpClient(), "forge-atomgit")
+	return client.Do(req)
+}
+
+func (c *AtomGit) get(ctx context.Context, token, apiURL string, out any) error {
+	resp, err := c.request(ctx, http.MethodGet, token, apiURL, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("atomgit api error: status %d: %s", resp.StatusCode, string(data))
+	}
+	if out == nil {
+		return nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	// Try the bare response first (real AtomGit list endpoints return a plain
+	// JSON array), then fall back to a {"data": [...]} envelope (Gitee-style
+	// fixtures). Accept both shapes transparently.
+	if err := json.Unmarshal(body, out); err == nil {
+		return nil
+	} else {
+		var env struct {
+			Data json.RawMessage `json:"data"`
+		}
+		if json.Unmarshal(body, &env) == nil && len(env.Data) > 0 {
+			if e2 := json.Unmarshal(env.Data, out); e2 == nil {
+				return nil
+			} else {
+				err = e2
+			}
+		}
+		preview := body
+		if len(preview) > 240 {
+			preview = preview[:240]
+		}
+		return fmt.Errorf("atomgit api: failed to decode response: %w (body: %s)", err, string(preview))
+	}
+}
+
+func (c *AtomGit) getRaw(ctx context.Context, token, apiURL string) ([]byte, int, error) {
+	resp, err := c.request(ctx, http.MethodGet, token, apiURL, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return data, resp.StatusCode, nil
+}
+
+func (c *AtomGit) post(ctx context.Context, token, apiURL string, body any) ([]byte, int, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, 0, err
+	}
+	resp, err := c.request(ctx, http.MethodPost, token, apiURL, strings.NewReader(string(raw)))
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	return data, resp.StatusCode, nil
+}
+
+func (c *AtomGit) delete(ctx context.Context, token, apiURL string) ([]byte, int, error) {
+	resp, err := c.request(ctx, http.MethodDelete, token, apiURL, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	return data, resp.StatusCode, nil
+}

--- a/server/forge/atomgit/atomgit_test.go
+++ b/server/forge/atomgit/atomgit_test.go
@@ -1,0 +1,302 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomgit
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge/atomgit/fixtures"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+func TestNew(t *testing.T) {
+	forge, _ := New(1, Opts{
+		URL:        "http://localhost:8080",
+		SkipVerify: true,
+	})
+
+	f, _ := forge.(*AtomGit)
+	assert.Equal(t, "http://localhost:8080", f.url)
+	assert.True(t, f.skipVerify)
+	assert.Equal(t, "atomgit", f.Name())
+}
+
+// Test_user_unmarshal verifies AtomGit's /api/v5/user payload decodes
+// correctly. AtomGit returns the id as an opaque hex string (e.g.
+// "6638af02bbeee41d0fe74c35"), never a number, and the login field is
+// "login" rather than "username". This guards the login regression where the
+// id could not be unmarshaled.
+func Test_user_unmarshal(t *testing.T) {
+	var u user
+	// AtomGit returns id as a hex string and the login field as "login".
+	err := json.Unmarshal([]byte(`{"id":"6638af02bbeee41d0fe74c35","login":"someuser","name":"Some User","email":"a@b.com"}`), &u)
+	assert.NoError(t, err)
+	assert.Equal(t, "6638af02bbeee41d0fe74c35", u.ID.String())
+	assert.Equal(t, "someuser", u.Username)
+
+	w := toUser(&u)
+	assert.Equal(t, model.ForgeRemoteID("6638af02bbeee41d0fe74c35"), w.ForgeRemoteID)
+	assert.Equal(t, "someuser", w.Login)
+}
+
+func Test_atomgit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(fixtures.Handler())
+	defer s.Close()
+	c, _ := New(1, Opts{
+		URL:        s.URL,
+		SkipVerify: true,
+	})
+
+	mockStore := store_mocks.NewMockStore(t)
+	ctx := store.InjectToContext(t.Context(), mockStore)
+
+	t.Run("repository details", func(t *testing.T) {
+		repo, err := c.Repo(ctx, fakeUser, fakeRepo.ForgeRemoteID, fakeRepo.Owner, fakeRepo.Name)
+		assert.NoError(t, err)
+		assert.Equal(t, fakeRepo.Owner, repo.Owner)
+		assert.Equal(t, fakeRepo.Name, repo.Name)
+		assert.Equal(t, fakeRepo.Owner+"/"+fakeRepo.Name, repo.FullName)
+		assert.Equal(t, "http://localhost/test_name/repo_name.git", repo.Clone)
+		assert.Equal(t, "http://localhost/test_name/repo_name", repo.ForgeURL)
+	})
+	t.Run("repo not found", func(t *testing.T) {
+		_, err := c.Repo(ctx, fakeUser, "0", fakeRepoNotFound.Owner, fakeRepoNotFound.Name)
+		assert.Error(t, err)
+	})
+
+	t.Run("repository list", func(t *testing.T) {
+		repos, err := c.Repos(ctx, fakeUser, &model.ListOptions{Page: 1, PerPage: 10})
+		assert.NoError(t, err)
+		assert.Equal(t, fakeRepo.ForgeRemoteID, repos[0].ForgeRemoteID)
+		assert.Equal(t, fakeRepo.Owner, repos[0].Owner)
+		assert.Equal(t, fakeRepo.Name, repos[0].Name)
+	})
+
+	t.Run("register repository", func(t *testing.T) {
+		err := c.Activate(ctx, fakeUser, fakeRepo, "http://localhost")
+		assert.NoError(t, err)
+	})
+
+	t.Run("remove hooks", func(t *testing.T) {
+		err := c.Deactivate(ctx, fakeUser, fakeRepo, "http://localhost")
+		assert.NoError(t, err)
+	})
+
+	t.Run("repository file", func(t *testing.T) {
+		raw, err := c.File(ctx, fakeUser, fakeRepo, fakePipeline, ".woodpecker.yml")
+		assert.NoError(t, err)
+		assert.Equal(t, "{ platform: linux/amd64 }", string(raw))
+	})
+
+	t.Run("pipeline status is no-op", func(t *testing.T) {
+		err := c.Status(ctx, fakeUser, fakeRepo, fakePipeline, fakeWorkflow)
+		assert.NoError(t, err)
+	})
+
+	t.Run("PR hook", func(t *testing.T) {
+		buf := bytes.NewBufferString(fixtures.HookMergeRequest)
+		req, _ := http.NewRequest(http.MethodPost, "/hook", buf)
+		req.Header = http.Header{}
+		req.Header.Set(hookEvent, hookMergeRequest)
+		mockStore.On("GetRepoNameFallback", mock.Anything, mock.Anything, mock.Anything).Return(fakeRepo, nil)
+		mockStore.On("GetUser", mock.Anything).Return(fakeUser, nil)
+		r, b, err := c.Hook(ctx, req)
+		assert.NotNil(t, r)
+		assert.NotNil(t, b)
+		assert.NoError(t, err)
+		assert.Equal(t, model.EventPull, b.Event)
+	})
+
+	t.Run("netrc", func(t *testing.T) {
+		netrc, err := c.Netrc(fakeUser, fakeRepo)
+		assert.NoError(t, err)
+		assert.Equal(t, "localhost", netrc.Machine)
+	assert.Equal(t, fakeUser.Login, netrc.Login)
+	assert.Equal(t, model.ForgeTypeAtomGit, netrc.Type)
+})
+}
+
+// Test_atomgit_repoByIDScan_noNamespace reproduces the bug where the
+// /user/repos summary omits the namespace object. Repo() must still upgrade
+// the matched summary to the full repository (via GET /repos/:owner/:name) so
+// that forge_url (html_url) and pr_enabled (has_pull_requests) are populated.
+func Test_atomgit_repoByIDScan_noNamespace(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mux := http.NewServeMux()
+	// Force the primary GET /repositories/:id path to 404 so Repo() falls
+	// back to getRepoByIDScan.
+	mux.HandleFunc("/api/v5/repositories/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found","code":404}`))
+	})
+	// /user/repos summary WITHOUT a namespace object, but with the fields
+	// needed to derive owner/name (path_with_namespace / full_name).
+	mux.HandleFunc("/api/v5/user/repos", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{
+			"id": 5,
+			"name": "repo_name",
+			"path_with_namespace": "test_name/repo_name",
+			"full_name": "test_name/repo_name",
+			"html_url": "http://localhost/test_name/repo_name",
+			"has_pull_requests": true
+		}]`))
+	})
+	// Full repo fetch returns html_url + has_pull_requests.
+	mux.HandleFunc("/api/v5/repos/test_name/repo_name", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id": 5,
+			"name": "repo_name",
+			"path_with_namespace": "test_name/repo_name",
+			"full_name": "test_name/repo_name",
+			"html_url": "http://localhost/test_name/repo_name",
+			"http_url_to_repo": "http://localhost/test_name/repo_name.git",
+			"ssh_url_to_repo": "git@localhost:test_name/repo_name.git",
+			"default_branch": "master",
+			"public": true,
+			"has_pull_requests": true
+		}`))
+	})
+
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	c, _ := New(1, Opts{URL: s.URL, SkipVerify: true})
+
+	mockStore := store_mocks.NewMockStore(t)
+	ctx := store.InjectToContext(t.Context(), mockStore)
+
+	// Call Repo() with only the remoteID (no owner/name) so the by-id scan
+	// path is exercised.
+	repo, err := c.Repo(ctx, fakeUser, "5", "", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost/test_name/repo_name", repo.ForgeURL)
+	assert.True(t, repo.PREnabled)
+}
+
+// Test_atomgit_repo_byIDIncomplete verifies that when GET /repositories/:id
+// succeeds but returns an incomplete payload (no html_url), Repo() does NOT
+// trust it and instead upgrades to the full repository via GET /repos/:owner/:name
+// (or the /user/repos scan), so forge_url is still populated. This is the exact
+// bug that produced an empty forge_url -> "<button>" on the repo page.
+func Test_atomgit_repo_byIDIncomplete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mux := http.NewServeMux()
+	// /repositories/:id returns 200 but WITHOUT html_url / has_pull_requests.
+	mux.HandleFunc("/api/v5/repositories/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id": 5, "name": "repo_name", "full_name": "test_name/repo_name"}`))
+	})
+	// /user/repos scan (used by getRepoByIDScan fallback) returns the summary.
+	mux.HandleFunc("/api/v5/user/repos", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"id": 5, "path_with_namespace": "test_name/repo_name", "full_name": "test_name/repo_name"}]`))
+	})
+	// Full repo fetch carries html_url + has_pull_requests.
+	mux.HandleFunc("/api/v5/repos/test_name/repo_name", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id": 5,
+			"name": "repo_name",
+			"path_with_namespace": "test_name/repo_name",
+			"full_name": "test_name/repo_name",
+			"html_url": "http://localhost/test_name/repo_name",
+			"http_url_to_repo": "http://localhost/test_name/repo_name.git",
+			"ssh_url_to_repo": "git@localhost:test_name/repo_name.git",
+			"default_branch": "master",
+			"public": true,
+			"has_pull_requests": true
+		}`))
+	})
+
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	c, _ := New(1, Opts{URL: s.URL, SkipVerify: true})
+
+	mockStore := store_mocks.NewMockStore(t)
+	ctx := store.InjectToContext(t.Context(), mockStore)
+
+	// Call with a valid remoteID AND owner/name; the by-id path is incomplete
+	// and must be upgraded to the full repo.
+	repo, err := c.Repo(ctx, fakeUser, "5", "test_name", "repo_name")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost/test_name/repo_name", repo.ForgeURL)
+	assert.True(t, repo.PREnabled)
+}
+
+var (
+	fakeUser = &model.User{
+		Login:       "someuser",
+		AccessToken: "cfcd2084",
+	}
+
+	fakeRepo = &model.Repo{
+		Clone:         "http://localhost/test_name/repo_name.git",
+		ForgeRemoteID: "5",
+		Owner:         "test_name",
+		Name:          "repo_name",
+		FullName:      "test_name/repo_name",
+		Hash:          "secret",
+	}
+
+	fakeRepoNotFound = &model.Repo{
+		Owner:    "test_name",
+		Name:     "repo_not_found",
+		FullName: "test_name/repo_not_found",
+	}
+
+	fakePipeline = &model.Pipeline{
+		Commit: "9ecad50",
+	}
+
+	fakeWorkflow = &model.Workflow{
+		Name:  "test",
+		State: model.StatusSuccess,
+	}
+)
+
+// Test_sshURLFromClone_derivesFromHTTPHost verifies the SSH clone URL is built
+// from the HTTP clone URL's host.
+func Test_sshURLFromClone_derivesFromHTTPHost(t *testing.T) {
+	cases := []struct {
+		name  string
+		clone string
+		owner string
+		repo  string
+		want  string
+	}{
+		{"atomgit https", "https://atomgit.com/jetsung/testci.git", "jetsung", "testci", "git@atomgit.com:jetsung/testci.git"},
+		{"atomgit http", "http://atomgit.com/jetsung/testci.git", "jetsung", "testci", "git@atomgit.com:jetsung/testci.git"},
+		{"same as http host", "https://atomgit.com/jetsung/testci.git", "jetsung", "testci", "git@atomgit.com:jetsung/testci.git"},
+		{"empty clone", "", "jetsung", "testci", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := sshURLFromClone(c.clone, c.owner, c.repo)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}

--- a/server/forge/atomgit/convert.go
+++ b/server/forge/atomgit/convert.go
@@ -1,0 +1,328 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomgit
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/shared/utils"
+)
+
+// toUser converts a AtomGit user payload to a Woodpecker user.
+func toUser(from *user) *model.User {
+	avatar := expandAvatar(from.HTMLURL, from.AvatarURL)
+	return &model.User{
+		ForgeRemoteID: model.ForgeRemoteID(from.ID),
+		Login:         from.Username,
+		Email:         from.Email,
+		Avatar:        avatar,
+	}
+}
+
+// repoOwnerName splits a full name ("owner/repo") into owner and name.
+func repoOwnerName(fullName string) (owner, name string) {
+	parts := strings.SplitN(fullName, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return fullName, fullName
+}
+
+// toRepo converts a AtomGit repository payload to a Woodpecker repository.
+func toRepo(from *repository) *model.Repo {
+	owner, name := repoOwnerName(from.FullName)
+	if owner == "" && from.Namespace != nil {
+		owner = from.Namespace.Path
+		name = from.Name
+	}
+	if from.FullName == "" {
+		from.FullName = fmt.Sprintf("%s/%s", owner, name)
+	}
+
+	avatar := expandAvatar(from.WebURL, from.AvatarURL)
+	clone := from.GitURL
+	if clone == "" && from.HTTPURL() != "" {
+		clone = from.HTTPURL()
+	}
+
+	// AtomGit's API does not return `html_url` on repository objects; the web
+	// page URL is carried by `web_url` (or derivable from `http_url_to_repo`
+	// by stripping the `.git` suffix). Default to that so the UI "Open in
+	// forge" link renders as an <a> rather than an empty <button>.
+	forgeURL := from.WebURL
+	if forgeURL == "" && clone != "" {
+		forgeURL = strings.TrimSuffix(clone, ".git")
+	}
+
+	// AtomGit supports merge requests (Pull requests) but the API has no
+	// `has_pull_requests` field, so HasPullRequests is always false. Treat PRs
+	// as enabled so the Pull requests tab is shown.
+	//
+	// Derive the SSH clone URL from the HTTP clone URL host so clone and
+	// cloneSSH always point at the same forge host.
+	cloneSSH := sshURLFromClone(clone, owner, name)
+
+	repo := &model.Repo{
+		ForgeRemoteID: model.ForgeRemoteID(from.ID),
+		Owner:         owner,
+		Name:          name,
+		FullName:      from.FullName,
+		Avatar:        avatar,
+		ForgeURL:      forgeURL,
+		Clone:         clone,
+		CloneSSH:      cloneSSH,
+		Branch:        from.DefaultBranch,
+		IsSCMPrivate:  !from.Public.Bool(),
+		PREnabled:     true,
+	}
+	if repo.Branch == "" {
+		repo.Branch = "master"
+	}
+	if perm := toPerm(from); perm != nil {
+		repo.Perm = perm
+	}
+	return repo
+}
+
+// toPerm derives Woodpecker permissions from a AtomGit repository's permissions.
+func toPerm(from *repository) *model.Perm {
+	// AtomGit access levels: 10 Guest, 20 Reporter, 30 Developer, 40 Maintainer, 50 Owner.
+	if from.Permissions == nil {
+		// The repository listing endpoint (/user/repos) does not include a
+		// permissions object. These repos are returned for the authenticated
+		// user, so treat them as fully accessible (pull/push/admin) so the
+		// add-repository page and permission sync can use them without a nil
+		// pointer dereference upstream.
+		return &model.Perm{
+			Pull:  true,
+			Push:  true,
+			Admin: true,
+		}
+	}
+	level := 0
+	if from.Permissions.ProjectAccess != nil {
+		level = from.Permissions.ProjectAccess.AccessLevel
+	}
+	if from.Permissions.GroupAccess != nil && from.Permissions.GroupAccess.AccessLevel > level {
+		level = from.Permissions.GroupAccess.AccessLevel
+	}
+	return &model.Perm{
+		Pull:  level >= 20,
+		Push:  level >= 30,
+		Admin: level >= 40,
+	}
+}
+
+// toTeam converts a AtomGit namespace into a Woodpecker team.
+func toTeam(from *namespace, link string) *model.Team {
+	return &model.Team{
+		Login:  from.Path,
+		Avatar: expandAvatar(link, from.AvatarURL),
+	}
+}
+
+// toOrg converts a AtomGit namespace into a Woodpecker org.
+func toOrg(from *namespace) *model.Org {
+	return &model.Org{
+		Name:    from.Path,
+		Private: from.VisibilityLevel != 0 && from.VisibilityLevel != 20,
+	}
+}
+
+// pipelineFromPush converts a AtomGit push webhook into a Woodpecker pipeline.
+func pipelineFromPush(hook *pushHook) *model.Pipeline {
+	avatar := expandAvatar(hook.Repository.HTMLURL, hook.UserAvatar)
+	author := hook.UserName
+	if author == "" {
+		author = hook.UserEmail
+	}
+
+	var message, link string
+	if len(hook.Commits) > 0 {
+		message = hook.Commits[0].Message
+		link = hook.Commits[0].URL
+	}
+	if message == "" {
+		message = fmt.Sprintf("push %s", hook.After)
+	}
+
+	return &model.Pipeline{
+		Event:        model.EventPush,
+		Commit:       hook.After,
+		Ref:          hook.Ref,
+		ForgeURL:     link,
+		Branch:       strings.TrimPrefix(hook.Ref, "refs/heads/"),
+		Message:      message,
+		Avatar:       avatar,
+		Author:       author,
+		Email:        hook.UserEmail,
+		Timestamp:    0,
+		Sender:       author,
+		ChangedFiles: getChangedFilesFromPushHook(hook),
+	}
+}
+
+// pipelineFromTag converts a AtomGit tag push webhook into a Woodpecker pipeline.
+func pipelineFromTag(hook *tagPushHook) *model.Pipeline {
+	avatar := expandAvatar(hook.Repository.HTMLURL, hook.UserAvatar)
+	author := hook.UserName
+	if author == "" {
+		author = hook.UserEmail
+	}
+	ref := strings.TrimPrefix(hook.Ref, "refs/tags/")
+
+	return &model.Pipeline{
+		Event:     model.EventTag,
+		Commit:    hook.After,
+		Ref:       fmt.Sprintf("refs/tags/%s", ref),
+		ForgeURL:  fmt.Sprintf("%s/-/tags/%s", hook.Repository.HTMLURL, ref),
+		Message:   fmt.Sprintf("created tag %s", ref),
+		Avatar:    avatar,
+		Author:    author,
+		Email:     hook.UserEmail,
+		Timestamp: 0,
+		Sender:    author,
+	}
+}
+
+// pipelineFromMergeRequest converts a AtomGit merge request webhook into a Woodpecker pipeline.
+func pipelineFromMergeRequest(hook *mergeRequestHook) *model.Pipeline {
+	pr := hook.ObjectAttributes
+	avatar := expandAvatar(hook.Project.HTMLURL, "")
+	if pr.Author != nil {
+		avatar = expandAvatar(hook.Project.HTMLURL, pr.Author.AvatarURL)
+	}
+
+	event := model.EventPull
+	switch hook.EventType {
+	case actionClose, actionMerge:
+		event = model.EventPullClosed
+	case actionUpdate:
+		event = model.EventPull
+	}
+
+	base := pr.TargetBranch
+	head := pr.SourceBranch
+
+	commitSHA := ""
+	if pr.LastCommit != nil {
+		commitSHA = pr.LastCommit.ID
+	}
+
+	pipeline := &model.Pipeline{
+		Event:    event,
+		Commit:   commitSHA,
+		ForgeURL: pr.HTTPURL,
+		Ref:      fmt.Sprintf("refs/pull/%s/head", pr.IID),
+		Branch:   base,
+		Message:  pr.Title,
+		Avatar:   avatar,
+		Author:   authorLogin(pr.Author),
+		Sender:   authorLogin(hook.User),
+		Email:    authorEmail(pr.Author),
+		Title:    pr.Title,
+		Refspec:  fmt.Sprintf("%s:%s", head, base),
+		FromFork: pr.SourceRepo != nil && pr.TargetRepo != nil && pr.SourceRepo.ID != pr.TargetRepo.ID,
+	}
+	if labels := convertLabels(hook.Labels); len(labels) > 0 {
+		pipeline.PullRequestLabels = labels
+	} else if labels := convertLabels(pr.Labels); len(labels) > 0 {
+		pipeline.PullRequestLabels = labels
+	}
+	if pr.Milestone != nil {
+		pipeline.PullRequestMilestone = pr.Milestone.Title
+	}
+	pipeline.PullRequestDraft = pr.Draft
+	return pipeline
+}
+
+func authorLogin(u *user) string {
+	if u == nil {
+		return ""
+	}
+	return u.Username
+}
+
+func authorEmail(u *user) string {
+	if u == nil {
+		return ""
+	}
+	return u.Email
+}
+
+func convertLabels(from []label) []string {
+	labels := make([]string, 0, len(from))
+	for _, label := range from {
+		labels = append(labels, label.Name)
+	}
+	return labels
+}
+
+// getChangedFilesFromPushHook collects changed files from a push webhook payload.
+func getChangedFilesFromPushHook(hook *pushHook) []string {
+	files := make([]string, 0)
+	for _, c := range hook.Commits {
+		files = append(files, c.Added...)
+		files = append(files, c.Modified...)
+		files = append(files, c.Removed...)
+	}
+	return utils.DeduplicateStrings(files)
+}
+
+// HTTPURL returns the HTTP clone URL of a repository.
+func (r *repository) HTTPURL() string {
+	if r.GitURL != "" {
+		return r.GitURL
+	}
+	return r.WebURL
+}
+
+// sshURLFromClone derives the SSH clone URL from the HTTP clone URL's host,
+// so both clone methods point at the same forge host.
+func sshURLFromClone(clone, owner, name string) string {
+	if clone == "" || owner == "" || name == "" {
+		return ""
+	}
+	host := clone
+	if i := strings.Index(clone, "://"); i >= 0 {
+		host = clone[i+len("://"):]
+	}
+	if i := strings.IndexByte(host, '/'); i >= 0 {
+		host = host[:i]
+	}
+	return fmt.Sprintf("git@%s:%s/%s.git", host, owner, name)
+}
+
+// expandAvatar resolves a possibly-relative avatar URL against the base URL.
+func expandAvatar(repo, rawURL string) string {
+	if rawURL == "" {
+		return rawURL
+	}
+	aURL, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if aURL.IsAbs() {
+		return aURL.String()
+	}
+	bURL, err := url.Parse(repo)
+	if err != nil {
+		return rawURL
+	}
+	return bURL.ResolveReference(aURL).String()
+}

--- a/server/forge/atomgit/fixtures/fixtures.go
+++ b/server/forge/atomgit/fixtures/fixtures.go
@@ -1,0 +1,154 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures
+
+// HookPush is a AtomGit push webhook payload.
+const HookPush = `{
+  "object_kind": "push",
+  "event_name": "push",
+  "before": "95790bf891e76feeb30fa2fcc762bd98c1e28ad9",
+  "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "ref": "refs/heads/master",
+  "checkout_sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "user_id": 4,
+  "user_name": "John Doe",
+  "user_email": "john@example.com",
+  "user_avatar": "https://atomgit.com/avatar.png",
+  "project_id": 15,
+  "project": {
+    "id": 15,
+    "name": "repo_name",
+    "path_with_namespace": "test_name/repo_name",
+    "full_name": "test_name/repo_name",
+    "http_url_to_repo": "https://atomgit.com/test_name/repo_name.git",
+    "default_branch": "master",
+    "html_url": "https://atomgit.com/test_name/repo_name"
+  },
+  "repository": {
+    "id": 15,
+    "name": "repo_name",
+    "full_name": "test_name/repo_name",
+    "http_url_to_repo": "https://atomgit.com/test_name/repo_name.git",
+    "default_branch": "master",
+    "html_url": "https://atomgit.com/test_name/repo_name"
+  },
+  "commits": [
+    {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fix: bugs",
+      "title": "fix: bugs",
+      "url": "https://atomgit.com/test_name/repo_name/-/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {"name": "John Doe", "email": "john@example.com", "username": "john"},
+      "added": ["file1.txt"],
+      "modified": ["file2.txt"],
+      "removed": []
+    }
+  ],
+  "total_commits_count": 1
+}`
+
+// HookTagPush is a AtomGit tag push webhook payload.
+const HookTagPush = `{
+  "object_kind": "tag_push",
+  "event_name": "tag_push",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
+  "ref": "refs/tags/v1.0.0",
+  "checkout_sha": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
+  "user_id": 4,
+  "user_name": "John Doe",
+  "user_email": "john@example.com",
+  "user_avatar": "https://atomgit.com/avatar.png",
+  "project_id": 15,
+  "project": {
+    "id": 15,
+    "name": "repo_name",
+    "full_name": "test_name/repo_name",
+    "http_url_to_repo": "https://atomgit.com/test_name/repo_name.git",
+    "default_branch": "master",
+    "html_url": "https://atomgit.com/test_name/repo_name"
+  },
+  "repository": {
+    "id": 15,
+    "name": "repo_name",
+    "full_name": "test_name/repo_name",
+    "http_url_to_repo": "https://atomgit.com/test_name/repo_name.git",
+    "default_branch": "master",
+    "html_url": "https://atomgit.com/test_name/repo_name"
+  },
+  "commits": [],
+  "total_commits_count": 0
+}`
+
+// HookMergeRequest is a AtomGit merge request (open) webhook payload.
+const HookMergeRequest = `{
+  "object_kind": "merge_request",
+  "event_name": "merge_request_open",
+  "user": {
+    "id": 1,
+    "username": "someuser",
+    "name": "Some User",
+    "email": "someuser@atomgit.com",
+    "avatar_url": "https://atomgit.com/avatar.png",
+    "html_url": "https://atomgit.com/someuser"
+  },
+  "project": {
+    "id": 15,
+    "name": "repo_name",
+    "full_name": "test_name/repo_name",
+    "http_url_to_repo": "https://atomgit.com/test_name/repo_name.git",
+    "default_branch": "master",
+    "html_url": "https://atomgit.com/test_name/repo_name"
+  },
+  "repository": {
+    "id": 15,
+    "name": "repo_name",
+    "full_name": "test_name/repo_name",
+    "http_url_to_repo": "https://atomgit.com/test_name/repo_name.git",
+    "default_branch": "master",
+    "html_url": "https://atomgit.com/test_name/repo_name"
+  },
+  "object_attributes": {
+    "id": 99,
+    "iid": 1,
+    "target_branch": "master",
+    "source_branch": "feature",
+    "title": "Add feature",
+    "state": "opened",
+    "html_url": "https://atomgit.com/test_name/repo_name/-/merge_requests/1",
+    "author": {
+      "id": 1,
+      "username": "someuser",
+      "name": "Some User",
+      "email": "someuser@atomgit.com",
+      "avatar_url": "https://atomgit.com/avatar.png"
+    },
+    "source_repo": {
+      "id": 15,
+      "full_name": "test_name/repo_name"
+    },
+    "target_repo": {
+      "id": 15,
+      "full_name": "test_name/repo_name"
+    },
+    "draft": false,
+    "last_commit": {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7"
+    }
+  },
+  "labels": [
+    {"id": 1, "name": "bug", "color": "#d9534f"}
+  ]
+}`

--- a/server/forge/atomgit/fixtures/handler.go
+++ b/server/forge/atomgit/fixtures/handler.go
@@ -1,0 +1,141 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler returns an http.Handler that is capable of handling a variety of mock
+// AtomGit requests and returning mock responses.
+func Handler() http.Handler {
+	gin.SetMode(gin.TestMode)
+
+	e := gin.New()
+	e.GET("/api/v5/user", getUser)
+	e.GET("/api/v5/user/repos", getUserRepos)
+	e.GET("/api/v5/repos/:owner/:name", getRepo)
+	e.GET("/api/v5/repositories/:id", getRepoByID)
+	e.GET("/api/v5/repos/:owner/:name/raw/:file", getRepoFile)
+	e.POST("/api/v5/repos/:owner/:name/hooks", createRepoHook)
+	e.GET("/api/v5/repos/:owner/:name/hooks", listRepoHooks)
+	e.DELETE("/api/v5/repos/:owner/:name/hooks/:id", deleteRepoHook)
+	e.GET("/api/v5/repos/:owner/:name/pulls/:index/files", getPRFiles)
+	e.GET("/api/v5/user/memberships/orgs/:org", getOrgMembership)
+	e.GET("/api/v5/users/:org", getOrg)
+
+	return e
+}
+
+func getUser(c *gin.Context) {
+	c.JSON(http.StatusOK, userPayload)
+}
+
+func getUserRepos(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"data": []any{repoPayload}})
+}
+
+func getRepo(c *gin.Context) {
+	if c.Param("name") == "repo_not_found" {
+		c.JSON(http.StatusNotFound, gin.H{"message": "Not Found", "code": 404})
+		return
+	}
+	c.JSON(http.StatusOK, repoPayload)
+}
+
+func getRepoByID(c *gin.Context) {
+	if c.Param("id") == "0" {
+		c.JSON(http.StatusNotFound, gin.H{"message": "Not Found", "code": 404})
+		return
+	}
+	c.JSON(http.StatusOK, repoPayload)
+}
+
+func getRepoFile(c *gin.Context) {
+	c.String(http.StatusOK, "{ platform: linux/amd64 }")
+}
+
+func createRepoHook(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"id": 9529, "url": c.PostForm("url")})
+}
+
+func listRepoHooks(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"data": []any{
+		gin.H{
+			"id":                    9529,
+			"url":                   "http://localhost",
+			"password":              "secret",
+			"push_events":           true,
+			"tag_push_events":       true,
+			"merge_requests_events": true,
+		},
+	}})
+}
+
+func deleteRepoHook(c *gin.Context) {
+	c.Status(http.StatusNoContent)
+}
+
+func getPRFiles(c *gin.Context) {
+	c.JSON(http.StatusOK, []any{
+		gin.H{"new_path": "README.md", "old_path": "README.md", "new_file": false, "deleted_file": false},
+	})
+}
+
+func getOrgMembership(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"state": "active"})
+}
+
+func getOrg(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"id": 1, "username": c.Param("org"), "name": c.Param("org")})
+}
+
+var userPayload = gin.H{
+	"id":         1,
+	"username":   "someuser",
+	"name":       "Some User",
+	"email":      "someuser@atomgit.com",
+	"state":      "active",
+	"avatar_url": "https://atomgit.com/avatar.png",
+	"html_url":   "https://atomgit.com/someuser",
+}
+
+var repoPayload = gin.H{
+	"id":                  5,
+	"human_name":          "repo_name",
+	"name":                "repo_name",
+	"path":                "repo_name",
+	"path_with_namespace": "test_name/repo_name",
+	"full_name":           "test_name/repo_name",
+	"description":         "test repo",
+	"html_url":            "http://localhost/test_name/repo_name",
+	"web_url":             "http://localhost/test_name/repo_name",
+	"http_url_to_repo":    "http://localhost/test_name/repo_name.git",
+	"ssh_url_to_repo":     "git@localhost:test_name/repo_name.git",
+	"default_branch":      "master",
+	"visibility_level":    0,
+	"public":              true,
+	"archived":            false,
+	"has_pull_requests":   true,
+	"namespace": gin.H{
+		"id":        2,
+		"name":      "test_name",
+		"path":      "test_name",
+		"kind":      "user",
+		"full_path": "test_name",
+	},
+}

--- a/server/forge/atomgit/parse.go
+++ b/server/forge/atomgit/parse.go
@@ -1,0 +1,124 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomgit
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+)
+
+const (
+	hookEvent        = "X-AtomGit-Event"
+	hookPush         = "push"
+	hookTagPush      = "tag_push"
+	hookMergeRequest = "merge_request"
+
+	actionOpen   = "merge_request_open"
+	actionClose  = "merge_request_close"
+	actionMerge  = "merge_request_merge"
+	actionUpdate = "merge_request_update"
+	actionReopen = "merge_request_reopen"
+
+	refBranch = "branch"
+	refTag    = "tag"
+)
+
+// parseHook parses a AtomGit webhook from an http.Request and returns the
+// Repo and Pipeline detail. If a hook type is unsupported nil values are returned.
+func parseHook(r *http.Request) (*model.Repo, *model.Pipeline, error) {
+	hookType := r.Header.Get(hookEvent)
+	switch hookType {
+	case hookPush:
+		return parsePushHook(r.Body)
+	case hookTagPush:
+		return parseTagPushHook(r.Body)
+	case hookMergeRequest:
+		return parseMergeRequestHook(r.Body)
+	}
+	log.Debug().Msgf("unsupported atomgit hook type: '%s'", hookType)
+	return nil, nil, &types.ErrIgnoreEvent{Event: hookType}
+}
+
+func parsePushHook(payload io.Reader) (*model.Repo, *model.Pipeline, error) {
+	hook := new(pushHook)
+	if err := json.NewDecoder(payload).Decode(hook); err != nil {
+		return nil, nil, err
+	}
+
+	if hook.Repository == nil {
+		return nil, nil, fmt.Errorf("parsed push webhook does not contain repository info")
+	}
+
+	// ignore tag pushes handled by tag_push event
+	if strings.HasPrefix(hook.Ref, "refs/tags/") {
+		return nil, nil, nil
+	}
+
+	repo := toRepo(hook.Repository)
+	pipeline := pipelineFromPush(hook)
+	return repo, pipeline, nil
+}
+
+func parseTagPushHook(payload io.Reader) (*model.Repo, *model.Pipeline, error) {
+	hook := new(tagPushHook)
+	if err := json.NewDecoder(payload).Decode(hook); err != nil {
+		return nil, nil, err
+	}
+
+	if hook.Repository == nil {
+		return nil, nil, fmt.Errorf("parsed tag push webhook does not contain repository info")
+	}
+
+	repo := toRepo(hook.Repository)
+	pipeline := pipelineFromTag(hook)
+	return repo, pipeline, nil
+}
+
+func parseMergeRequestHook(payload io.Reader) (*model.Repo, *model.Pipeline, error) {
+	hook := new(mergeRequestHook)
+	if err := json.NewDecoder(payload).Decode(hook); err != nil {
+		return nil, nil, err
+	}
+
+	if hook.ObjectAttributes == nil {
+		return nil, nil, fmt.Errorf("parsed merge_request webhook does not contain merge request info")
+	}
+
+	if !supportedMergeRequestAction(hook.EventType) {
+		log.Debug().Msgf("merge_request action '%s' is not supported, ignoring", hook.EventType)
+		return nil, nil, nil
+	}
+
+	repo := toRepo(hook.Project)
+	pipeline := pipelineFromMergeRequest(hook)
+	return repo, pipeline, nil
+}
+
+func supportedMergeRequestAction(action string) bool {
+	switch action {
+	case actionOpen, actionUpdate, actionReopen, actionClose, actionMerge:
+		return true
+	default:
+		return false
+	}
+}

--- a/server/forge/atomgit/parse_test.go
+++ b/server/forge/atomgit/parse_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomgit
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge/atomgit/fixtures"
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+)
+
+func newHookRequest(event, body string) *http.Request {
+	req, _ := http.NewRequest(http.MethodPost, "/hook", bytes.NewBufferString(body))
+	req.Header = http.Header{}
+	req.Header.Set(hookEvent, event)
+	return req
+}
+
+func TestParsePushHook(t *testing.T) {
+	repo, pipeline, err := parseHook(newHookRequest(hookPush, fixtures.HookPush))
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+	assert.NotNil(t, pipeline)
+	assert.Equal(t, model.EventPush, pipeline.Event)
+	assert.Equal(t, "da1560886d4f094c3e6c9ef40349f7d38b5d27d7", pipeline.Commit)
+	assert.Equal(t, "master", pipeline.Branch)
+	assert.Equal(t, "test_name/repo_name", repo.FullName)
+	assert.Equal(t, []string{"file1.txt", "file2.txt"}, pipeline.ChangedFiles)
+}
+
+func TestParseTagPushHook(t *testing.T) {
+	repo, pipeline, err := parseHook(newHookRequest(hookTagPush, fixtures.HookTagPush))
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+	assert.NotNil(t, pipeline)
+	assert.Equal(t, model.EventTag, pipeline.Event)
+	assert.Equal(t, "refs/tags/v1.0.0", pipeline.Ref)
+	assert.Equal(t, "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7", pipeline.Commit)
+}
+
+func TestParseMergeRequestHook(t *testing.T) {
+	repo, pipeline, err := parseHook(newHookRequest(hookMergeRequest, fixtures.HookMergeRequest))
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+	assert.NotNil(t, pipeline)
+	assert.Equal(t, model.EventPull, pipeline.Event)
+	assert.Equal(t, "refs/pull/1/head", pipeline.Ref)
+	assert.Equal(t, "Add feature", pipeline.Title)
+	assert.Equal(t, []string{"bug"}, pipeline.PullRequestLabels)
+	assert.Equal(t, "da1560886d4f094c3e6c9ef40349f7d38b5d27d7", pipeline.Commit)
+}
+
+func TestParseUnsupportedHook(t *testing.T) {
+	req := newHookRequest("unknown_event", "{}")
+	_, _, err := parseHook(req)
+	assert.Error(t, err)
+	var ignore *types.ErrIgnoreEvent
+	assert.ErrorAs(t, err, &ignore)
+}

--- a/server/forge/atomgit/types.go
+++ b/server/forge/atomgit/types.go
@@ -1,0 +1,323 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomgit
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+// id is a AtomGit identifier. AtomGit's real API serializes identifiers (user
+// id, repository id, hook id, merge request iid, ...) as opaque hex strings
+// (e.g. "6638af02bbeee41d0fe74c35"), but the local fixtures return them as
+// JSON numbers. This type accepts both encodings and always stores the value
+// as a string so it can be passed through to model.ForgeRemoteID unchanged.
+type id string
+
+// UnmarshalJSON decodes a value that is either a JSON number or a JSON string.
+func (i *id) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		*i = ""
+		return nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*i = id(s)
+		return nil
+	}
+	// JSON number (used by fixtures): render it without loss of precision.
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*i = id(n.String())
+	return nil
+}
+
+// String returns the identifier as a string.
+func (i id) String() string { return string(i) }
+
+// Int64 parses the identifier as a base-10 integer when it is numeric.
+// It is provided only for callers that need an integer (e.g. building URLs);
+// AtomGit hex ids are not numeric and callers should prefer String().
+func (i id) Int64() int64 {
+	n, _ := strconv.ParseInt(string(i), 10, 64)
+	return n
+}
+
+// boolInt decodes a AtomGit boolean flag that may arrive either as a JSON
+// boolean (e.g. true) or as an integer (e.g. 0 / 1). It is used for fields
+// like repository.public / repository.archived whose encoding differs between
+// the real AtomGit API and the Gitee-style fixtures.
+type boolInt bool
+
+// UnmarshalJSON accepts both a JSON boolean and a 0/1 integer.
+func (b *boolInt) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == 't' || len(data) > 0 && data[0] == 'f' {
+		var v bool
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		*b = boolInt(v)
+		return nil
+	}
+	var n int
+	if err := json.Unmarshal(data, &n); err != nil {
+		// Fall back to a plain bool if the value is neither int nor bool-shaped.
+		var v bool
+		if e2 := json.Unmarshal(data, &v); e2 != nil {
+			return err
+		}
+		*b = boolInt(v)
+		return nil
+	}
+	*b = boolInt(n != 0)
+	return nil
+}
+
+// Bool returns the underlying boolean value.
+func (b boolInt) Bool() bool { return bool(b) }
+
+// namespace represents the namespace (owner) of a repository on AtomGit.
+type namespace struct {
+	ID              id     `json:"id"`
+	Name            string `json:"name"`
+	Path            string `json:"path"`
+	Kind            string `json:"kind"`
+	FullPath        string `json:"full_path"`
+	HTMLURL         string `json:"html_url"`
+	AvatarURL       string `json:"avatar_url"`
+	VisibilityLevel int    `json:"visibility_level"`
+}
+
+// permissions represents the access permissions a user has on a repository.
+type permissions struct {
+	ProjectAccess *projectAccess `json:"project_access"`
+	GroupAccess   *projectAccess `json:"group_access"`
+}
+
+type projectAccess struct {
+	AccessLevel int `json:"access_level"`
+}
+
+// user is the AtomGit user payload returned by /api/v5/user.
+type user struct {
+	ID        id     `json:"id"`
+	Username  string `json:"login"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	State     string `json:"state"`
+	AvatarURL string `json:"avatar_url"`
+	HTMLURL   string `json:"html_url"`
+	Bio       string `json:"bio"`
+	Blog      string `json:"blog"`
+	Company   string `json:"company"`
+}
+
+// repository is the AtomGit repository payload returned by the API.
+type repository struct {
+	ID                id           `json:"id"`
+	HumanName         string       `json:"human_name"`
+	Name              string       `json:"name"`
+	Path              string       `json:"path"`
+	PathWithNamespace string       `json:"path_with_namespace"`
+	FullName          string       `json:"full_name"`
+	Description       string       `json:"description"`
+	HTMLURL           string       `json:"html_url"`
+	WebURL            string       `json:"web_url"`
+	GitURL            string       `json:"http_url_to_repo"`
+	SSHURL            string       `json:"ssh_url_to_repo"`
+	Namespace         *namespace   `json:"namespace"`
+	DefaultBranch     string       `json:"default_branch"`
+	VisibilityLevel   int          `json:"visibility_level"`
+	Public            boolInt      `json:"public"`
+	Archived          boolInt      `json:"archived"`
+	AvatarURL         string       `json:"avatar_url"`
+	Owner             *user        `json:"owner"`
+	Permissions       *permissions `json:"permissions"`
+	CreatedAt         time.Time    `json:"created_at"`
+	LastActivityAt    time.Time    `json:"last_activity_at"`
+	StarCount         int          `json:"star_count"`
+	ForksCount        int          `json:"forks_count"`
+	WatchCount        int          `json:"watch_count"`
+	HasPullRequests   bool         `json:"has_pull_requests"`
+}
+
+// branch is the AtomGit branch payload returned by /api/v5/repos/{owner}/{repo}/branches.
+type branch struct {
+	Name      string  `json:"name"`
+	Protected bool    `json:"protected"`
+	Default   bool    `json:"default"`
+	Commit    *commit `json:"commit"`
+	HTMLURL   string  `json:"html_url"`
+}
+
+// commit is the AtomGit commit payload.
+type commit struct {
+	ID             string    `json:"id"`
+	SHA            string    `json:"sha"`
+	ShortID        string    `json:"short_id"`
+	Title          string    `json:"title"`
+	Message        string    `json:"message"`
+	AuthorName     string    `json:"author_name"`
+	AuthorEmail    string    `json:"author_email"`
+	AuthoredDate   time.Time `json:"authored_date"`
+	CommittedDate  time.Time `json:"committed_date"`
+	CommitterName  string    `json:"committer_name"`
+	CommitterEmail string    `json:"committer_email"`
+	CreatedAt      time.Time `json:"created_at"`
+	URL            string    `json:"url"`
+}
+
+// hook is the AtomGit webhook payload returned by the hooks API.
+type hook struct {
+	ID                  id     `json:"id"`
+	URL                 string `json:"url"`
+	Password            string `json:"password"`
+	ProjectID           id     `json:"project_id"`
+	PushEvents          bool   `json:"push_events"`
+	TagPushEvents       bool   `json:"tag_push_events"`
+	IssuesEvents        bool   `json:"issues_events"`
+	NoteEvents          bool   `json:"note_events"`
+	MergeRequestsEvents bool   `json:"merge_requests_events"`
+	CreatedAt           string `json:"created_at"`
+}
+
+// pullRequest is the AtomGit merge request payload.
+type pullRequest struct {
+	ID           id          `json:"id"`
+	IID          id          `json:"iid"`
+	ProjectID    id          `json:"project_id"`
+	Title        string      `json:"title"`
+	Description  string      `json:"description"`
+	State        string      `json:"state"`
+	MergeStatus  string      `json:"merge_status"`
+	TargetBranch string      `json:"target_branch"`
+	SourceBranch string      `json:"source_branch"`
+	Upvotes      int         `json:"upvotes"`
+	Downvotes    int         `json:"downvotes"`
+	Author       *user       `json:"author"`
+	Assignee     *user       `json:"assignee"`
+	SourceRepo   *repository `json:"source_repo"`
+	TargetRepo   *repository `json:"target_repo"`
+	HTTPURL      string      `json:"html_url"`
+	CreatedAt    time.Time   `json:"created_at"`
+	UpdatedAt    time.Time   `json:"updated_at"`
+	ClosedAt     time.Time   `json:"closed_at"`
+	MergedAt     time.Time   `json:"merged_at"`
+	Draft        bool        `json:"draft"`
+	Milestone    *milestone  `json:"milestone"`
+	Labels       []label     `json:"labels"`
+	LastCommit   *commit     `json:"last_commit"`
+}
+
+type milestone struct {
+	ID          id     `json:"id"`
+	IID         id     `json:"iid"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	State       string `json:"state"`
+}
+
+type label struct {
+	ID          id     `json:"id"`
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+// commitFile is a changed file entry in a merge request.
+type commitFile struct {
+	OldPath     string `json:"old_path"`
+	NewPath     string `json:"new_path"`
+	AMode       string `json:"a_mode"`
+	BMode       string `json:"b_mode"`
+	Diff        string `json:"diff"`
+	NewFile     bool   `json:"new_file"`
+	RenamedFile bool   `json:"renamed_file"`
+	DeletedFile bool   `json:"deleted_file"`
+}
+
+// webhook push payload sent by AtomGit.
+type pushHook struct {
+	ObjectKind        string          `json:"object_kind"`
+	EventType         string          `json:"event_name"`
+	Before            string          `json:"before"`
+	After             string          `json:"after"`
+	Ref               string          `json:"ref"`
+	CheckoutSHA       string          `json:"checkout_sha"`
+	UserID            id              `json:"user_id"`
+	UserName          string          `json:"user_name"`
+	UserEmail         string          `json:"user_email"`
+	UserAvatar        string          `json:"user_avatar"`
+	ProjectID         id              `json:"project_id"`
+	Project           *repository     `json:"project"`
+	Repository        *repository     `json:"repository"`
+	Commits           []payloadCommit `json:"commits"`
+	TotalCommitsCount int             `json:"total_commits_count"`
+}
+
+// webhook tag push payload sent by AtomGit.
+type tagPushHook struct {
+	ObjectKind        string          `json:"object_kind"`
+	EventType         string          `json:"event_name"`
+	Before            string          `json:"before"`
+	After             string          `json:"after"`
+	Ref               string          `json:"ref"`
+	CheckoutSHA       string          `json:"checkout_sha"`
+	UserID            id              `json:"user_id"`
+	UserName          string          `json:"user_name"`
+	UserEmail         string          `json:"user_email"`
+	UserAvatar        string          `json:"user_avatar"`
+	ProjectID         id              `json:"project_id"`
+	Project           *repository     `json:"project"`
+	Repository        *repository     `json:"repository"`
+	Commits           []payloadCommit `json:"commits"`
+	TotalCommitsCount int             `json:"total_commits_count"`
+}
+
+type payloadCommit struct {
+	ID        id           `json:"id"`
+	Message   string       `json:"message"`
+	Title     string       `json:"title"`
+	Timestamp string       `json:"timestamp"`
+	URL       string       `json:"url"`
+	Author    commitAuthor `json:"author"`
+	Added     []string     `json:"added"`
+	Modified  []string     `json:"modified"`
+	Removed   []string     `json:"removed"`
+}
+
+type commitAuthor struct {
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Username string `json:"username"`
+}
+
+// mergeRequestHook is the webhook payload for merge request events.
+type mergeRequestHook struct {
+	ObjectKind       string         `json:"object_kind"`
+	EventType        string         `json:"event_name"`
+	User             *user          `json:"user"`
+	Project          *repository    `json:"project"`
+	Repository       *repository    `json:"repository"`
+	ObjectAttributes *pullRequest   `json:"object_attributes"`
+	Labels           []label        `json:"labels"`
+	Changes          map[string]any `json:"changes"`
+}

--- a/server/forge/setup/setup.go
+++ b/server/forge/setup/setup.go
@@ -23,6 +23,7 @@ import (
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge"
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/addon"
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge/atomgit"
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/bitbucket"
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/bitbucketdatacenter"
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/forgejo"
@@ -44,6 +45,8 @@ func Forge(forge *model.Forge) (forge.Forge, error) {
 		return setupBitbucket(forge)
 	case model.ForgeTypeGitea:
 		return setupGitea(forge)
+	case model.ForgeTypeAtomGit:
+		return setupAtomGit(forge)
 	case model.ForgeTypeForgejo:
 		return setupForgejo(forge)
 	case model.ForgeTypeBitbucketDatacenter:
@@ -92,6 +95,32 @@ func setupGitea(forge *model.Forge) (forge.Forge, error) {
 		Str("type", string(forge.Type)).
 		Msg("setting up forge")
 	return gitea.New(forge.ID, opts)
+}
+
+func setupAtomGit(forge *model.Forge) (forge.Forge, error) {
+	serverURL, err := url.Parse(forge.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := atomgit.Opts{
+		URL:               strings.TrimRight(serverURL.String(), "/"),
+		OAuthClientID:     forge.OAuthClientID,
+		OAuthClientSecret: forge.OAuthClientSecret,
+		SkipVerify:        forge.SkipVerify,
+		OAuthHost:         forge.OAuthHost,
+	}
+	if len(opts.URL) == 0 {
+		return nil, fmt.Errorf("WOODPECKER_ATOMGIT_URL must be set")
+	}
+	log.Debug().
+		Str("url", opts.URL).
+		Bool("skip-verify", opts.SkipVerify).
+		Bool("oauth-client-id-set", opts.OAuthClientID != "").
+		Bool("oauth-secret-id-set", opts.OAuthClientSecret != "").
+		Str("type", string(forge.Type)).
+		Msg("setting up forge")
+	return atomgit.New(forge.ID, opts)
 }
 
 func setupForgejo(forge *model.Forge) (forge.Forge, error) {

--- a/server/model/forge.go
+++ b/server/model/forge.go
@@ -23,6 +23,7 @@ const (
 	ForgeTypeForgejo             ForgeType = "forgejo"
 	ForgeTypeBitbucket           ForgeType = "bitbucket"
 	ForgeTypeBitbucketDatacenter ForgeType = "bitbucket-dc"
+	ForgeTypeAtomGit             ForgeType = "atomgit"
 	ForgeTypeAddon               ForgeType = "addon"
 )
 
@@ -45,9 +46,10 @@ func (Forge) TableName() string {
 // PublicCopy returns a copy of the forge without sensitive information and technical details.
 func (f *Forge) PublicCopy() *Forge {
 	forge := &Forge{
-		ID:   f.ID,
-		Type: f.Type,
-		URL:  f.URL,
+		ID:        f.ID,
+		Type:      f.Type,
+		URL:       f.URL,
+		OAuthHost: f.OAuthHost,
 	}
 
 	return forge

--- a/server/services/setup.go
+++ b/server/services/setup.go
@@ -158,6 +158,17 @@ func setupForgeService(c *cli.Command, _store store.Store) error {
 		if _forge.URL == "" {
 			_forge.URL = "https://try.gitea.com"
 		}
+	case c.Bool("atomgit"):
+		_forge.Type = model.ForgeTypeAtomGit
+		if _forge.URL == "" {
+			_forge.URL = "https://api.atomgit.com"
+		}
+		// The AtomGit API host (api.atomgit.com) returns correct clone URLs,
+		// but its OAuth endpoints live on the web host (atomgit.com). Point
+		// OAuth there unless explicitly overridden.
+		if _forge.OAuthHost == "" {
+			_forge.OAuthHost = "https://atomgit.com"
+		}
 	case c.Bool("forgejo"):
 		_forge.Type = model.ForgeTypeForgejo
 		// TODO enable oauth URL with generic config option

--- a/web/src/components/atomic/Icon.vue
+++ b/web/src/components/atomic/Icon.vue
@@ -12,6 +12,7 @@
   <SvgIcon v-else-if="name === 'commit'" :bg-circle="bgCircle" :path="mdiSourceCommit" size="1.3rem" />
   <SvgIcon v-else-if="name === 'back'" :bg-circle="bgCircle" :path="mdiArrowLeft" size="1.3rem" />
   <SvgIcon v-else-if="name === 'github'" :bg-circle="bgCircle" :path="mdiGithub" size="1.3rem" />
+  <SvgIcon v-else-if="name === 'atomgit'" :bg-circle="bgCircle" :path="mdiGit" size="1.3rem" />
   <SvgIcon v-else-if="name === 'repo'" :bg-circle="bgCircle" :path="mdiGit" size="1.3rem" />
   <SvgIcon v-else-if="name === 'settings'" :bg-circle="bgCircle" :path="mdiCog" size="1.3rem" />
   <SvgIcon v-else-if="name === 'settings-outline'" :bg-circle="bgCircle" :path="mdiCogOutline" size="1.3rem" />
@@ -233,6 +234,7 @@ export type IconNames =
   | 'bitbucket'
   | 'bitbucket-dc'
   | 'forgejo'
+  | 'atomgit'
   | 'question'
   | 'list'
   | 'plus'


### PR DESCRIPTION
## Add AtomGit forge driver

This pull request adds support for [AtomGit](https://atomgit.com) as a forge provider in Woodpecker CI.

### Changes
- **model**: new `ForgeTypeAtomGit` type and expose `OAuthHost` in `PublicCopy`
- **forge/setup**: register and configure the atomgit forge
- **services/setup**: `atomgit` flag with `https://api.atomgit.com` and OAuth host defaults
- **cmd/server/flags**: `WOODPECKER_ATOMGIT*` env vars and enable flag
- **api/repo**: lazily backfill `forge_url` and other fields for stale repos
- **server/forge/atomgit**: new driver package (auth, repo lookup, conversion, webhook parsing) with tests and fixtures
- **web**: add atomgit icon

### Notes
- AtomGit's API host (`api.atomgit.com`) returns correct clone URLs, while its OAuth endpoints live on the web host (`atomgit.com`); the driver points OAuth there unless overridden.
- Repos enabled before the forge populated `forge_url` are self-healed on first `GET /api/repos/{id}` request (forge contacted at most once).