### PR TITLE
feat(backend): add nsjail backend for pipeline execution

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -37,6 +37,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/docker"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/kubernetes"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/local"
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/nsjail"
 	backend_types "go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/builder"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/metadata"
@@ -54,13 +55,14 @@ var Command = &cli.Command{
 	Usage:     "execute a local pipeline",
 	ArgsUsage: "[path/to/.woodpecker.yaml]",
 	Action:    run,
-	Flags:     slices.Concat(flags, docker.Flags, kubernetes.Flags, local.Flags),
+	Flags:     slices.Concat(flags, docker.Flags, kubernetes.Flags, local.Flags, nsjail.Flags),
 }
 
 var backends = []backend_types.Backend{
 	kubernetes.New(),
 	docker.New(),
 	local.New(),
+	nsjail.New(),
 }
 
 func run(ctx context.Context, c *cli.Command) error {
@@ -136,9 +138,12 @@ func execFile(ctx context.Context, c *cli.Command, file string) error {
 }
 
 func runExec(ctx context.Context, c *cli.Command, yamls []*builder.YamlFile, repoPath string) error {
-	// if we use the local backend we should signal to run at $repoPath
+	// if we use the local or nsjail backend we should signal to run at $repoPath
 	if c.String("backend-engine") == "local" {
 		local.CLIWorkaroundExecAtDir = repoPath
+	}
+	if c.String("backend-engine") == "nsjail" {
+		nsjail.CLIWorkaroundExecAtDir = repoPath
 	}
 
 	// collect secrets from flags

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -23,6 +23,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/docker"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/kubernetes"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/local"
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/nsjail"
 	backend_types "go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
 	"go.woodpecker-ci.org/woodpecker/v3/shared/dot_env"
 	"go.woodpecker-ci.org/woodpecker/v3/shared/utils"
@@ -32,6 +33,7 @@ var backends = []backend_types.Backend{
 	kubernetes.New(),
 	docker.New(),
 	local.New(),
+	nsjail.New(),
 }
 
 func main() {

--- a/cmd/agent/man.go
+++ b/cmd/agent/man.go
@@ -25,6 +25,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/docker"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/kubernetes"
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/local"
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/nsjail"
 	backend_types "go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
 	"go.woodpecker-ci.org/woodpecker/v3/shared/dot_env"
 )
@@ -33,6 +34,7 @@ var backends = []backend_types.Backend{
 	kubernetes.New(),
 	docker.New(),
 	local.New(),
+	nsjail.New(),
 }
 
 func main() {

--- a/pipeline/backend/nsjail/clone.go
+++ b/pipeline/backend/nsjail/clone.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
+)
+
+// checkGitCloneCap checks if the git command is available on the host.
+func checkGitCloneCap() error {
+	_, err := exec.LookPath("git")
+	return err
+}
+
+// loadClone on backend start determines if there is a global plugin-git binary.
+func (e *nsjail) loadClone() {
+	binary, err := exec.LookPath("plugin-git")
+	if err != nil || binary == "" {
+		return
+	}
+	e.pluginGitBinary = binary
+}
+
+// setupClone prepares the clone environment before exec.
+func (e *nsjail) setupClone(ctx context.Context, state *workflowState) error {
+	if e.pluginGitBinary != "" {
+		state.pluginGitBinary = e.pluginGitBinary
+		return nil
+	}
+
+	log.Info().Msg("no global 'plugin-git' installed, download for current workflow")
+	state.pluginGitBinary = filepath.Join(state.homeDir, "plugin-git")
+	if e.os == "windows" {
+		state.pluginGitBinary += ".exe"
+	}
+	return e.downloadLatestGitPluginBinary(ctx, state.pluginGitBinary)
+}
+
+// execClone executes a clone-step inside the nsjail sandbox.
+func (e *nsjail) execClone(ctx context.Context, step *types.Step, state *workflowState, env []string) error {
+	if err := checkGitCloneCap(); err != nil {
+		return fmt.Errorf("check for git clone capabilities failed: %w", err)
+	}
+
+	if err := e.setupClone(ctx, state); err != nil {
+		return fmt.Errorf("setup clone step failed: %w", err)
+	}
+
+	if !strings.Contains(step.Image, "plugin-git") {
+		log.Warn().Msgf("clone step image '%s' does not match default git clone image", step.Image)
+	}
+
+	rmCmd, netrcPath, err := e.writeNetRC(step, state)
+	if err != nil {
+		return err
+	}
+
+	// Build nsjail args (without the command after "--")
+	nsjailArgs := e.buildNsJailArgsForClone(step, state, env, state.pluginGitBinary, netrcPath)
+
+	// Append actual command (after "--")
+	var cmd *exec.Cmd
+	if rmCmd != "" {
+		// Execute plugin-git in sandbox, clean up netrc after
+		nsjailArgs = append(nsjailArgs,
+			"/bin/sh", "-c",
+			fmt.Sprintf("/bin/plugin-git ; export code=$? ; rm -f '%s/.netrc' ; exit $code",
+				state.homeDir),
+		)
+		cmd = newNsJailCmd(ctx, e.cfg.binPath, nsjailArgs...)
+	} else {
+		nsjailArgs = append(nsjailArgs, "/bin/plugin-git")
+		cmd = newNsJailCmd(ctx, e.cfg.binPath, nsjailArgs...)
+	}
+	cmd.Env = env
+	cmd.Dir = state.workspaceDir
+
+	reader, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = cmd.Stdout
+
+	state.stepState.Store(step.UUID, &stepState{cmd: cmd, output: reader})
+	return cmd.Start()
+}
+
+// writeNetRC writes a netrc file into the home dir of a given workflow state.
+// Returns (rmCmd, netrcFilePath, error) to support netrc file injection into the nsjail sandbox.
+func (e *nsjail) writeNetRC(step *types.Step, state *workflowState) (string, string, error) {
+	if step.Environment["CI_NETRC_MACHINE"] == "" {
+		log.Trace().Msg("no netrc to write")
+		return "", "", nil
+	}
+
+	if !e.cfg.isolatedHome {
+		log.Trace().Msg("writing .netrc skipped due to disabled isolated home")
+		return "", "", nil
+	}
+
+	file := filepath.Join(state.homeDir, ".netrc")
+	rmCmd := fmt.Sprintf("rm \"%s\"", file)
+	if e.os == "windows" {
+		file = filepath.Join(state.homeDir, "_netrc")
+		rmCmd = fmt.Sprintf("del \"%s\"", file)
+	}
+
+	log.Trace().Msgf("try to write netrc to '%s'", file)
+	return rmCmd, file, os.WriteFile(file, []byte(genNetRC(step.Environment)), 0o600)
+}
+
+// downloadLatestGitPluginBinary downloads the latest plugin-git binary based on runtime OS and Arch
+// and saves it to dest.
+func (e *nsjail) downloadLatestGitPluginBinary(ctx context.Context, dest string) error {
+	type asset struct {
+		Name               string
+		BrowserDownloadURL string `json:"browser_download_url"`
+	}
+
+	type release struct {
+		Assets []asset
+	}
+
+	// get latest release
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/repos/woodpecker-ci/plugin-git/releases/latest", nil)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("could not get latest release: %w", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	var rel release
+	if err := json.Unmarshal(raw, &rel); err != nil {
+		return fmt.Errorf("could not unmarshal github response: %w", err)
+	}
+
+	for _, at := range rel.Assets {
+		if strings.Contains(at.Name, e.os) && strings.Contains(at.Name, e.arch) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, at.BrowserDownloadURL, nil)
+			if err != nil {
+				return err
+			}
+			assetResp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return fmt.Errorf("could not download plugin-git: %w", err)
+			}
+			defer assetResp.Body.Close()
+
+			file, err := os.Create(dest)
+			if err != nil {
+				return fmt.Errorf("could not create plugin-git: %w", err)
+			}
+			defer file.Close()
+
+			if _, err := io.Copy(file, assetResp.Body); err != nil {
+				return fmt.Errorf("could not download plugin-git: %w", err)
+			}
+			if err := os.Chmod(dest, 0o755); err != nil {
+				return err
+			}
+
+			log.Trace().Msgf("download of 'plugin-git' to '%s' successful", dest)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("could not download plugin-git, binary for this os/arch not found")
+}

--- a/pipeline/backend/nsjail/command.go
+++ b/pipeline/backend/nsjail/command.go
@@ -1,0 +1,441 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// cSpell:ignore ERRORLEVEL
+
+package nsjail
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"al.essio.dev/pkg/shellescape"
+
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
+)
+
+// defaultSeccompProfile returns an architecture-appropriate default seccomp policy.
+// Kafel syscall names differ between architectures (e.g., arm64 lacks open, access, arch_prctl).
+// Users can override via --backend-nsjail-seccomp / --backend-nsjail-seccomp-string.
+func defaultSeccompProfile() string {
+	if runtime.GOARCH == "arm64" {
+		return arm64SeccompProfile
+	}
+	return amd64SeccompProfile
+}
+
+const amd64SeccompProfile = `
+POLICY ci_default {
+    ALLOW {
+        read, write, open, openat, close,
+        mmap, munmap, brk, mprotect,
+        fstat, fstatat, newfstatat, lstat, stat,
+        access, faccessat, faccessat2,
+        lseek, pread64, pwrite64,
+        readv, writev, preadv, pwritev,
+        unlink, unlinkat, rmdir, mkdir, mkdirat,
+        rename, renameat, renameat2,
+        link, linkat, symlink, symlinkat,
+        readlink, readlinkat, getdents, getdents64,
+        chdir, fchdir, fchmod, fchmodat,
+        chown, fchown, lchown, fchownat,
+        copy_file_range, splice, sendfile,
+        fallocate, ftruncate, truncate,
+        utimensat, futimesat,
+        clone, clone3, fork, vfork,
+        execve, execveat, exit_group,
+        getpid, getppid, gettid,
+        getuid, getgid, geteuid, getegid,
+        getresuid, getresgid,
+        setuid, setgid, setresuid, setresgid,
+        set_tid_address, set_robust_list,
+        wait4, waitid,
+        mremap, msync, mincore, madvise,
+        shmget, shmat, shmdt, shmctl,
+        rt_sigreturn, rt_sigaction, rt_sigprocmask,
+        rt_sigpending, rt_sigsuspend, sigaltstack,
+        kill, tkill, tgkill,
+        socket, connect, bind, listen, accept, accept4,
+        sendto, recvfrom, sendmsg, recvmsg,
+        sendmmsg, recvmmsg,
+        setsockopt, getsockopt,
+        shutdown, getsockname, getpeername,
+        nanosleep, clock_nanosleep,
+        sched_yield,
+        clock_gettime, clock_settime,
+        gettimeofday, settimeofday, time,
+        futex, futex_time64,
+        arch_prctl, prctl,
+        sysinfo, uname,
+        pipe, pipe2,
+        eventfd, eventfd2, epoll_create,
+        epoll_create1, epoll_ctl, epoll_wait,
+        poll, ppoll, select, pselect6,
+        ioctl,
+        getrandom,
+        capget, capset,
+        statfs, statfs64, fstatfs, fstatfs64,
+        mount, umount, umount2,
+        personality
+    }
+}
+USE ci_default DEFAULT KILL
+`
+
+// arm64SeccompProfile uses syscall names from the ARM64 generic syscall ABI.
+// ARM64 uses a simplified ABI that lacks many legacy syscalls (open, access, dup2, pipe, etc.).
+const arm64SeccompProfile = `
+POLICY ci_default {
+    ALLOW {
+        read, write, close,
+        mmap, munmap, mprotect, brk, madvise,
+        openat, newfstatat, statx, faccessat,
+        lseek, pread64, pwrite64,
+        readv, writev, preadv, pwritev,
+        unlinkat, mkdirat, renameat, symlinkat, readlinkat,
+        getdents64,
+        chdir, fchdir, fchmodat, fchownat,
+        copy_file_range,
+        clone, clone3,
+        execve, execveat, exit_group,
+        getpid, getppid, gettid,
+        getuid, getgid, geteuid, getegid,
+        setuid, setgid,
+        set_tid_address, set_robust_list,
+        waitid,
+        mremap, msync, mincore,
+        rt_sigreturn, rt_sigaction, rt_sigprocmask,
+        rt_sigpending, rt_sigsuspend, sigaltstack,
+        kill, tkill, tgkill,
+        socket, connect, bind, listen, accept4,
+        sendto, recvfrom, sendmsg, recvmsg,
+        sendmmsg, recvmmsg,
+        setsockopt, getsockopt,
+        shutdown, getsockname, getpeername,
+        nanosleep, clock_nanosleep,
+        sched_yield,
+        clock_gettime, clock_settime,
+        gettimeofday, settimeofday,
+        futex,
+        prctl,
+        pipe2, eventfd2, epoll_create1, epoll_ctl, epoll_pwait,
+        ppoll, pselect6,
+        ioctl, fcntl,
+        getrandom,
+        capget, capset,
+        statfs, fstatfs,
+        getcwd, dup, dup3, umask, fchmod,
+        fchown, linkat, renameat2, truncate, ftruncate,
+        setpgid, getpgid, setsid, getsid,
+        flock, fsync, fdatasync,
+        symlinkat, readlinkat,
+        faccessat2
+    }
+}
+USE ci_default DEFAULT KILL
+`
+
+// buildNsJailArgs converts a Woodpecker Step into nsjail CLI arguments.
+// All security hardening is enabled by default; config can override.
+func (e *nsjail) buildNsJailArgs(step *types.Step, state *workflowState, env []string) []string {
+	var args []string
+
+	// === Mode: ONCE (execute once then exit) ===
+	args = append(args, "-Mo")
+
+	// === Chroot ===
+	args = append(args, "--chroot", "/")
+
+	// === Resource limits ===
+	if e.cfg.maxCPU > 0 {
+		args = append(args, "--rlimit_cpu", strconv.Itoa(e.cfg.maxCPU))
+	} else {
+		args = append(args, "--rlimit_cpu", "300")
+	}
+	if e.cfg.maxMemory > 0 {
+		args = append(args, "--rlimit_as", strconv.Itoa(e.cfg.maxMemory))
+	} else {
+		args = append(args, "--rlimit_as", "512")
+	}
+	if e.cfg.maxNofile > 0 {
+		args = append(args, "--rlimit_nofile", strconv.Itoa(e.cfg.maxNofile))
+	} else {
+		args = append(args, "--rlimit_nofile", "64")
+	}
+	if e.cfg.maxPids > 0 {
+		args = append(args, "--rlimit_nproc", strconv.Itoa(e.cfg.maxPids))
+	} else {
+		args = append(args, "--rlimit_nproc", "64")
+	}
+
+	// === cgroup resource limits ===
+	// detect_cgroupv2: auto-detect cgroup v2 if available (needed on modern Linux)
+	args = append(args, "--detect_cgroupv2")
+	if e.cfg.cgroupPidsMax > 0 {
+		args = append(args, "--cgroup_pids_max", strconv.Itoa(e.cfg.cgroupPidsMax))
+	} else {
+		args = append(args, "--cgroup_pids_max", "64")
+	}
+	if e.cfg.cgroupCpuMs > 0 {
+		args = append(args, "--cgroup_cpu_ms_per_sec", strconv.Itoa(e.cfg.cgroupCpuMs))
+	} else {
+		args = append(args, "--cgroup_cpu_ms_per_sec", "800")
+	}
+
+	// === Time limit ===
+	if e.cfg.timeLimit > 0 {
+		args = append(args, "--time_limit", strconv.Itoa(e.cfg.timeLimit))
+	} else {
+		args = append(args, "--time_limit", "600")
+	}
+
+	// === Seccomp policy ===
+	// seccompString="off" disables seccomp entirely (omit --seccomp_string flag)
+	if e.cfg.seccompString != "" && e.cfg.seccompString != "off" {
+		args = append(args, "--seccomp_string", e.cfg.seccompString)
+	} else if e.cfg.seccompFile != "" {
+		args = append(args, "--seccomp", e.cfg.seccompFile)
+	} else if e.cfg.seccompString != "off" {
+		// Default seccomp policy when nothing is configured
+		args = append(args, "--seccomp_string", defaultSeccompProfile())
+	}
+
+	// === User/Group mapping ===
+	// Default to nobody (UID/GID 65534), overridable via --backend-nsjail-uid / --backend-nsjail-gid
+	jailUID := 65534
+	if e.cfg.uid > 0 {
+		jailUID = e.cfg.uid
+	}
+	jailGID := 65534
+	if e.cfg.gid > 0 {
+		jailGID = e.cfg.gid
+	}
+	args = append(args, "--user", strconv.Itoa(jailUID))
+	args = append(args, "--group", strconv.Itoa(jailGID))
+	args = append(args, "--uid_mapping", fmt.Sprintf("0:%d:1", jailUID))
+	args = append(args, "--gid_mapping", fmt.Sprintf("0:%d:1", jailGID))
+
+	// === Filesystem ===
+	// When readonly=true mount as read-only, otherwise chroot / allows read-write access by default
+	if e.cfg.readonly {
+		args = append(args, "--ro", state.workspaceDir)
+		args = append(args, "--ro", state.homeDir)
+	}
+
+	// === Namespace isolation ===
+	if !e.cfg.isolateNet {
+		args = append(args, "--disable_clone_newnet")
+	}
+	if !e.cfg.isolatePid {
+		args = append(args, "--disable_clone_newpid")
+	}
+	if !e.cfg.isolateIpc {
+		args = append(args, "--disable_clone_newipc")
+	}
+	if !e.cfg.isolateUts {
+		args = append(args, "--disable_clone_newuts")
+	}
+	if !e.cfg.isolateUser {
+		args = append(args, "--disable_clone_newuser")
+	}
+
+	// === Security hardening ===
+	if e.cfg.noNewPrivs {
+		args = append(args, "--no_new_privs")
+	}
+
+	// === /proc mount (default: off) ===
+	if e.cfg.procMount {
+		args = append(args, "--bindmount", "/proc:/proc")
+	}
+
+	// === Environment variables ===
+	// nsjail does NOT inherit parent process env — each --env flag is explicit
+	for _, envVar := range env {
+		args = append(args, "--env", envVar)
+	}
+
+	// === Hostname isolation ===
+	args = append(args, "--hostname", "nsjail")
+
+	// === Separator: end of nsjail args ===
+	args = append(args, "--")
+
+	return args
+}
+
+// execCommands executes a commands step inside the nsjail sandbox.
+func (e *nsjail) execCommands(ctx context.Context, step *types.Step, state *workflowState, env []string) error {
+	// Look up the full path of the shell binary (e.g., "bash" → "/bin/bash")
+	// nsjail's execve() inside the jail needs an absolute path
+	shellPath, err := exec.LookPath(step.Image)
+	if err != nil {
+		return fmt.Errorf("shell %q not found: %w", step.Image, err)
+	}
+
+	// Build nsjail base arguments (ending with "--")
+	nsjailArgs := e.buildNsJailArgs(step, state, env)
+
+	// Get shell arguments via genCmdByShell (different shell types use different argument formats)
+	shellArgs, err := e.genCmdByShell(step.Image, step.Commands, state.baseDir)
+	if err != nil {
+		return fmt.Errorf("could not convert commands into args: %w", err)
+	}
+
+	// Append shell binary and its arguments after "--"
+	// nsjail expects the first arg after "--" to be the executable path
+	nsjailArgs = append(nsjailArgs, shellPath)
+	nsjailArgs = append(nsjailArgs, shellArgs...)
+
+	cmd := newNsJailCmd(ctx, e.cfg.binPath, nsjailArgs...)
+	cmd.Env = env
+	cmd.Dir = state.workspaceDir
+
+	reader, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = cmd.Stdout
+
+	state.stepState.Store(step.UUID, &stepState{cmd: cmd, output: reader})
+	return cmd.Start()
+}
+
+// genCmdByShell generates shell execution arguments based on shell type (step.Image).
+// Supports: sh/bash/zsh (POSIX), cmd, fish, nu, powershell/pwsh.
+func (e *nsjail) genCmdByShell(shell string, cmdList []string, baseDir string) (args []string, err error) {
+	if len(cmdList) == 0 {
+		return nil, ErrNoCmdSet
+	}
+
+	script := ""
+	for _, cmd := range cmdList {
+		script += fmt.Sprintf("echo %s\n%s\n", strings.TrimSpace(shellescape.Quote("+ "+cmd)), cmd)
+	}
+	script = strings.TrimSpace(script)
+
+	shell = strings.TrimSuffix(strings.ToLower(shell), ".exe")
+	switch shell {
+	default:
+		// assume posix shell
+		if err := probeShellIsPosix(shell); err != nil {
+			return nil, err
+		}
+		fallthrough
+	case "sh", "bash", "zsh":
+		return []string{"-e", "-c", script}, nil
+	case "":
+		return nil, ErrNoShellSet
+	case "cmd":
+		script := "@SET PROMPT=$\n"
+		for _, cmd := range cmdList {
+			quotedCmd := strings.TrimSpace(shellescape.Quote(cmd))
+			quotedCmd = strings.ReplaceAll(quotedCmd, "\n", "\\n")
+			quotedCmd = strings.ReplaceAll(quotedCmd, "&", "\\AND")
+			quotedCmd = strings.ReplaceAll(quotedCmd, "|", "\\OR")
+			script += fmt.Sprintf("@echo + %s\n", quotedCmd)
+			script += fmt.Sprintf("@%s\n", cmd)
+			script += "@IF NOT %ERRORLEVEL% == 0 exit %ERRORLEVEL%\n"
+		}
+		cmdFile, err := os.CreateTemp(baseDir, "*.cmd")
+		if err != nil {
+			return nil, err
+		}
+		defer cmdFile.Close()
+		if _, err := cmdFile.WriteString(script); err != nil {
+			return nil, err
+		}
+		return []string{"/c", cmdFile.Name()}, nil
+	case "fish":
+		script := ""
+		for _, cmd := range cmdList {
+			script += fmt.Sprintf("echo %s\n%s || exit $status\n", strings.TrimSpace(shellescape.Quote("+ "+cmd)), cmd)
+		}
+		return []string{"-c", script}, nil
+	case "nu":
+		return []string{"--commands", script}, nil
+	case "powershell", "pwsh":
+		return []string{"-noprofile", "-noninteractive", "-c", "$ErrorActionPreference = \"Stop\"; " + script}, nil
+	}
+}
+
+// probeShellIsPosix checks if the given shell is POSIX-compatible.
+func probeShellIsPosix(shell string) error {
+	script := `x=1 && [ "$x" = "1" ] && command -v test >/dev/null && printf ok`
+
+	cmd := exec.Command(shell, "-c", script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return &ErrNoPosixShell{Shell: shell, Err: err}
+	}
+
+	if strings.TrimSpace(string(output)) != "ok" {
+		return &ErrNoPosixShell{Shell: shell, Err: fmt.Errorf("unexpected output: %q", string(output))}
+	}
+
+	return nil
+}
+
+// buildNsJailArgsForClone builds nsjail CLI arguments for clone steps (with bindmount for plugin-git).
+// The returned args end with "--", the actual command is appended by execClone.
+func (e *nsjail) buildNsJailArgsForClone(step *types.Step, state *workflowState, env []string, pluginGitPath, netrcPath string) []string {
+	args := e.buildNsJailArgs(step, state, env)
+
+	// Find "--" separator and truncate to it (keep "--")
+	sepIdx := len(args) - 1
+	for i := len(args) - 1; i >= 0; i-- {
+		if args[i] == "--" {
+			sepIdx = i
+			break
+		}
+	}
+	args = args[:sepIdx+1] // keep "--"
+
+	// Insert clone-specific bindmount arguments before "--"
+	var extraArgs []string
+	if pluginGitPath != "" {
+		extraArgs = append(extraArgs, "--bindmount_ro", pluginGitPath+":/bin/plugin-git")
+	}
+	if netrcPath != "" {
+		netrcInside := filepath.Join(state.homeDir, ".netrc")
+		extraArgs = append(extraArgs, "--bindmount", netrcPath+":"+netrcInside)
+	}
+
+	// Insert extra args before "--"
+	args = append(args[:sepIdx], append(extraArgs, args[sepIdx:]...)...)
+
+	return args // ends with "--", command appended by execClone
+}
+
+// newNsJailCmd creates an nsjail command with process group support for batch kill.
+func newNsJailCmd(ctx context.Context, binPath string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	return cmd
+}

