### PR TITLE
Adds native compilation of `.woodpecker.jsonnet` / `.woodpecker/*.jsonnet` pipeline configs via embedded [go-jsonnet](https://github.com/google/go-jsonnet)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -110,6 +110,7 @@
     "intlify",
     "Ionescu",
     "Jetpack",
+    "jsonnet",
     "Kaniko",
     "Keyfunc",
     "kyvg",

--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -85,7 +85,7 @@ func execDir(ctx context.Context, c *cli.Command, dir string) error {
 		if e != nil {
 			return e
 		}
-		if info.Mode().IsRegular() && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml")) {
+		if info.Mode().IsRegular() && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml") || strings.HasSuffix(info.Name(), ".jsonnet")) {
 			dat, err := os.ReadFile(path)
 			if err != nil {
 				return err

--- a/cli/lint/lint.go
+++ b/cli/lint/lint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"go.woodpecker-ci.org/woodpecker/v3/cli/common"
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/jsonnet"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/yaml"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/yaml/linter"
 	"go.woodpecker-ci.org/woodpecker/v3/shared/constant"
@@ -74,7 +75,7 @@ func lintDir(ctx context.Context, c *cli.Command, dir string) error {
 		}
 
 		// check if it is a regular file (not dir)
-		if info.Mode().IsRegular() && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml")) {
+		if info.Mode().IsRegular() && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml") || strings.HasSuffix(info.Name(), ".jsonnet")) {
 			fmt.Println("#", info.Name())
 			if err := lintFile(ctx, c, path); err != nil {
 				errorStrings = append(errorStrings, err.Error())
@@ -106,17 +107,27 @@ func lintFile(_ context.Context, c *cli.Command, file string) error {
 		return err
 	}
 
-	rawConfig := string(buf)
-
-	parsedConfig, err := yaml.ParseString(rawConfig)
-	if err != nil {
-		return err
+	var workflowFiles []*jsonnet.File
+	if jsonnet.IsJsonnetFile(file) {
+		workflowFiles, err = jsonnet.Compile(file, buf)
+		if err != nil {
+			return err
+		}
+	} else {
+		workflowFiles = []*jsonnet.File{{Name: path.Base(file), Data: buf}}
 	}
 
-	config := &linter.WorkflowConfig{
-		File:      path.Base(file),
-		RawConfig: rawConfig,
-		Workflow:  parsedConfig,
+	configs := make([]*linter.WorkflowConfig, 0, len(workflowFiles))
+	for _, workflowFile := range workflowFiles {
+		parsedConfig, err := yaml.ParseString(string(workflowFile.Data))
+		if err != nil {
+			return err
+		}
+		configs = append(configs, &linter.WorkflowConfig{
+			File:      workflowFile.Name,
+			RawConfig: string(workflowFile.Data),
+			Workflow:  parsedConfig,
+		})
 	}
 
 	// TODO: lint multiple files at once to allow checks for sth like "depends_on" to work
@@ -128,9 +139,9 @@ func lintFile(_ context.Context, c *cli.Command, file string) error {
 		}),
 		linter.PrivilegedPlugins(c.StringSlice("plugins-privileged")),
 		linter.WithTrustedClonePlugins(c.StringSlice("plugins-trusted-clone")),
-	).Lint([]*linter.WorkflowConfig{config})
+	).Lint(configs)
 	if err != nil {
-		str, err := FormatLintError(config.File, err, c.Bool("strict"))
+		str, err := FormatLintError(path.Base(file), err, c.Bool("strict"))
 
 		if str != "" {
 			fmt.Print(str)

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -326,7 +326,7 @@ var flags = append([]cli.Flag{
 		Sources: cli.EnvVars("WOODPECKER_DEFAULT_PIPELINE_CONFIG_EXTENSIONS"),
 		Name:    "default-pipeline-config-extensions",
 		Usage:   "default pipeline config extensions when scanning a pipeline config directory",
-		Value:   []string{".yaml", ".yml"},
+		Value:   constant.DefaultConfigExtensions,
 		Config: cli.StringConfig{
 			TrimSpace: true,
 		},

--- a/docs/docs/20-usage/25-workflows.md
+++ b/docs/docs/20-usage/25-workflows.md
@@ -4,7 +4,7 @@ A pipeline has at least one workflow. A workflow is a set of steps that are exec
 
 In case there is a single configuration in `.woodpecker.yaml` Woodpecker will create a pipeline with a single workflow.
 
-By placing the configurations in a folder which is by default named `.woodpecker/` Woodpecker will create a pipeline with multiple workflows each named by the file they are defined in. Only `.yml` and `.yaml` files will be used and files in any subfolders like `.woodpecker/sub-folder/test.yaml` will be ignored.
+By placing the configurations in a folder which is by default named `.woodpecker/` Woodpecker will create a pipeline with multiple workflows each named by the file they are defined in. Only `.yml`, `.yaml` and [`.jsonnet`](./26-jsonnet.md) files will be used and files in any subfolders like `.woodpecker/sub-folder/test.yaml` will be ignored.
 
 You can also set some custom path like `.my-ci/pipelines/` instead of `.woodpecker/` in the [project settings](./75-project-settings.md).
 
@@ -82,7 +82,7 @@ The workflows run in parallel on separate agents and share nothing.
 
 Dependencies between workflows can be set with the `depends_on` element. A workflow doesn't execute until all of its dependencies finished successfully.
 
-The name for a `depends_on` entry is the filename without the path, leading dots and without the file extension `.yml` or `.yaml`. If the project config for example uses `.woodpecker/` as path for CI files with a file named `.woodpecker/.lint.yaml` the corresponding `depends_on` entry would be `lint`.
+The name for a `depends_on` entry is the filename without the path, leading dots and without the file extension `.yml`, `.yaml` or `.jsonnet`. If the project config for example uses `.woodpecker/` as path for CI files with a file named `.woodpecker/.lint.yaml` the corresponding `depends_on` entry would be `lint`.
 
 ```diff
  steps:

--- a/docs/docs/20-usage/26-jsonnet.md
+++ b/docs/docs/20-usage/26-jsonnet.md
@@ -1,0 +1,54 @@
+# Jsonnet
+
+Instead of writing every workflow as a separate YAML file, you can define your pipeline configuration in [Jsonnet](https://jsonnet.org/), a data templating language that compiles to JSON. This is useful when many workflows share structure — for example a matrix of build variants that differ only in a few settings.
+
+Woodpecker compiles files with a `.jsonnet` extension natively. They can be placed in the same locations as YAML configs: a single `.woodpecker.jsonnet` at the repository root, or `.jsonnet` files inside the `.woodpecker/` folder (or your custom config path). `woodpecker-cli exec` and `woodpecker-cli lint` support them as well.
+
+## Single workflow
+
+A Jsonnet config that evaluates to a single object defines one workflow, just like a YAML file:
+
+```jsonnet title=".woodpecker.jsonnet"
+{
+  steps: [
+    {
+      name: 'build',
+      image: 'debian:stable-slim',
+      commands: ['echo building'],
+    },
+  ],
+}
+```
+
+The workflow is named after the file. Alternatively, a top-level `name` field sets the workflow name explicitly; it is removed from the config before it is processed.
+
+## Multiple workflows from one file
+
+A Jsonnet config that evaluates to an array of objects defines one workflow per element. Each element must have a unique `name`:
+
+```jsonnet title=".woodpecker.jsonnet"
+local variant(name, tag) = {
+  name: name,
+  steps: [
+    {
+      name: 'build',
+      image: 'golang:' + tag,
+      commands: ['go build ./...'],
+    },
+  ],
+};
+
+[
+  variant('go-stable', '1'),
+  variant('go-latest', 'rc'),
+  variant('lint', '1') { steps: [{ name: 'lint', image: 'golangci/golangci-lint', commands: ['golangci-lint run'] }] },
+]
+```
+
+This behaves exactly like placing `go-stable.yaml`, `go-latest.yaml` and `lint.yaml` in the `.woodpecker/` folder — workflows run in parallel and can be ordered with [`depends_on`](./25-workflows.md#flow-control).
+
+## Limitations
+
+- Configs must be self-contained: `import`/`importstr`, external variables (`std.extVar`) and native functions are not available. The full [Jsonnet standard library](https://jsonnet.org/ref/stdlib.html) can be used.
+- Linter messages refer to the compiled JSON of a workflow, not to the Jsonnet source. Compile errors do reference the original source location.
+- The compiled output is limited to 1 MiB.

--- a/docs/docs/20-usage/72-extensions/40-configuration-extension.md
+++ b/docs/docs/20-usage/72-extensions/40-configuration-extension.md
@@ -9,7 +9,7 @@ Using such an extension can be useful if you want to:
 - Preprocess the original configuration file with something like Go templating
 - Convert custom attributes to Woodpecker attributes
 - Add defaults to the configuration like default steps
-- Convert configuration files from a totally different format like Gitlab CI config, Starlark, Jsonnet, ...
+- Convert configuration files from a totally different format like Gitlab CI config, Starlark, ... (Jsonnet is [supported natively](../26-jsonnet.md))
 - Centralize configuration for multiple repositories in one place
 
 ## Security

--- a/docs/docs/30-administration/10-configuration/10-server.md
+++ b/docs/docs/30-administration/10-configuration/10-server.md
@@ -1035,7 +1035,7 @@ Specify a configuration extension endpoint, see [Configuration Extension](../../
 ### DEFAULT_PIPELINE_CONFIGS
 
 - Name: `WOODPECKER_DEFAULT_PIPELINE_CONFIGS`
-- Default: `.woodpecker/`, `.woodpecker.yaml`, `.woodpecker.yml`
+- Default: `.woodpecker/`, `.woodpecker.yaml`, `.woodpecker.yml`, `.woodpecker.jsonnet`
 
 Specify the default pipeline config paths.
 
@@ -1044,7 +1044,7 @@ Specify the default pipeline config paths.
 ### DEFAULT_PIPELINE_CONFIG_EXTENSIONS
 
 - Name: `WOODPECKER_DEFAULT_PIPELINE_CONFIG_EXTENSIONS`
-- Default: `.yaml`, `.yml`
+- Default: `.yaml`, `.yml`, `.jsonnet`
 
 Specify the default pipeline config extensions when scanning a pipeline config directory.
 

--- a/e2e/setup/server.go
+++ b/e2e/setup/server.go
@@ -164,7 +164,7 @@ func newTestManager(s store.Store, mockForge *forge_mocks.MockForge) (services.M
 			&cli.BoolFlag{Name: string(TestForgeType), Value: true},
 			&cli.StringFlag{Name: "forge-url", Value: "https://forge.example.test"},
 			&cli.StringSliceFlag{Name: "default-pipeline-configs", Value: constant.DefaultConfigOrder},
-			&cli.StringSliceFlag{Name: "default-pipeline-config-extensions", Value: []string{".yaml", ".yml"}},
+			&cli.StringSliceFlag{Name: "default-pipeline-config-extensions", Value: constant.DefaultConfigExtensions},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -152,6 +152,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-github/v73 v73.0.0 // indirect
+	github.com/google/go-jsonnet v0.21.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/google/go-github/v73 v73.0.0 h1:aR+Utnh+Y4mMkS+2qLQwcQ/cF9mOTpdwnzlaw
 github.com/google/go-github/v73 v73.0.0/go.mod h1:fa6w8+/V+edSU0muqdhCVY7Beh1M8F1IlQPZIANKIYw=
 github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
 github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
+github.com/google/go-jsonnet v0.21.0 h1:43Bk3K4zMRP/aAZm9Po2uSEjY6ALCkYUVIcz9HLGMvA=
+github.com/google/go-jsonnet v0.21.0/go.mod h1:tCGAu8cpUpEZcdGMmdOu37nh8bGgqubhI5v2iSk3KJQ=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pipeline/frontend/builder/builder.go
+++ b/pipeline/frontend/builder/builder.go
@@ -29,6 +29,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline"
 	backend_types "go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
 	pipeline_errors "go.woodpecker-ci.org/woodpecker/v3/pipeline/errors"
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/jsonnet"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/metadata"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/yaml"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/yaml/compiler"
@@ -50,6 +51,9 @@ type PipelineBuilder struct {
 }
 
 func (b *PipelineBuilder) Build() (items []*Item, errorsAndWarnings error) {
+	if err := b.expandJsonnetFiles(); err != nil {
+		return nil, err
+	}
 	b.Yamls = SortYamlFilesByName(b.Yamls)
 
 	pidSequence := 1
@@ -94,6 +98,27 @@ func (b *PipelineBuilder) Build() (items []*Item, errorsAndWarnings error) {
 	items = filterMissingDependencies(items)
 
 	return items, errorsAndWarnings
+}
+
+// expandJsonnetFiles replaces every jsonnet config with the workflow
+// configs it compiles into.
+func (b *PipelineBuilder) expandJsonnetFiles() error {
+	expanded := make([]*YamlFile, 0, len(b.Yamls))
+	for _, y := range b.Yamls {
+		if !jsonnet.IsJsonnetFile(y.Name) {
+			expanded = append(expanded, y)
+			continue
+		}
+		files, err := jsonnet.Compile(y.Name, y.Data)
+		if err != nil {
+			return &pipeline_errors.PipelineError{Message: err.Error(), Type: pipeline_errors.PipelineErrorTypeCompiler}
+		}
+		for _, f := range files {
+			expanded = append(expanded, &YamlFile{Name: f.Name, Data: f.Data})
+		}
+	}
+	b.Yamls = expanded
+	return nil
 }
 
 func (b *PipelineBuilder) genItemForWorkflow(workflow *Workflow, axis matrix.Axis, data string) (item *Item, errorsAndWarnings error) {

--- a/pipeline/frontend/builder/builder_test.go
+++ b/pipeline/frontend/builder/builder_test.go
@@ -460,6 +460,14 @@ func TestSanitizePath(t *testing.T) {
 			path:          "folder/sub-folder/test.yaml",
 			sanitizedPath: "test",
 		},
+		{
+			path:          ".woodpecker.jsonnet",
+			sanitizedPath: "woodpecker",
+		},
+		{
+			path:          ".woodpecker/test.jsonnet",
+			sanitizedPath: "test",
+		},
 	}
 
 	for _, test := range testTable {
@@ -932,4 +940,83 @@ steps:
 
 	assert.Equal(t, "main", items[0].Labels[pipeline.LabelCommitBranch])
 	assert.Equal(t, "push", items[0].Labels[pipeline.LabelEvent])
+}
+
+func TestJsonnetMultiWorkflow(t *testing.T) {
+	t.Parallel()
+
+	m := &testMetadata{
+		pipelineEvent: "push",
+	}
+
+	b := PipelineBuilder{
+		GetWorkflowMetadata: m.GetWorkflowMetadata,
+		RepoTrusted:         &metadata.TrustedConfiguration{},
+		Yamls: []*YamlFile{
+			{Name: ".woodpecker.jsonnet", Data: []byte(`
+local pipeline(name) = {
+  name: name,
+  when: { event: 'push' },
+  steps: [{ name: 'build', image: 'scratch' }],
+};
+std.map(pipeline, ['alpha', 'beta']) + [pipeline('deploy') { depends_on: ['alpha', 'beta'] }]
+`)},
+		},
+	}
+
+	items, err := b.Build()
+	assert.NoError(t, err)
+	assert.Len(t, items, 3)
+	assert.Equal(t, "alpha", items[0].Workflow.Name)
+	assert.Equal(t, "beta", items[1].Workflow.Name)
+	assert.Equal(t, "deploy", items[2].Workflow.Name)
+	assert.Len(t, items[2].DependsOn, 2)
+}
+
+func TestJsonnetMatrix(t *testing.T) {
+	t.Parallel()
+
+	m := &testMetadata{
+		pipelineEvent: "push",
+	}
+
+	b := PipelineBuilder{
+		GetWorkflowMetadata: m.GetWorkflowMetadata,
+		RepoTrusted:         &metadata.TrustedConfiguration{},
+		Yamls: []*YamlFile{
+			{Name: ".woodpecker.jsonnet", Data: []byte(`
+{
+  when: { event: 'push' },
+  matrix: { TAG: ['a', 'b'] },
+  steps: [{ name: 'build', image: 'scratch', commands: ['echo ${TAG}'] }],
+}
+`)},
+		},
+	}
+
+	items, err := b.Build()
+	assert.NoError(t, err)
+	assert.Len(t, items, 2)
+	assert.Equal(t, "a", items[0].Workflow.Environ["TAG"])
+	assert.Equal(t, "b", items[1].Workflow.Environ["TAG"])
+}
+
+func TestJsonnetCompileError(t *testing.T) {
+	t.Parallel()
+
+	m := &testMetadata{
+		pipelineEvent: "push",
+	}
+
+	b := PipelineBuilder{
+		GetWorkflowMetadata: m.GetWorkflowMetadata,
+		RepoTrusted:         &metadata.TrustedConfiguration{},
+		Yamls: []*YamlFile{
+			{Name: ".woodpecker.jsonnet", Data: []byte(`{ steps: [ }`)},
+		},
+	}
+
+	_, err := b.Build()
+	assert.Error(t, err)
+	assert.True(t, errors.HasBlockingErrors(err))
 }

--- a/pipeline/frontend/builder/utils.go
+++ b/pipeline/frontend/builder/utils.go
@@ -25,6 +25,7 @@ func SanitizePath(path string) string {
 	path = filepath.Base(path)
 	path = strings.TrimSuffix(path, ".yml")
 	path = strings.TrimSuffix(path, ".yaml")
+	path = strings.TrimSuffix(path, ".jsonnet")
 	path = strings.TrimPrefix(path, ".")
 	return path
 }

--- a/pipeline/frontend/jsonnet/jsonnet.go
+++ b/pipeline/frontend/jsonnet/jsonnet.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package jsonnet compiles jsonnet pipeline configs into workflow configs.
+package jsonnet
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-jsonnet"
+)
+
+const (
+	fileExtension = ".jsonnet"
+	nameKey       = "name"
+	maxStack      = 500
+	// Limits the compiled JSON size to protect the server from configs
+	// that expand into unreasonably large documents.
+	maxOutputSize = 1 << 20 // 1 MiB
+)
+
+// File is a single workflow config produced by compiling a jsonnet config.
+type File struct {
+	Name string
+	Data []byte
+}
+
+// IsJsonnetFile reports whether name refers to a jsonnet config file.
+func IsJsonnetFile(name string) bool {
+	return filepath.Ext(name) == fileExtension
+}
+
+// Compile evaluates a jsonnet config and returns one workflow config per
+// produced pipeline object. The jsonnet may evaluate to a single object
+// (one workflow, optionally named via a top-level "name" field) or to an
+// array of objects (each requiring a "name" field). The "name" field is
+// stripped from the resulting workflow config. Imports, external variables
+// and native functions are not supported.
+func Compile(name string, data []byte) ([]*File, error) {
+	vm := jsonnet.MakeVM()
+	vm.MaxStack = maxStack
+	vm.Importer(&noImporter{})
+
+	output, err := vm.EvaluateAnonymousSnippet(filepath.Base(name), string(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile jsonnet config %s: %w", name, err)
+	}
+	if len(output) > maxOutputSize {
+		return nil, fmt.Errorf("jsonnet config %s compiles to %d bytes, exceeding the limit of %d bytes", name, len(output), maxOutputSize)
+	}
+
+	var compiled any
+	if err := json.Unmarshal([]byte(output), &compiled); err != nil {
+		return nil, fmt.Errorf("failed to parse compiled jsonnet config %s: %w", name, err)
+	}
+
+	switch value := compiled.(type) {
+	case map[string]any:
+		file, err := workflowFile(name, value, defaultWorkflowName(name), 0)
+		if err != nil {
+			return nil, err
+		}
+		return []*File{file}, nil
+	case []any:
+		files := make([]*File, 0, len(value))
+		seen := make(map[string]struct{}, len(value))
+		for i, element := range value {
+			workflow, ok := element.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("jsonnet config %s: element %d is not an object", name, i)
+			}
+			file, err := workflowFile(name, workflow, "", i)
+			if err != nil {
+				return nil, err
+			}
+			if _, exists := seen[file.Name]; exists {
+				return nil, fmt.Errorf("jsonnet config %s: duplicate workflow name %q", name, file.Name)
+			}
+			seen[file.Name] = struct{}{}
+			files = append(files, file)
+		}
+		return files, nil
+	default:
+		return nil, fmt.Errorf("jsonnet config %s must evaluate to an object or an array of objects", name)
+	}
+}
+
+func workflowFile(configName string, workflow map[string]any, fallbackName string, index int) (*File, error) {
+	name := fallbackName
+	if rawName, ok := workflow[nameKey]; ok {
+		stringName, ok := rawName.(string)
+		if !ok {
+			return nil, fmt.Errorf("jsonnet config %s: workflow %d has a non-string name", configName, index)
+		}
+		name = stringName
+		delete(workflow, nameKey)
+	}
+	if name == "" {
+		return nil, fmt.Errorf("jsonnet config %s: workflow %d has no name", configName, index)
+	}
+	if strings.ContainsAny(name, "/\\") || strings.HasPrefix(name, ".") {
+		return nil, fmt.Errorf("jsonnet config %s: invalid workflow name %q", configName, name)
+	}
+
+	data, err := json.Marshal(workflow)
+	if err != nil {
+		return nil, fmt.Errorf("jsonnet config %s: failed to encode workflow %q: %w", configName, name, err)
+	}
+	return &File{Name: name, Data: data}, nil
+}
+
+func defaultWorkflowName(configName string) string {
+	name := strings.TrimSuffix(filepath.Base(configName), fileExtension)
+	return strings.TrimPrefix(name, ".")
+}
+
+type noImporter struct{}
+
+func (*noImporter) Import(_, importedPath string) (jsonnet.Contents, string, error) {
+	return jsonnet.Contents{}, "", fmt.Errorf("imports are not supported in jsonnet configs (import of %q)", importedPath)
+}

--- a/pipeline/frontend/jsonnet/jsonnet_test.go
+++ b/pipeline/frontend/jsonnet/jsonnet_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonnet
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsJsonnetFile(t *testing.T) {
+	assert.True(t, IsJsonnetFile(".woodpecker.jsonnet"))
+	assert.True(t, IsJsonnetFile(".woodpecker/pipelines.jsonnet"))
+	assert.False(t, IsJsonnetFile(".woodpecker.yaml"))
+	assert.False(t, IsJsonnetFile(".woodpecker.yml"))
+	assert.False(t, IsJsonnetFile("jsonnet"))
+}
+
+func TestCompileSingleObject(t *testing.T) {
+	files, err := Compile(".woodpecker.jsonnet", []byte(`{
+		steps: [{ name: 'test', image: 'alpine', commands: ['echo hi'] }],
+	}`))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "woodpecker", files[0].Name)
+	assert.JSONEq(t, `{"steps":[{"name":"test","image":"alpine","commands":["echo hi"]}]}`, string(files[0].Data))
+}
+
+func TestCompileSingleObjectWithName(t *testing.T) {
+	files, err := Compile(".woodpecker.jsonnet", []byte(`{
+		name: 'build',
+		steps: [{ name: 'test', image: 'alpine' }],
+	}`))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "build", files[0].Name)
+
+	var workflow map[string]any
+	require.NoError(t, json.Unmarshal(files[0].Data, &workflow))
+	assert.NotContains(t, workflow, "name")
+}
+
+func TestCompileArray(t *testing.T) {
+	files, err := Compile(".woodpecker.jsonnet", []byte(`
+		local pipeline(name) = {
+			name: name,
+			steps: [{ name: 'test', image: 'alpine', commands: ['echo ' + name] }],
+		};
+		std.map(pipeline, ['alpha', 'beta', 'gamma'])
+	`))
+	require.NoError(t, err)
+	require.Len(t, files, 3)
+	assert.Equal(t, "alpha", files[0].Name)
+	assert.Equal(t, "beta", files[1].Name)
+	assert.Equal(t, "gamma", files[2].Name)
+	for _, file := range files {
+		var workflow map[string]any
+		require.NoError(t, json.Unmarshal(file.Data, &workflow))
+		assert.NotContains(t, workflow, "name")
+		assert.Contains(t, workflow, "steps")
+	}
+}
+
+func TestCompileTextBlocks(t *testing.T) {
+	files, err := Compile(".woodpecker.jsonnet", []byte(`{
+		steps: [{
+			name: 'test',
+			image: 'alpine',
+			commands: [|||
+				echo one
+				echo two
+			|||],
+		}],
+	}`))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Contains(t, string(files[0].Data), "echo one\\necho two")
+}
+
+func TestCompileErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name:    "syntax error",
+			config:  `{ steps: [ }`,
+			wantErr: "failed to compile",
+		},
+		{
+			name:    "top-level scalar",
+			config:  `"not a workflow"`,
+			wantErr: "must evaluate to an object or an array",
+		},
+		{
+			name:    "array element not an object",
+			config:  `[{ name: 'ok', steps: [] }, 42]`,
+			wantErr: "element 1 is not an object",
+		},
+		{
+			name:    "array element without name",
+			config:  `[{ steps: [] }]`,
+			wantErr: "has no name",
+		},
+		{
+			name:    "duplicate names",
+			config:  `[{ name: 'a', steps: [] }, { name: 'a', steps: [] }]`,
+			wantErr: "duplicate workflow name",
+		},
+		{
+			name:    "non-string name",
+			config:  `{ name: 42, steps: [] }`,
+			wantErr: "non-string name",
+		},
+		{
+			name:    "invalid name",
+			config:  `{ name: 'foo/bar', steps: [] }`,
+			wantErr: "invalid workflow name",
+		},
+		{
+			name:    "import",
+			config:  `import 'other.jsonnet'`,
+			wantErr: "imports are not supported",
+		},
+		{
+			name:    "importstr",
+			config:  `{ data: importstr 'file.txt' }`,
+			wantErr: "imports are not supported",
+		},
+		{
+			name:    "external variable",
+			config:  `{ name: std.extVar('x'), steps: [] }`,
+			wantErr: "failed to compile",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Compile(".woodpecker.jsonnet", []byte(tt.config))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestCompileOutputSizeLimit(t *testing.T) {
+	_, err := Compile(".woodpecker.jsonnet", []byte(`{
+		steps: [{ name: 'test', image: 'alpine', commands: [std.repeat('x', 2 * 1024 * 1024)] }],
+	}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeding the limit")
+}

--- a/server/services/config/combined_test.go
+++ b/server/services/config/combined_test.go
@@ -221,7 +221,7 @@ func TestFetchFromConfigService(t *testing.T) {
 
 			f.On("Netrc", mock.Anything, mock.Anything).Return(&model.Netrc{Machine: "mock", Login: "mock", Password: "mock"}, nil)
 
-			forgeFetcher := config.NewForge(time.Second*3, 3, constant.DefaultConfigOrder, []string{".yaml", ".yml"})
+			forgeFetcher := config.NewForge(time.Second*3, 3, constant.DefaultConfigOrder, constant.DefaultConfigExtensions)
 			configFetcher := config.NewCombined(forgeFetcher, httpFetcher)
 			files, err := configFetcher.Fetch(
 				t.Context(),

--- a/server/services/config/forge_test.go
+++ b/server/services/config/forge_test.go
@@ -278,6 +278,52 @@ func TestFetch(t *testing.T) {
 			expectedFileNames: []string{},
 			expectedError:     true,
 		},
+		{
+			name:       "Default config - .woodpecker.jsonnet",
+			repoConfig: "",
+			files: []file{{
+				name: ".woodpecker.jsonnet",
+				data: dummyData,
+			}},
+			expectedFileNames: []string{
+				".woodpecker.jsonnet",
+			},
+			expectedError: false,
+		},
+		{
+			name:       "Default config - .woodpecker.yml before .woodpecker.jsonnet",
+			repoConfig: "",
+			files: []file{{
+				name: ".woodpecker.yml",
+				data: dummyData,
+			}, {
+				name: ".woodpecker.jsonnet",
+				data: dummyData,
+			}},
+			expectedFileNames: []string{
+				".woodpecker.yml",
+			},
+			expectedError: false,
+		},
+		{
+			name:       "Default config with .jsonnet - .woodpecker/",
+			repoConfig: "",
+			files: []file{{
+				name: ".woodpecker/release.yml",
+				data: dummyData,
+			}, {
+				name: ".woodpecker/pipelines.jsonnet",
+				data: dummyData,
+			}, {
+				name: ".woodpecker/notes.txt",
+				data: dummyData,
+			}},
+			expectedFileNames: []string{
+				".woodpecker/release.yml",
+				".woodpecker/pipelines.jsonnet",
+			},
+			expectedError: false,
+		},
 	}
 
 	for _, tt := range testTable {
@@ -309,7 +355,7 @@ func TestFetch(t *testing.T) {
 				time.Second*3,
 				3,
 				constant.DefaultConfigOrder,
-				[]string{".yaml", ".yml"},
+				constant.DefaultConfigExtensions,
 			)
 			files, err := configFetcher.Fetch(
 				t.Context(),

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -22,6 +22,15 @@ var DefaultConfigOrder = []string{
 	".woodpecker/",
 	".woodpecker.yaml",
 	".woodpecker.yml",
+	".woodpecker.jsonnet",
+}
+
+// DefaultConfigExtensions represent the file extensions woodpecker considers
+// as pipeline configs when scanning a config folder by default.
+var DefaultConfigExtensions = []string{
+	".yaml",
+	".yml",
+	".jsonnet",
 }
 
 const (


### PR DESCRIPTION
## What
- New package `pipeline/frontend/jsonnet` (`IsJsonnetFile`, `Compile`): hermetic evaluation — no imports, no external variables, no native functions; explicit `MaxStack` and a 1 MiB output cap.
- A jsonnet config may evaluate to a **single workflow object** (named after the file, or via an optional top-level `name` field) or to an **array of named workflow objects** — one file can define a whole multi-workflow pipeline. The `name` field is stripped before YAML processing.
- Expansion is hooked at the top of `PipelineBuilder.Build()`, so the server (create/restart/approve), `woodpecker-cli exec` and `woodpecker-cli lint` all support it through one code path. Compiled JSON is valid YAML, so matrix, env substitution, linter and schema validation work unchanged.
- `.woodpecker.jsonnet` appended to the default config order (after the YAML entries, so existing resolution is unchanged); `.jsonnet` added to the default config-extension list (hoisted to `constant.DefaultConfigExtensions`).
- Docs: new usage page, updated workflows page, env-var defaults, configuration-extension note.

## Notes
- Compile errors surface as blocking pipeline errors with jsonnet source positions; linter messages refer to the compiled JSON of a workflow (documented).
- No eval wall-clock timeout; mitigations are the import ban, stack limit and output cap.

## Testing
- Unit tests: `pipeline/frontend/jsonnet` (single/array forms, name handling, error cases, size cap), builder (multi-workflow expansion, cross-workflow `depends_on`, matrix inside jsonnet, blocking compile errors), config fetcher (root file and folder scan).
- `golangci-lint`: 0 issues on touched packages.
- End-to-end: `woodpecker-cli exec` runs a two-pipeline jsonnet config with the local backend; `woodpecker-cli lint` validates a 1.5k-line production jsonnet config producing 7 workflows, byte-for-byte equivalent to its previously generated YAML files.