### PR TITLE
fix(server): guard DAG cycle check against filtered-out optional dependencies

### DIFF
--- a/pipeline/frontend/yaml/compiler/dag.go
+++ b/pipeline/frontend/yaml/compiler/dag.go
@@ -75,6 +75,16 @@ func (c dagCompiler) compileByDependsOn() ([]*backend_types.Stage, error) {
 }
 
 func dfsVisit(steps map[string]*dagCompilerStep, name string, visited map[string]struct{}, path []string) error {
+	step, exists := steps[name]
+	if !exists {
+		// `name` is an optional dependency on a step that was filtered out. convertDAGToStages
+		// drops those edges, but it resolves one step at a time and runs this walk in the same
+		// loop, so the walk can reach a step whose dependsOn is not resolved yet and follow an
+		// edge to a filtered-out step. There is nothing to traverse, and a missing *required*
+		// dependency is still reported by convertDAGToStages when it reaches that step.
+		return nil
+	}
+
 	if _, ok := visited[name]; ok {
 		return &ErrStepDependencyCycle{path: path}
 	}
@@ -82,7 +92,7 @@ func dfsVisit(steps map[string]*dagCompilerStep, name string, visited map[string
 	visited[name] = struct{}{}
 	path = append(path, name)
 
-	for _, dep := range steps[name].dependsOn {
+	for _, dep := range step.dependsOn {
 		if err := dfsVisit(steps, dep.Name, visited, path); err != nil {
 			return err
 		}

--- a/pipeline/frontend/yaml/compiler/dag_test.go
+++ b/pipeline/frontend/yaml/compiler/dag_test.go
@@ -162,6 +162,42 @@ func TestOptionalStepDependency(t *testing.T) {
 		assert.Len(t, stages, 2, "should produce 2 stages (build then deploy)")
 	})
 
+	t.Run("missing optional step dep on a step that has dependents", func(t *testing.T) {
+		// convertDAGToStages resolves one step at a time and runs the cycle check in the
+		// same loop, so if it reaches `notify` before `deploy`, the walk follows deploy's
+		// still-unresolved edge to the absent `lint`. Map iteration order decides, so run
+		// this enough times to cover both orders.
+		for range 100 {
+			steps := map[string]*dagCompilerStep{
+				"build": {
+					position: 0,
+					name:     "build",
+					step:     &backend_types.Step{Name: "build"},
+				},
+				"deploy": {
+					position: 1,
+					name:     "deploy",
+					step:     &backend_types.Step{Name: "deploy"},
+					dependsOn: constraint.DependsOn{
+						{Name: "build"},
+						{Name: "lint", Optional: true},
+					},
+				},
+				"notify": {
+					position: 2,
+					name:     "notify",
+					step:     &backend_types.Step{Name: "notify"},
+					dependsOn: constraint.DependsOn{
+						{Name: "deploy"},
+					},
+				},
+			}
+			stages, err := convertDAGToStages(steps)
+			assert.NoError(t, err)
+			assert.Len(t, stages, 3, "build, then deploy, then notify")
+		}
+	})
+
 	t.Run("missing required step dep still errors", func(t *testing.T) {
 		steps := map[string]*dagCompilerStep{
 			"deploy": {


### PR DESCRIPTION
Fixes #6914.

`convertDAGToStages` resolves one step's `depends_on` and then immediately runs the cycle check from that step, all inside a single `range` over a map. Since map iteration order is randomised, the walk can reach a step the loop hasn't resolved yet, follow that step's still-present `optional` edge to a filtered-out step, and dereference a nil entry at `dag.go:85`.

The server recovers via gin's middleware, but the pipeline is left with no workflows and never enqueues — it sits indefinitely, indistinguishable from a queued build, and reports no status to the forge. It reproduces on ~50% of pipeline creations for an affected config, so the same config succeeds on one attempt and hangs on the next. It also affects configs using no `optional` edges at all: a *required* `depends_on` on a filtered-out step panics instead of returning `ErrStepMissingDependency`.

`dfsVisit` now returns early when a step is absent. There's nothing to traverse, and a missing **required** dependency is still reported by `convertDAGToStages` when its own loop reaches that step — I verified that separately, since returning `nil` here could plausibly have swallowed it.

The added test case is the existing `missing optional step dep is dropped` case plus one step depending on `deploy`. Every current fixture and test keeps the step holding the `optional` edge terminal, so nothing ever traverses into it — which is why this went unnoticed. The test loops 100× because a single run only fails on about half of map orders.

I also considered resolving all steps before running any cycle check, which would make the nil case unreachable rather than handled, and matches what `builder/utils.go`'s `filterMissingDependencies` already does at workflow level. I kept this PR minimal since that changes which error a config with *both* a missing required dependency and a cycle reports — happy to do it that way instead if you'd prefer.

Introduced in #6461.

### Verification

- The new test panics at `dag.go:85 ← 86 ← 86 ← 115` on unpatched `main`, matching the trace observed on a production server; passes 20× with the fix.
- `go vet ./pipeline/frontend/...` clean, and all 12 `pipeline/frontend/...` packages pass at `-count=5`.
- `go build ./...` fails on `web/web.go`'s `all:dist/*` embed, which is pre-existing and needs the web UI built first.