--- a/pipeline/backend/nsjail/command_test.go
+++ b/pipeline/backend/nsjail/command_test.go
@@ -290,5 +290,3 @@ func TestDefaultSeccompProfileArchAware(t *testing.T) {
 		assert.Contains(t, profile, "arch_prctl")
 	}
 }
-
-

--- a/pipeline/backend/nsjail/command_test.go
+++ b/pipeline/backend/nsjail/command_test.go
@@ -1,0 +1,294 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
+)
+
+func TestGenCmdByShell(t *testing.T) {
+	e := &nsjail{}
+
+	t.Run("error cases", func(t *testing.T) {
+		args, err := e.genCmdByShell("", []string{"echo hi"}, t.TempDir())
+		assert.Nil(t, args)
+		assert.ErrorIs(t, err, ErrNoShellSet)
+
+		args, err = e.genCmdByShell("sh", []string{}, t.TempDir())
+		assert.Nil(t, args)
+		assert.ErrorIs(t, err, ErrNoCmdSet)
+	})
+
+	t.Run("unix shells", func(t *testing.T) {
+		args, err := e.genCmdByShell("sh", []string{"echo hello", "pwd"}, t.TempDir())
+		require.NoError(t, err)
+		assert.Len(t, args, 3)
+		assert.Equal(t, "-e", args[0])
+		assert.Equal(t, "-c", args[1])
+		assert.Contains(t, args[2], "echo hello")
+		assert.Contains(t, args[2], "pwd")
+
+		args, err = e.genCmdByShell("bash", []string{"ls -la"}, t.TempDir())
+		require.NoError(t, err)
+		assert.Len(t, args, 3)
+		assert.Equal(t, "-e", args[0])
+
+		args, err = e.genCmdByShell("zsh", []string{"echo test"}, t.TempDir())
+		require.NoError(t, err)
+		assert.Len(t, args, 3)
+		assert.Equal(t, "-e", args[0])
+	})
+
+	t.Run("windows shells", func(t *testing.T) {
+		args, err := e.genCmdByShell("cmd.exe", []string{"echo hi"}, t.TempDir())
+		require.NoError(t, err)
+		require.Len(t, args, 2)
+		assert.Equal(t, "/c", args[0])
+		assert.True(t, strings.HasSuffix(args[1], ".cmd"))
+
+		args, err = e.genCmdByShell("powershell", []string{"Write-Host 'test'"}, t.TempDir())
+		require.NoError(t, err)
+		assert.Len(t, args, 4)
+		assert.Equal(t, "-noprofile", args[0])
+		assert.Equal(t, "-noninteractive", args[1])
+		assert.Equal(t, "-c", args[2])
+	})
+
+	t.Run("fish shell", func(t *testing.T) {
+		args, err := e.genCmdByShell("fish", []string{"echo test"}, t.TempDir())
+		require.NoError(t, err)
+		assert.Len(t, args, 2)
+		assert.Equal(t, "-c", args[0])
+		assert.Contains(t, args[1], "|| exit $status")
+	})
+
+	t.Run("nu shell", func(t *testing.T) {
+		args, err := e.genCmdByShell("nu", []string{"echo test"}, t.TempDir())
+		require.NoError(t, err)
+		assert.Len(t, args, 2)
+		assert.Equal(t, "--commands", args[0])
+	})
+
+	t.Run("cmd temp file content", func(t *testing.T) {
+		args, err := e.genCmdByShell("cmd", []string{"echo hello"}, t.TempDir())
+		require.NoError(t, err)
+		content, err := os.ReadFile(args[1])
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "@echo + 'echo hello'")
+		assert.Contains(t, string(content), "@echo hello")
+	})
+}
+
+func TestBuildNsJailArgs(t *testing.T) {
+	t.Run("custom values", func(t *testing.T) {
+		e := &nsjail{}
+		e.cfg.timeLimit = 30
+		e.cfg.maxCPU = 60
+
+		step := &types.Step{UUID: "test-step"}
+		state := &workflowState{
+			workspaceDir: "/tmp/workspace",
+			homeDir:      "/tmp/home",
+		}
+
+		args := e.buildNsJailArgs(step, state, nil)
+
+		// Check essential args
+		assert.Contains(t, args, "-Mo")
+		assert.Contains(t, args, "--chroot")
+		assert.Contains(t, args, "/")
+		assert.Contains(t, args, "--time_limit")
+		assert.Contains(t, args, "30")
+		assert.Contains(t, args, "--rlimit_cpu")
+		assert.Contains(t, args, "60")
+		assert.Contains(t, args, "--hostname")
+		assert.Contains(t, args, "nsjail")
+		assert.Contains(t, args, "--user")
+		assert.Contains(t, args, "65534")
+		assert.Contains(t, args, "--group")
+		assert.Contains(t, args, "65534")
+		assert.Contains(t, args, "--seccomp_string")
+		assert.Contains(t, args, "--")
+
+		// Verify separator position (last element before command)
+		sepIdx := -1
+		for i, a := range args {
+			if a == "--" {
+				sepIdx = i
+				break
+			}
+		}
+		assert.Greater(t, sepIdx, 0, "-- separator should exist")
+	})
+
+	t.Run("default values", func(t *testing.T) {
+		e := &nsjail{}
+
+		args := e.buildNsJailArgs(&types.Step{}, &workflowState{}, nil)
+
+		// Default resource limits
+		assert.Contains(t, args, "--rlimit_cpu")
+		assert.Contains(t, args, "300")
+		assert.Contains(t, args, "--rlimit_as")
+		assert.Contains(t, args, "512")
+		assert.Contains(t, args, "--rlimit_nofile")
+		assert.Contains(t, args, "64")
+		assert.Contains(t, args, "--rlimit_nproc")
+		assert.Contains(t, args, "64")
+		assert.Contains(t, args, "--time_limit")
+		assert.Contains(t, args, "600")
+
+		// Default cgroup limits
+		assert.Contains(t, args, "--cgroup_pids_max")
+		assert.Contains(t, args, "64")
+		assert.Contains(t, args, "--cgroup_cpu_ms_per_sec")
+		assert.Contains(t, args, "800")
+
+		// Default seccomp (built-in policy)
+		assert.Contains(t, args, "--seccomp_string")
+	})
+}
+
+func TestBuildNsJailArgsCustomUID(t *testing.T) {
+	e := &nsjail{}
+	e.cfg.uid = 1000
+	e.cfg.gid = 1000
+	e.cfg.noNewPrivs = true
+	e.cfg.readonly = true
+
+	step := &types.Step{UUID: "test"}
+	state := &workflowState{
+		workspaceDir: "/tmp/ws",
+		homeDir:      "/tmp/hm",
+	}
+
+	args := e.buildNsJailArgs(step, state, nil)
+
+	assert.Contains(t, args, "--user")
+	assert.Contains(t, args, "1000")
+	assert.Contains(t, args, "--group")
+	assert.Contains(t, args, "1000")
+	assert.Contains(t, args, "--no_new_privs")
+	assert.Contains(t, args, "--ro")
+	assert.Contains(t, args, "/tmp/ws")
+	assert.Contains(t, args, "/tmp/hm")
+}
+
+func TestBuildNsJailArgsDisableIsolation(t *testing.T) {
+	e := &nsjail{}
+	e.cfg.isolateNet = false
+	e.cfg.isolatePid = false
+
+	args := e.buildNsJailArgs(&types.Step{}, &workflowState{}, nil)
+
+	assert.Contains(t, args, "--disable_clone_newnet")
+	assert.Contains(t, args, "--disable_clone_newpid")
+}
+
+func TestBuildNsJailArgsSeccompFile(t *testing.T) {
+	e := &nsjail{}
+	e.cfg.seccompFile = "/etc/nsjail/seccomp.cfg"
+
+	args := e.buildNsJailArgs(&types.Step{}, &workflowState{}, nil)
+
+	assert.Contains(t, args, "--seccomp")
+	assert.Contains(t, args, "/etc/nsjail/seccomp.cfg")
+	assert.NotContains(t, args, "--seccomp_string")
+}
+
+func TestBuildNsJailArgsSeccompString(t *testing.T) {
+	e := &nsjail{}
+	e.cfg.seccompString = "POLICY my { ALLOW { read } DEFAULT KILL } USE my DEFAULT KILL"
+
+	args := e.buildNsJailArgs(&types.Step{}, &workflowState{}, nil)
+
+	assert.Contains(t, args, "--seccomp_string")
+	assert.NotContains(t, args, "--seccomp")
+
+	// Find the seccomp_string value in args
+	for i, a := range args {
+		if a == "--seccomp_string" && i+1 < len(args) {
+			assert.Contains(t, args[i+1], "POLICY my")
+			return
+		}
+	}
+	t.Error("--seccomp_string not found in args")
+}
+
+func TestBuildNsJailArgsForClone(t *testing.T) {
+	e := &nsjail{}
+
+	step := &types.Step{UUID: "clone-step"}
+	state := &workflowState{
+		workspaceDir: "/tmp/ws",
+		homeDir:      "/tmp/home",
+	}
+
+	args := e.buildNsJailArgsForClone(step, state, nil, "/usr/local/bin/plugin-git", "/tmp/home/.netrc")
+
+	assert.Contains(t, args, "--bindmount_ro")
+	assert.Contains(t, args, "/usr/local/bin/plugin-git:/bin/plugin-git")
+	assert.Contains(t, args, "--bindmount")
+
+	// Find "--" separator
+	sepIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			sepIdx = i
+			break
+		}
+	}
+	assert.Greater(t, sepIdx, 0, "-- separator should exist")
+	// bindmount args should be before "--"
+	assert.Contains(t, args[:sepIdx], "--bindmount_ro")
+}
+
+func TestDefaultSeccompProfile(t *testing.T) {
+	profile := defaultSeccompProfile()
+	assert.Contains(t, profile, "POLICY ci_default")
+	assert.Contains(t, profile, "ALLOW {")
+	assert.Contains(t, profile, "DEFAULT KILL")
+}
+
+func TestDefaultSeccompProfileArchAware(t *testing.T) {
+	profile := defaultSeccompProfile()
+
+	// Both profiles must have at least these core syscalls
+	core := []string{"read,", "write,", "close,", "mmap,", "execve,", "exit_group,"}
+	for _, syscall := range core {
+		assert.Contains(t, profile, syscall,
+			"default seccomp profile should allow syscall: "+syscall)
+	}
+
+	// Architecture-specific checks
+	// x86_64 profile has arch_prctl, arm64 profile does not
+	if runtime.GOARCH == "arm64" {
+		assert.Contains(t, profile, "openat,")
+		assert.NotContains(t, profile, "arch_prctl")
+	} else {
+		assert.Contains(t, profile, "open,")
+		assert.Contains(t, profile, "arch_prctl")
+	}
+}
+
+

--- a/pipeline/backend/nsjail/config.go
+++ b/pipeline/backend/nsjail/config.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"github.com/urfave/cli/v3"
+)
+
+type config struct {
+	binPath       string
+	tempDir       string   // temp dir for workflow workspaces
+	isolatedHome  bool     // set HOME/USERPROFILE to isolated dir
+	seccompFile   string
+	seccompString string
+	maxCPU        int
+	maxMemory     int
+	maxNofile     int
+	maxPids       int
+	readonly      bool
+	procMount     bool   // mount /proc from host (default: off)
+	noNewPrivs    bool
+	isolateNet    bool
+	isolatePid    bool
+	isolateIpc    bool
+	isolateUts    bool
+	isolateUser   bool
+	uid           int
+	gid           int
+	timeLimit     int
+	cgroupPidsMax int
+	cgroupCpuMs   int
+}
+
+func configFromCli(c *cli.Command) config {
+	return config{
+		binPath:       c.String("backend-nsjail-bin"),
+		tempDir:       c.String("backend-nsjail-temp-dir"),
+		isolatedHome:  c.Bool("backend-nsjail-isolated-home"),
+		seccompFile:   c.String("backend-nsjail-seccomp"),
+		seccompString: c.String("backend-nsjail-seccomp-string"),
+		maxCPU:        c.Int("backend-nsjail-max-cpu"),
+		maxMemory:     c.Int("backend-nsjail-max-memory"),
+		maxNofile:     c.Int("backend-nsjail-max-nofile"),
+		maxPids:       c.Int("backend-nsjail-max-pids"),
+		readonly:      c.Bool("backend-nsjail-readonly"),
+		procMount:     c.Bool("backend-nsjail-proc-mount"),
+		noNewPrivs:    c.Bool("backend-nsjail-no-new-privs"),
+		isolateNet:    c.Bool("backend-nsjail-isolate-net"),
+		isolatePid:    c.Bool("backend-nsjail-isolate-pid"),
+		isolateIpc:    c.Bool("backend-nsjail-isolate-ipc"),
+		isolateUts:    c.Bool("backend-nsjail-isolate-uts"),
+		isolateUser:   c.Bool("backend-nsjail-isolate-user"),
+		uid:           c.Int("backend-nsjail-uid"),
+		gid:           c.Int("backend-nsjail-gid"),
+		timeLimit:     c.Int("backend-nsjail-time-limit"),
+		cgroupPidsMax: c.Int("backend-nsjail-cgroup-pids-max"),
+		cgroupCpuMs:   c.Int("backend-nsjail-cgroup-cpu-ms"),
+	}
+}

--- a/pipeline/backend/nsjail/const.go
+++ b/pipeline/backend/nsjail/const.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import "fmt"
+
+const netrcFile = `
+machine %s
+login %s
+password %s
+`
+
+func genNetRC(env map[string]string) string {
+	return fmt.Sprintf(
+		netrcFile,
+		env["CI_NETRC_MACHINE"],
+		env["CI_NETRC_USERNAME"],
+		env["CI_NETRC_PASSWORD"],
+	)
+}

--- a/pipeline/backend/nsjail/const_test.go
+++ b/pipeline/backend/nsjail/const_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenNetRC(t *testing.T) {
+	assert.Equal(t, `
+machine example.com
+login user
+password pass
+`, genNetRC(map[string]string{
+		"CI_NETRC_MACHINE":  "example.com",
+		"CI_NETRC_USERNAME": "user",
+		"CI_NETRC_PASSWORD": "pass",
+	}))
+}

--- a/pipeline/backend/nsjail/errors.go
+++ b/pipeline/backend/nsjail/errors.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrUnsupportedStepType   = errors.New("nsjail: unsupported step type")
+	ErrNsjailNotFound        = errors.New("nsjail binary not found")
+	ErrNsjailNotAvailable    = errors.New("nsjail requires Linux")
+	ErrNoCmdSet              = errors.New("nsjail: no commands provided")
+	ErrNoShellSet            = errors.New("nsjail: no shell set")
+	ErrStepReaderNotFound    = errors.New("nsjail: could not found pipe reader for step")
+	ErrWorkflowStateNotFound = errors.New("nsjail: workflow state not found")
+	ErrStepStateNotFound     = errors.New("nsjail: step state not found")
+)
+
+// ErrNoPosixShell indicates that a shell was assumed to be POSIX-compatible but failed the test.
+type ErrNoPosixShell struct {
+	Shell string
+	Err   error
+}
+
+func (e *ErrNoPosixShell) Error() string {
+	return fmt.Sprintf("nsjail: shell %q is not POSIX compatible: %v", e.Shell, e.Err)
+}
+
+func (e *ErrNoPosixShell) Unwrap() error {
+	return e.Err
+}

--- a/pipeline/backend/nsjail/flags.go
+++ b/pipeline/backend/nsjail/flags.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+var Flags = []cli.Flag{
+	// temp dir
+	&cli.StringFlag{
+		Name:        "backend-nsjail-temp-dir",
+		Sources:     cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_TEMP_DIR"),
+		Usage:       "set a different temp dir to clone workflows into",
+		DefaultText: "system temporary directory",
+		Value:       os.TempDir(),
+	},
+	&cli.BoolFlag{
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_ISOLATED_HOME"),
+		Name:    "backend-nsjail-isolated-home",
+		Usage:   "set HOME/USERPROFILE to an isolated directory",
+		Value:   true,
+	},
+	// nsjail 二进制路径
+	&cli.StringFlag{
+		Name:    "backend-nsjail-bin",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_BIN"),
+		Usage:   "path to nsjail binary",
+		Value:   "nsjail",
+	},
+	// Seccomp 策略文件
+	&cli.StringFlag{
+		Name:    "backend-nsjail-seccomp",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_SECCOMP"),
+		Usage:   "path to seccomp policy file (Kafel syntax)",
+	},
+	// 内联 seccomp 策略（优先级高于文件）
+	&cli.StringFlag{
+		Name:    "backend-nsjail-seccomp-string",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_SECCOMP_STRING"),
+		Usage:   "inline seccomp policy string",
+	},
+	// 资源限制
+	&cli.IntFlag{
+		Name:    "backend-nsjail-max-cpu",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_MAX_CPU"),
+		Usage:   "CPU time limit in seconds",
+	},
+	&cli.IntFlag{
+		Name:    "backend-nsjail-max-memory",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_MAX_MEMORY"),
+		Usage:   "address space limit in MB",
+	},
+	&cli.IntFlag{
+		Name:    "backend-nsjail-max-nofile",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_MAX_NOFILE"),
+		Usage:   "max open files",
+	},
+	&cli.IntFlag{
+		Name:    "backend-nsjail-max-pids",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_MAX_PIDS"),
+		Usage:   "max number of processes",
+	},
+	// 挂载
+	&cli.BoolFlag{
+		Name:    "backend-nsjail-readonly",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_READONLY"),
+		Usage:   "mount workspace as read-only",
+	},
+	// /proc 挂载（默认不挂载，利用 PID namespace 隔离）
+	&cli.BoolFlag{
+		Name:    "backend-nsjail-proc-mount",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_PROC_MOUNT"),
+		Usage:   "mount /proc from host (default: off — prevents host proc leak)",
+		Value:   false,
+	},
+	// 安全
+	&cli.BoolFlag{
+		Name:    "backend-nsjail-no-new-privs",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_NO_NEW_PRIVS"),
+		Usage:   "disallow granting new privileges",
+	},
+	// Namespace 隔离（默认全部开启）
+	&cli.BoolFlag{
+		Name:    "backend-nsjail-isolate-net",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_ISOLATE_NET"),
+		Usage:   "use new network namespace (default: on)",
+		Value:   true,
+	},
+	&cli.BoolFlag{
+		Name:    "backend-nsjail-isolate-pid",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_ISOLATE_PID"),
+		Usage:   "use new PID namespace (default: on)",
+		Value:   true,
+	},
+	&cli.BoolFlag{
+		Name:    "backend-nsjail-isolate-ipc",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_ISOLATE_IPC"),
+		Usage:   "use new IPC namespace (default: on)",
+		Value:   true,
+	},
+	&cli.BoolFlag{
+		Name:    "backend-nsjail-isolate-uts",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_ISOLATE_UTS"),
+		Usage:   "use new UTS namespace (default: on)",
+		Value:   true,
+	},
+	&cli.BoolFlag{
+		Name:    "backend-nsjail-isolate-user",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_ISOLATE_USER"),
+		Usage:   "use new user namespace (default: on)",
+		Value:   true,
+	},
+	// 用户/组映射
+	&cli.IntFlag{
+		Name:    "backend-nsjail-uid",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_UID"),
+		Usage:   "UID inside jail",
+	},
+	&cli.IntFlag{
+		Name:    "backend-nsjail-gid",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_GID"),
+		Usage:   "GID inside jail",
+	},
+	// 时间限制
+	&cli.IntFlag{
+		Name:    "backend-nsjail-time-limit",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_TIME_LIMIT"),
+		Usage:   "wall-time limit in seconds",
+		Value:   600,
+	},
+	// cgroup 资源控制
+	&cli.IntFlag{
+		Name:    "backend-nsjail-cgroup-pids-max",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_CGROUP_PIDS_MAX"),
+		Usage:   "cgroup pids max",
+	},
+	&cli.IntFlag{
+		Name:    "backend-nsjail-cgroup-cpu-ms",
+		Sources: cli.EnvVars("WOODPECKER_BACKEND_NSJAIL_CGROUP_CPU_MS"),
+		Usage:   "cgroup CPU quota (ms per second)",
+	},
+}

--- a/pipeline/backend/nsjail/nsjail.go
+++ b/pipeline/backend/nsjail/nsjail.go
@@ -1,0 +1,363 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
+)
+
+type workflowState struct {
+	stepState       sync.Map // map of *stepState
+	baseDir         string
+	homeDir         string
+	workspaceDir    string
+	pluginGitBinary string
+}
+
+type stepState struct {
+	cmd    *exec.Cmd
+	output io.ReadCloser
+}
+
+type nsjail struct {
+	cfg             config
+	os              string
+	arch            string
+	workflows       sync.Map
+	pluginGitBinary string
+}
+
+// notAllowedEnvVarOverwrites are all env vars that cannot be overwritten by step config.
+var notAllowedEnvVarOverwrites = []string{
+	"CI_NETRC_MACHINE",
+	"CI_NETRC_USERNAME",
+	"CI_NETRC_PASSWORD",
+	"CI_SCRIPT",
+	"HOME",
+	"SHELL",
+	"CI_WORKSPACE",
+	"USERPROFILE",
+}
+
+const EngineName = "nsjail"
+
+var CLIWorkaroundExecAtDir string // To handle edge case for running nsjail backend via cli exec
+
+// New returns a new nsjail Backend.
+func New() types.Backend {
+	return &nsjail{
+		os:   runtime.GOOS,
+		arch: runtime.GOARCH,
+	}
+}
+
+func (e *nsjail) Name() string {
+	return EngineName
+}
+
+func (e *nsjail) IsAvailable(ctx context.Context) bool {
+	// NsJail requires Linux
+	if runtime.GOOS != "linux" {
+		return false
+	}
+
+	// When explicitly selected, trust the user
+	if c, ok := ctx.Value(types.CliCommand).(*cli.Command); ok {
+		if c.String("backend-engine") == e.Name() {
+			return true
+		}
+	}
+
+	// Auto-detect: check if nsjail binary exists
+	binPath := e.cfg.binPath
+	if binPath == "" {
+		binPath = "nsjail"
+	}
+	if _, err := exec.LookPath(binPath); err != nil {
+		return false
+	}
+	return true
+}
+
+func (e *nsjail) Flags() []cli.Flag {
+	return Flags
+}
+
+func (e *nsjail) Load(ctx context.Context) (*types.BackendInfo, error) {
+	c, ok := ctx.Value(types.CliCommand).(*cli.Command)
+	if ok {
+		e.cfg = configFromCli(c)
+	}
+
+	e.loadClone()
+
+	return &types.BackendInfo{
+		Platform: e.os + "/" + e.arch,
+	}, nil
+}
+
+func (e *nsjail) SetupWorkflow(_ context.Context, _ *types.Config, taskUUID string) error {
+	log.Trace().Str("taskUUID", taskUUID).Msg("create workflow environment")
+
+	baseDir, err := os.MkdirTemp(e.cfg.tempDir, "woodpecker-nsjail-*")
+	if err != nil {
+		return err
+	}
+
+	state := &workflowState{
+		baseDir: baseDir,
+		homeDir: filepath.Join(baseDir, "home"),
+	}
+	e.workflows.Store(taskUUID, state)
+
+	if err := os.Mkdir(state.homeDir, 0o700); err != nil {
+		_ = os.RemoveAll(baseDir)
+		e.workflows.Delete(taskUUID)
+		return err
+	}
+
+	// normal workspace setup case
+	if CLIWorkaroundExecAtDir == "" {
+		state.workspaceDir = filepath.Join(baseDir, "workspace")
+		if err := os.Mkdir(state.workspaceDir, 0o700); err != nil {
+			_ = os.RemoveAll(baseDir)
+			e.workflows.Delete(taskUUID)
+			return err
+		}
+	} else {
+		// setup workspace via internal flag signaled from cli exec to a specific dir
+		state.workspaceDir = CLIWorkaroundExecAtDir
+		if stat, err := os.Stat(CLIWorkaroundExecAtDir); os.IsNotExist(err) {
+			log.Debug().Msgf("create workspace directory '%s' set by internal flag", CLIWorkaroundExecAtDir)
+			if err := os.Mkdir(state.workspaceDir, 0o700); err != nil {
+				_ = os.RemoveAll(baseDir)
+				e.workflows.Delete(taskUUID)
+				return err
+			}
+		} else if !stat.IsDir() {
+			_ = os.RemoveAll(baseDir)
+			e.workflows.Delete(taskUUID)
+			//nolint:forbidigo
+			log.Fatal().Msg("This should never happen! CLIWorkaroundExecAtDir was set to an non directory path!")
+		}
+	}
+
+	e.workflows.Store(taskUUID, state)
+
+	return nil
+}
+
+func (e *nsjail) StartStep(ctx context.Context, step *types.Step, taskUUID string) error {
+	log.Trace().Str("taskUUID", taskUUID).Msgf("start step %s", step.Name)
+
+	state, err := e.getWorkflowState(taskUUID)
+	if err != nil {
+		return err
+	}
+
+	// Get environment variables
+	env := os.Environ()
+	for a, b := range step.Environment {
+		// append allowed env vars to command env
+		if !slices.Contains(notAllowedEnvVarOverwrites, a) {
+			env = append(env, a+"="+b)
+		}
+	}
+
+	if e.cfg.isolatedHome {
+		env = append(env, "HOME="+state.homeDir)
+		env = append(env, "USERPROFILE="+state.homeDir)
+	}
+
+	env = append(env, "CI_WORKSPACE="+state.workspaceDir)
+
+	switch step.Type {
+	case types.StepTypeClone:
+		return e.execClone(ctx, step, state, env)
+	case types.StepTypeCommands:
+		return e.execCommands(ctx, step, state, env)
+	case types.StepTypePlugin:
+		return e.execPlugin(ctx, step, state, env)
+	default:
+		return ErrUnsupportedStepType
+	}
+}
+
+func (e *nsjail) WaitStep(ctx context.Context, step *types.Step, taskUUID string) (*types.State, error) {
+	log.Trace().Str("taskUUID", taskUUID).Msgf("wait for step %s", step.Name)
+
+	stepState := &types.State{
+		Exited: true,
+	}
+
+	if err := ctx.Err(); err != nil {
+		stepState.Error = err
+		return stepState, nil
+	}
+
+	state, err := e.getStepState(taskUUID, step.UUID)
+	if err != nil {
+		return nil, err
+	}
+
+	if state.cmd == nil {
+		return nil, errors.New("nsjail: step command not set up")
+	}
+
+	// normally we use cmd.Wait() to wait for *exec.Cmd, but cmd.StdoutPipe() tells us not
+	// as Wait() would close the io pipe even if not all logs where read and send back
+	// so we have to do use the underlying functions
+	if state.cmd.Process == nil {
+		return nil, errors.New("nsjail: not started")
+	}
+	if state.cmd.ProcessState == nil {
+		cmdState, err := state.cmd.Process.Wait()
+		if err != nil {
+			return nil, err
+		}
+		if cmdState == nil {
+			return nil, errors.New("nsjail: cmd state after Wait() can not be nil but is")
+		}
+		stepState.ExitCode = cmdState.ExitCode()
+		// can be nil if step got canceled
+		if state.cmd != nil {
+			state.cmd.ProcessState = cmdState
+		}
+	} else {
+		stepState.ExitCode = state.cmd.ProcessState.ExitCode()
+	}
+
+	return stepState, err
+}
+
+func (e *nsjail) TailStep(_ context.Context, step *types.Step, taskUUID string) (io.ReadCloser, error) {
+	state, err := e.getStepState(taskUUID, step.UUID)
+	if err != nil {
+		return nil, err
+	} else if state.output == nil {
+		return nil, ErrStepReaderNotFound
+	}
+	return state.output, nil
+}
+
+func (e *nsjail) DestroyStep(_ context.Context, step *types.Step, taskUUID string) error {
+	state, err := e.getStepState(taskUUID, step.UUID)
+	if err != nil {
+		if errors.Is(err, ErrStepStateNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	// As WaitStep can not use cmd.Wait() witch ensures the process already finished and
+	// the io pipe is closed on process end, we make sure it is done.
+	if state.output != nil {
+		_ = state.output.Close()
+		state.output = nil
+	}
+	if state.cmd != nil {
+		_ = state.cmd.Cancel()
+		state.cmd = nil
+	}
+	workflowState, err := e.getWorkflowState(taskUUID)
+	if err != nil {
+		return err
+	}
+
+	workflowState.stepState.Delete(step.UUID)
+	return nil
+}
+
+func (e *nsjail) DestroyWorkflow(_ context.Context, _ *types.Config, taskUUID string) error {
+	log.Trace().Str("taskUUID", taskUUID).Msg("delete workflow environment")
+
+	state, err := e.getWorkflowState(taskUUID)
+	if err != nil {
+		return err
+	}
+
+	// clean up steps not cleaned up because of context cancel or detached function
+	state.stepState.Range(func(_, value any) bool {
+		if state, ok := value.(*stepState); ok && state != nil {
+			if state.output != nil {
+				_ = state.output.Close()
+				state.output = nil
+			}
+			if state.cmd != nil {
+				_ = state.cmd.Cancel()
+				state.cmd = nil
+			}
+		}
+		return true
+	})
+
+	err = os.RemoveAll(state.baseDir)
+	if err != nil {
+		return err
+	}
+
+	// hint for the gc to clean stuff
+	state.stepState.Clear()
+	e.workflows.Delete(taskUUID)
+
+	return err
+}
+
+func (e *nsjail) getWorkflowState(taskUUID string) (*workflowState, error) {
+	state, ok := e.workflows.Load(taskUUID)
+	if !ok {
+		return nil, ErrWorkflowStateNotFound
+	}
+
+	s, ok := state.(*workflowState)
+	if !ok || s == nil {
+		return nil, fmt.Errorf("could not parse state: %v", state)
+	}
+
+	return s, nil
+}
+
+func (e *nsjail) getStepState(taskUUID, stepUUID string) (*stepState, error) {
+	wState, err := e.getWorkflowState(taskUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	state, ok := wState.stepState.Load(stepUUID)
+	if !ok {
+		return nil, ErrStepStateNotFound
+	}
+
+	s, ok := state.(*stepState)
+	if !ok || s == nil {
+		return nil, fmt.Errorf("could not parse state: %v", state)
+	}
+
+	return s, nil
+}

--- a/pipeline/backend/nsjail/nsjail_test.go
+++ b/pipeline/backend/nsjail/nsjail_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
+)
+
+func TestName(t *testing.T) {
+	backend := New()
+	assert.Equal(t, "nsjail", backend.Name())
+}
+
+func TestIsAvailable(t *testing.T) {
+	t.Run("not available on non-linux", func(t *testing.T) {
+		if runtime.GOOS == "linux" {
+			t.Skip("skipping on linux")
+		}
+		backend := New()
+		available := backend.IsAvailable(context.Background())
+		assert.False(t, available)
+	})
+}
+
+func TestLoad(t *testing.T) {
+	backend, _ := New().(*nsjail)
+
+	t.Run("load without cli context", func(t *testing.T) {
+		ctx := context.Background()
+		info, err := backend.Load(ctx)
+
+		require.NoError(t, err)
+		assert.NotNil(t, info)
+		assert.Equal(t, runtime.GOOS+"/"+runtime.GOARCH, info.Platform)
+	})
+
+	t.Run("load with cli context", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cmd := &cli.Command{}
+		cmd.Flags = []cli.Flag{
+			&cli.StringFlag{
+				Name:  "backend-nsjail-temp-dir",
+				Value: tmpDir,
+			},
+			&cli.BoolFlag{
+				Name:  "backend-nsjail-isolated-home",
+				Value: true,
+			},
+		}
+		ctx := context.WithValue(context.Background(), types.CliCommand, cmd)
+
+		info, err := backend.Load(ctx)
+
+		require.NoError(t, err)
+		assert.NotNil(t, info)
+		assert.Equal(t, tmpDir, backend.cfg.tempDir)
+		assert.True(t, backend.cfg.isolatedHome)
+		assert.Equal(t, runtime.GOOS+"/"+runtime.GOARCH, info.Platform)
+	})
+}
+
+func TestSetupWorkflow(t *testing.T) {
+	t.Run("successful setup", func(t *testing.T) {
+		backend, _ := New().(*nsjail)
+		backend.cfg.tempDir = t.TempDir()
+
+		ctx := context.Background()
+		taskUUID := "test-task-uuid-123"
+		config := &types.Config{}
+
+		err := backend.SetupWorkflow(ctx, config, taskUUID)
+		require.NoError(t, err)
+
+		// Verify state was saved
+		state, err := backend.getWorkflowState(taskUUID)
+		require.NoError(t, err)
+		assert.NotNil(t, state)
+		assert.NotEmpty(t, state.baseDir)
+		assert.NotEmpty(t, state.workspaceDir)
+		assert.NotEmpty(t, state.homeDir)
+
+		// Verify directories were created
+		assert.DirExists(t, state.baseDir)
+		assert.DirExists(t, state.workspaceDir)
+		assert.DirExists(t, state.homeDir)
+
+		// Verify directory structure
+		assert.Equal(t, filepath.Join(state.baseDir, "workspace"), state.workspaceDir)
+		assert.Equal(t, filepath.Join(state.baseDir, "home"), state.homeDir)
+
+		// Cleanup
+		assert.NoError(t, os.RemoveAll(state.baseDir))
+	})
+
+	t.Run("MkdirTemp fails", func(t *testing.T) {
+		backend, _ := New().(*nsjail)
+		// Use a regular file path as tempDir so MkdirTemp fails
+		tmpFile := filepath.Join(t.TempDir(), "not-a-dir")
+		require.NoError(t, os.WriteFile(tmpFile, []byte("x"), 0o644))
+		backend.cfg.tempDir = tmpFile
+
+		err := backend.SetupWorkflow(context.Background(), &types.Config{}, "fail-uuid")
+		require.Error(t, err)
+
+		_, err = backend.getWorkflowState("fail-uuid")
+		assert.ErrorIs(t, err, ErrWorkflowStateNotFound)
+	})
+}
+
+func TestDestroyWorkflow(t *testing.T) {
+	backend, _ := New().(*nsjail)
+	backend.cfg.tempDir = t.TempDir()
+
+	ctx := context.Background()
+	taskUUID := "test-destroy-task"
+	config := &types.Config{}
+
+	// Setup workflow first
+	err := backend.SetupWorkflow(ctx, config, taskUUID)
+	require.NoError(t, err)
+
+	state, err := backend.getWorkflowState(taskUUID)
+	require.NoError(t, err)
+	baseDir := state.baseDir
+
+	// Verify directory exists
+	assert.DirExists(t, baseDir)
+
+	// Destroy workflow
+	err = backend.DestroyWorkflow(ctx, config, taskUUID)
+	require.NoError(t, err)
+
+	// Verify directory was removed
+	assert.NoDirExists(t, baseDir)
+
+	// Verify state was deleted
+	_, err = backend.getWorkflowState(taskUUID)
+	assert.ErrorIs(t, err, ErrWorkflowStateNotFound)
+}
+
+func TestStateManagement(t *testing.T) {
+	backend, _ := New().(*nsjail)
+
+	t.Run("save and get state", func(t *testing.T) {
+		taskUUID := "test-state-uuid"
+		state := &workflowState{
+			baseDir:      "/tmp/test",
+			homeDir:      "/tmp/test/home",
+			workspaceDir: "/tmp/test/workspace",
+		}
+
+		backend.workflows.Store(taskUUID, state)
+
+		retrieved, err := backend.getWorkflowState(taskUUID)
+		require.NoError(t, err)
+		assert.Equal(t, state.baseDir, retrieved.baseDir)
+		assert.Equal(t, state.homeDir, retrieved.homeDir)
+		assert.Equal(t, state.workspaceDir, retrieved.workspaceDir)
+	})
+
+	t.Run("get nonexistent state", func(t *testing.T) {
+		_, err := backend.getWorkflowState("nonexistent-uuid")
+		assert.ErrorIs(t, err, ErrWorkflowStateNotFound)
+	})
+
+	t.Run("delete state", func(t *testing.T) {
+		taskUUID := "test-delete-uuid"
+		state := &workflowState{}
+
+		backend.workflows.Store(taskUUID, state)
+
+		// Verify state exists
+		_, err := backend.getWorkflowState(taskUUID)
+		require.NoError(t, err)
+
+		// Delete state
+		backend.workflows.Delete(taskUUID)
+
+		// Verify state is gone
+		_, err = backend.getWorkflowState(taskUUID)
+		assert.ErrorIs(t, err, ErrWorkflowStateNotFound)
+	})
+}

--- a/pipeline/backend/nsjail/plugin.go
+++ b/pipeline/backend/nsjail/plugin.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsjail
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"go.woodpecker-ci.org/woodpecker/v3/pipeline/backend/types"
+)
+
+// execPlugin executes a plugin step inside the nsjail sandbox.
+// step.Image is the plugin binary path, mounted into the sandbox via bindmount.
+func (e *nsjail) execPlugin(ctx context.Context, step *types.Step, state *workflowState, env []string) error {
+	binary, err := exec.LookPath(step.Image)
+	if err != nil {
+		return fmt.Errorf("lookup plugin binary: %w", err)
+	}
+
+	// Mount plugin binary into sandbox and construct nsjail command
+	// Inside sandbox, mount to /bin/plugin-bin
+	pluginInJail := "/bin/plugin-bin"
+	nsjailArgs := e.buildNsJailArgs(step, state, env)
+
+	// Find "--" separator and truncate (keep "--")
+	sepIdx := len(nsjailArgs) - 1
+	for i := len(nsjailArgs) - 1; i >= 0; i-- {
+		if nsjailArgs[i] == "--" {
+			sepIdx = i
+			break
+		}
+	}
+	nsjailArgs = nsjailArgs[:sepIdx+1]
+
+	// Insert bindmount before "--"
+	extraArgs := []string{"--bindmount_ro", binary + ":" + pluginInJail}
+	nsjailArgs = append(nsjailArgs[:sepIdx], append(extraArgs, nsjailArgs[sepIdx:]...)...)
+
+	// Append plugin binary as the command to execute
+	nsjailArgs = append(nsjailArgs, pluginInJail)
+
+	cmd := newNsJailCmd(ctx, e.cfg.binPath, nsjailArgs...)
+	cmd.Env = env
+	cmd.Dir = state.workspaceDir
+
+	reader, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = cmd.Stdout
+
+	state.stepState.Store(step.UUID, &stepState{cmd: cmd, output: reader})
+	return cmd.Start()
+}


### PR DESCRIPTION
## Add nsjail backend for pipeline execution

### Summary

Introduces a new pipeline execution backend based on [nsjail](https://github.com/google/nsjail), a lightweight security sandboxing tool that leverages Linux namespaces, seccomp-bpf, and cgroups to isolate CI pipeline steps. This backend provides strong isolation guarantees without the overhead of full container runtimes, making it an attractive alternative to the Docker or Kubernetes backends.

### Motivation

The existing backends (Docker, Kubernetes, Local) each have trade-offs:
- **Docker/Kubernetes**: strong isolation but heavy, requires daemon/cluster infrastructure
- **Local**: lightweight but no process isolation between steps or from the host

The nsjail backend fills the gap: it runs pipeline steps in a sandboxed environment with configurable isolation and resource limits, while requiring only the nsjail binary (no daemon, no container runtime).

### Changes

| File | Description |
|------|-------------|
| `pipeline/backend/nsjail/nsjail.go` | Backend lifecycle: `Init → Setup → Exec → Destroy` |
| `pipeline/backend/nsjail/config.go` | CLI flag configuration parsing (23 config options) |
| `pipeline/backend/nsjail/command.go` | nsjail command construction and arguments |
| `pipeline/backend/nsjail/flags.go` | CLI flag registration |
| `pipeline/backend/nsjail/clone.go` | Clone step implementation |
| `pipeline/backend/nsjail/plugin.go` | Plugin step execution (Docker-based plugins run inside nsjail) |
| `pipeline/backend/nsjail/const.go` | Constants |
| `pipeline/backend/nsjail/errors.go` | Error types |
| `pipeline/backend/nsjail/*_test.go` | Test coverage for config, command, and execution |
| `cmd/agent/main.go` | Register nsjail backend |
| `cli/exec/exec.go` | Local exec support |

### Configuration

The backend exposes CLI flags for the agent, all prefixed with `--backend-nsjail-`:

| Flag | Default | Description |
|------|---------|-------------|
| `--backend-nsjail-bin` | `nsjail` | Path to nsjail binary |
| `--backend-nsjail-temp-dir` | OS temp dir | Workspace temporary directory |
| `--backend-nsjail-isolated-home` | `false` | Isolate HOME/USERPROFILE per step |
| `--backend-nsjail-seccomp` | `""` | Path to seccomp .bpf policy file |
| `--backend-nsjail-seccomp-string` | `""` | Inline seccomp policy string |
| `--backend-nsjail-max-cpu` | `0` | Max CPU time (seconds) |
| `--backend-nsjail-max-memory` | `0` | Max memory (bytes) |
| `--backend-nsjail-max-fsize` | `0` | Max file size (bytes) |
| `--backend-nsjail-max-nofile` | `0` | Max open file descriptors |
| `--backend-nsjail-max-pids` | `0` | Max number of processes |
| `--backend-nsjail-readonly` | `false` | Mount filesystem as read-only |
| `--backend-nsjail-proc-mount` | `false` | Mount /proc from host |
| `--backend-nsjail-no-new-privs` | `false` | Prevent gaining new privileges |
| `--backend-nsjail-isolate-net` | `false` | Isolate network namespace |
| `--backend-nsjail-isolate-pid` | `false` | Isolate PID namespace |
| `--backend-nsjail-isolate-ipc` | `false` | Isolate IPC namespace |
| `--backend-nsjail-isolate-uts` | `false` | Isolate UTS namespace |
| `--backend-nsjail-isolate-user` | `false` | Isolate user namespace |
| `--backend-nsjail-uid` | `0` | Run as UID inside namespace |
| `--backend-nsjail-gid` | `0` | Run as GID inside namespace |
| `--backend-nsjail-time-limit` | `0` | Step time limit (seconds) |
| `--backend-nsjail-cgroup-pids-max` | `0` | Cgroup pids.max limit |
| `--backend-nsjail-cgroup-cpu-ms` | `0` | Cgroup cpu.max quota (ms) |

### Implementation details

- Register `nsjail.New()` in `cmd/agent/main.go` as a pipeline backend alongside docker, kubernetes, and local
- Backend lifecycle: `Init → Setup → Exec → Destroy`, following the existing `Backend` interface contract
- Each step is executed as an nsjail process with the configured isolation constraints
- Support for:
  - Workspace preparation and cleanup
  - Clone step (checkout pipeline code)
  - Plugin step execution (Docker-based plugins execute inside nsjail)
  - Metadata and environment variable injection
  - Seccomp policies for syscall filtering
  - JSON log output from nsjail process
- Full test coverage for config parsing, command construction, and step execution behaviors

### Usage

```yaml
# .woodpecker.yml
steps:
  build:
    image: alpine:latest
    commands:
      - echo "running in nsjail sandbox"
      - uname -a

backend:
  - nsjail
```