### PR TITLE
Add configurable queue priority rules

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -228,14 +228,6 @@ var flags = append([]cli.Flag{
 			TrimSpace: true,
 		},
 	},
-	&cli.StringSliceFlag{
-		Sources: cli.EnvVars("WOODPECKER_QUEUE_PRIORITY_RULES"),
-		Name:    "queue-priority-rules",
-		Usage:   "Rules that add or subtract queue priority for matching pipelines. Example: priority=100 event=push branch=main",
-		Config: cli.StringConfig{
-			TrimSpace: true,
-		},
-	},
 	&cli.DurationFlag{
 		Sources: cli.EnvVars("WOODPECKER_SESSION_EXPIRES"),
 		Name:    "session-expires",

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -228,6 +228,14 @@ var flags = append([]cli.Flag{
 			TrimSpace: true,
 		},
 	},
+	&cli.StringSliceFlag{
+		Sources: cli.EnvVars("WOODPECKER_QUEUE_PRIORITY_RULES"),
+		Name:    "queue-priority-rules",
+		Usage:   "Rules that add or subtract queue priority for matching pipelines. Example: priority=100 event=push branch=main",
+		Config: cli.StringConfig{
+			TrimSpace: true,
+		},
+	},
 	&cli.DurationFlag{
 		Sources: cli.EnvVars("WOODPECKER_SESSION_EXPIRES"),
 		Name:    "session-expires",

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -5801,6 +5801,10 @@ const docTemplate = `{
                 "pipeline_id": {
                     "type": "integer"
                 },
+                "priority": {
+                    "description": "Priority controls queue ordering. Higher priority tasks run before lower\npriority tasks, with Created and Name preserving FIFO behavior for ties.",
+                    "type": "integer"
+                },
                 "repo_id": {
                     "type": "integer"
                 },
@@ -6311,6 +6315,10 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "pipeline_number": {
+                    "type": "integer"
+                },
+                "priority": {
+                    "description": "Priority controls queue ordering. Higher priority tasks run before lower\npriority tasks, with Created and Name preserving FIFO behavior for ties.",
                     "type": "integer"
                 },
                 "repo_id": {

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -225,12 +225,6 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 		labels[name] = value
 	}
 	server.Config.Pipeline.DefaultWorkflowLabels = labels
-	queuePriorityRules, err := model.ParseQueuePriorityRules(c.StringSlice("queue-priority-rules"))
-	if err != nil {
-		return err
-	}
-	server.Config.Pipeline.QueuePriorityRules = queuePriorityRules
-
 	// backend options for pipeline compiler
 	server.Config.Pipeline.Proxy.No = c.String("backend-no-proxy")
 	server.Config.Pipeline.Proxy.HTTP = c.String("backend-http-proxy")

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -225,6 +225,11 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 		labels[name] = value
 	}
 	server.Config.Pipeline.DefaultWorkflowLabels = labels
+	queuePriorityRules, err := model.ParseQueuePriorityRules(c.StringSlice("queue-priority-rules"))
+	if err != nil {
+		return err
+	}
+	server.Config.Pipeline.QueuePriorityRules = queuePriorityRules
 
 	// backend options for pipeline compiler
 	server.Config.Pipeline.Proxy.No = c.String("backend-no-proxy")

--- a/docs/docs/30-administration/10-configuration/10-server.md
+++ b/docs/docs/30-administration/10-configuration/10-server.md
@@ -805,6 +805,17 @@ You can specify default label/platform conditions that will be used for agent se
 
 Example: `platform=linux/amd64,backend=docker`
 
+### QUEUE_PRIORITY_RULES
+
+- Name: `WOODPECKER_QUEUE_PRIORITY_RULES`
+- Default: none
+
+Rules that add or subtract queue priority for matching pipelines. Higher priority tasks run first; equal priorities keep the normal FIFO order.
+
+Each rule is a whitespace-separated list of `key=value` fields and must include `priority=<number>`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
+
+Example: `priority=100 event=push branch=main,priority=80 event=push branch=stable-*,priority=-20 event=pull_request event_reason=synchroniz*`
+
 ### DEFAULT_PIPELINE_TIMEOUT
 
 - Name: `WOODPECKER_DEFAULT_PIPELINE_TIMEOUT`

--- a/docs/docs/30-administration/10-configuration/10-server.md
+++ b/docs/docs/30-administration/10-configuration/10-server.md
@@ -805,16 +805,21 @@ You can specify default label/platform conditions that will be used for agent se
 
 Example: `platform=linux/amd64,backend=docker`
 
-### QUEUE_PRIORITY_RULES
+### Queue Priority
 
-- Name: `WOODPECKER_QUEUE_PRIORITY_RULES`
-- Default: none
+Woodpecker reads optional queue priority rules from `.woodpecker/queue-priority` on the repository's default branch.
 
-Rules that add or subtract queue priority for matching pipelines. Higher priority tasks run first; equal priorities keep the normal FIFO order.
+Rules add or subtract queue priority for matching pipelines. Higher priority tasks run first; equal priorities keep the normal FIFO order.
 
-Each rule is a whitespace-separated list of `key=value` fields and must include `priority=<number>`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
+Each non-empty, non-comment line is one whitespace-separated list of `key=value` fields and must include `priority=<number>`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
 
-Example: `priority=100 event=push branch=main,priority=80 event=push branch=stable-*,priority=-20 event=pull_request event_reason=synchroniz*`
+Example:
+
+```ini title=".woodpecker/queue-priority"
+priority=100 event=push branch=main
+priority=80 event=push branch=stable-*
+priority=-20 event=pull_request event_reason=synchroniz*
+```
 
 ### DEFAULT_PIPELINE_TIMEOUT
 

--- a/docs/docs/30-administration/10-configuration/10-server.md
+++ b/docs/docs/30-administration/10-configuration/10-server.md
@@ -807,18 +807,25 @@ Example: `platform=linux/amd64,backend=docker`
 
 ### Queue Priority
 
-Woodpecker reads optional queue priority rules from `.woodpecker/queue-priority` on the repository's default branch.
+Woodpecker reads optional queue priority rules from `.woodpecker/queue-priority.yml` on the repository's default branch.
 
 Rules add or subtract queue priority for matching pipelines. Higher priority tasks run first; equal priorities keep the normal FIFO order.
 
-Each non-empty, non-comment line is one whitespace-separated list of `key=value` fields and must include `priority=<number>`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
+Each rule must include `priority`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
 
 Example:
 
-```ini title=".woodpecker/queue-priority"
-priority=100 event=push branch=main
-priority=80 event=push branch=stable-*
-priority=-20 event=pull_request event_reason=synchroniz*
+```yaml title=".woodpecker/queue-priority.yml"
+rules:
+  - priority: 100
+    event: push
+    branch: main
+  - priority: 80
+    event: push
+    branch: stable-*
+  - priority: -20
+    event: pull_request
+    event_reason: synchroniz*
 ```
 
 ### DEFAULT_PIPELINE_TIMEOUT

--- a/docs/versioned_docs/version-3.17/30-administration/10-configuration/10-server.md
+++ b/docs/versioned_docs/version-3.17/30-administration/10-configuration/10-server.md
@@ -805,6 +805,17 @@ You can specify default label/platform conditions that will be used for agent se
 
 Example: `platform=linux/amd64,backend=docker`
 
+### QUEUE_PRIORITY_RULES
+
+- Name: `WOODPECKER_QUEUE_PRIORITY_RULES`
+- Default: none
+
+Rules that add or subtract queue priority for matching pipelines. Higher priority tasks run first; equal priorities keep the normal FIFO order.
+
+Each rule is a whitespace-separated list of `key=value` fields and must include `priority=<number>`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
+
+Example: `priority=100 event=push branch=main,priority=80 event=push branch=stable-*,priority=-20 event=pull_request event_reason=synchroniz*`
+
 ### DEFAULT_PIPELINE_TIMEOUT
 
 - Name: `WOODPECKER_DEFAULT_PIPELINE_TIMEOUT`

--- a/docs/versioned_docs/version-3.17/30-administration/10-configuration/10-server.md
+++ b/docs/versioned_docs/version-3.17/30-administration/10-configuration/10-server.md
@@ -805,16 +805,21 @@ You can specify default label/platform conditions that will be used for agent se
 
 Example: `platform=linux/amd64,backend=docker`
 
-### QUEUE_PRIORITY_RULES
+### Queue Priority
 
-- Name: `WOODPECKER_QUEUE_PRIORITY_RULES`
-- Default: none
+Woodpecker reads optional queue priority rules from `.woodpecker/queue-priority` on the repository's default branch.
 
-Rules that add or subtract queue priority for matching pipelines. Higher priority tasks run first; equal priorities keep the normal FIFO order.
+Rules add or subtract queue priority for matching pipelines. Higher priority tasks run first; equal priorities keep the normal FIFO order.
 
-Each rule is a whitespace-separated list of `key=value` fields and must include `priority=<number>`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
+Each non-empty, non-comment line is one whitespace-separated list of `key=value` fields and must include `priority=<number>`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
 
-Example: `priority=100 event=push branch=main,priority=80 event=push branch=stable-*,priority=-20 event=pull_request event_reason=synchroniz*`
+Example:
+
+```ini title=".woodpecker/queue-priority"
+priority=100 event=push branch=main
+priority=80 event=push branch=stable-*
+priority=-20 event=pull_request event_reason=synchroniz*
+```
 
 ### DEFAULT_PIPELINE_TIMEOUT
 

--- a/docs/versioned_docs/version-3.17/30-administration/10-configuration/10-server.md
+++ b/docs/versioned_docs/version-3.17/30-administration/10-configuration/10-server.md
@@ -807,18 +807,25 @@ Example: `platform=linux/amd64,backend=docker`
 
 ### Queue Priority
 
-Woodpecker reads optional queue priority rules from `.woodpecker/queue-priority` on the repository's default branch.
+Woodpecker reads optional queue priority rules from `.woodpecker/queue-priority.yml` on the repository's default branch.
 
 Rules add or subtract queue priority for matching pipelines. Higher priority tasks run first; equal priorities keep the normal FIFO order.
 
-Each non-empty, non-comment line is one whitespace-separated list of `key=value` fields and must include `priority=<number>`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
+Each rule must include `priority`. Supported match fields are `repo`, `event`, `branch`, `ref`, `author`, `sender`, `pr_label`, `event_reason`, and `min_rerun_count`. String fields support glob patterns.
 
 Example:
 
-```ini title=".woodpecker/queue-priority"
-priority=100 event=push branch=main
-priority=80 event=push branch=stable-*
-priority=-20 event=pull_request event_reason=synchroniz*
+```yaml title=".woodpecker/queue-priority.yml"
+rules:
+  - priority: 100
+    event: push
+    branch: main
+  - priority: 80
+    event: push
+    branch: stable-*
+  - priority: -20
+    event: pull_request
+    event_reason: synchroniz*
 ```
 
 ### DEFAULT_PIPELINE_TIMEOUT

--- a/server/api/queue_test.go
+++ b/server/api/queue_test.go
@@ -74,6 +74,7 @@ func TestGetQueueInfo(t *testing.T) {
 		waiting := &model.Task{
 			ID: "76054", Name: "build", PipelineID: pipe.ID, RepoID: repo.ID,
 			Dependencies: []string{"76057"},
+			Priority:     10,
 		}
 		running := &model.Task{
 			ID: "76057", Name: "check_preconditions", PipelineID: pipe.ID, RepoID: repo.ID,
@@ -106,6 +107,7 @@ func TestGetQueueInfo(t *testing.T) {
 
 		require.Len(t, got.WaitingOnDeps, 1)
 		assert.Equal(t, "76054", got.WaitingOnDeps[0].ID)
+		assert.Equal(t, 10, got.WaitingOnDeps[0].Priority)
 		assert.Empty(t, got.WaitingOnDeps[0].AgentName) // no agent assigned
 		assert.Equal(t, pipe.Number, got.WaitingOnDeps[0].PipelineNumber)
 

--- a/server/config.go
+++ b/server/config.go
@@ -71,6 +71,7 @@ var Config = struct {
 		DefaultCancelPreviousPipelineEvents []model.WebhookEvent
 		DefaultApprovalMode                 model.ApprovalMode
 		DefaultWorkflowLabels               map[string]string
+		QueuePriorityRules                  []model.QueuePriorityRule
 		DefaultClonePlugin                  string
 		TrustedClonePlugins                 []string
 		Volumes                             []string

--- a/server/config.go
+++ b/server/config.go
@@ -71,7 +71,6 @@ var Config = struct {
 		DefaultCancelPreviousPipelineEvents []model.WebhookEvent
 		DefaultApprovalMode                 model.ApprovalMode
 		DefaultWorkflowLabels               map[string]string
-		QueuePriorityRules                  []model.QueuePriorityRule
 		DefaultClonePlugin                  string
 		TrustedClonePlugins                 []string
 		Volumes                             []string

--- a/server/forge/forgejo/helper.go
+++ b/server/forge/forgejo/helper.go
@@ -187,7 +187,7 @@ func pipelineFromPullRequest(hook *pullRequestHook) *model.Pipeline {
 		FromFork:             hook.PullRequest.Head.RepoID != hook.PullRequest.Base.RepoID,
 	}
 
-	if pipeline.Event == model.EventPullMetadata {
+	if pipeline.Event == model.EventPullMetadata || hook.Action == actionSync {
 		pipeline.EventReason = []string{hook.Action}
 	}
 

--- a/server/forge/forgejo/parse_test.go
+++ b/server/forge/forgejo/parse_test.go
@@ -275,8 +275,11 @@ func TestForgejoParser(t *testing.T) {
 				},
 			},
 			pipe: &model.Pipeline{
-				Author:   "test",
-				Event:    "pull_request",
+				Author: "test",
+				Event:  "pull_request",
+				EventReason: []string{
+					"synchronized",
+				},
 				Commit:   "788ed8d02d3b7fcfcf6386dbcbca696aa1d4dc25",
 				Branch:   "main",
 				Ref:      "refs/pull/2/head",

--- a/server/forge/gitea/helper.go
+++ b/server/forge/gitea/helper.go
@@ -189,7 +189,7 @@ func pipelineFromPullRequest(hook *pullRequestHook) *model.Pipeline {
 		FromFork:             hook.PullRequest.Head.RepoID != hook.PullRequest.Base.RepoID,
 	}
 
-	if pipeline.Event == model.EventPullMetadata {
+	if pipeline.Event == model.EventPullMetadata || hook.Action == actionSync {
 		pipeline.EventReason = []string{hook.Action}
 	}
 

--- a/server/forge/gitea/parse_test.go
+++ b/server/forge/gitea/parse_test.go
@@ -295,8 +295,11 @@ func TestGiteaParser(t *testing.T) {
 				},
 			},
 			pipe: &model.Pipeline{
-				Author:   "test",
-				Event:    "pull_request",
+				Author: "test",
+				Event:  "pull_request",
+				EventReason: []string{
+					"synchronized",
+				},
 				Commit:   "788ed8d02d3b7fcfcf6386dbcbca696aa1d4dc25",
 				Branch:   "main",
 				Ref:      "refs/pull/2/head",

--- a/server/forge/github/parse.go
+++ b/server/forge/github/parse.go
@@ -179,8 +179,10 @@ func parsePullHook(hook *github.PullRequestEvent, merge bool) (*github.PullReque
 	eventAction := ""
 
 	switch hook.GetAction() {
-	case actionOpen, actionReopen, actionSync:
+	case actionOpen, actionReopen:
 		// default case nothing to do
+	case actionSync:
+		eventAction = common.NormalizeEventReason(hook.GetAction())
 	case actionClose:
 		event = model.EventPullClosed
 	case actionAssigned,

--- a/server/model/queue_priority.go
+++ b/server/model/queue_priority.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// QueuePriorityRule adds or subtracts priority from a pipeline's queued tasks
+// when all configured match fields match. Higher resulting task priority runs
+// earlier in the queue.
+type QueuePriorityRule struct {
+	Priority      int
+	Repo          string
+	Event         WebhookEvent
+	Branch        string
+	Ref           string
+	Author        string
+	Sender        string
+	PullLabel     string
+	EventReason   string
+	MinRerunCount int64
+}
+
+// ParseQueuePriorityRules parses a list of whitespace-separated key=value rule
+// strings. Every rule must include priority=<int>.
+func ParseQueuePriorityRules(values []string) ([]QueuePriorityRule, error) {
+	rules := make([]QueuePriorityRule, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+
+		rule, err := parseQueuePriorityRule(value)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+func parseQueuePriorityRule(value string) (QueuePriorityRule, error) {
+	var rule QueuePriorityRule
+	hasPriority := false
+
+	for _, field := range strings.Fields(value) {
+		key, raw, ok := strings.Cut(field, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			return rule, fmt.Errorf("invalid queue priority rule field %q in %q", field, value)
+		}
+		if raw == "" {
+			return rule, fmt.Errorf("empty queue priority rule value for %q in %q", key, value)
+		}
+
+		switch strings.ReplaceAll(strings.ToLower(key), "-", "_") {
+		case "priority":
+			priority, err := strconv.Atoi(raw)
+			if err != nil {
+				return rule, fmt.Errorf("invalid queue priority %q in %q: %w", raw, value, err)
+			}
+			rule.Priority = priority
+			hasPriority = true
+		case "repo":
+			if err := validateQueuePriorityGlob(key, raw); err != nil {
+				return rule, err
+			}
+			rule.Repo = raw
+		case "event":
+			event := WebhookEvent(raw)
+			if err := event.Validate(); err != nil {
+				return rule, err
+			}
+			rule.Event = event
+		case "branch":
+			if err := validateQueuePriorityGlob(key, raw); err != nil {
+				return rule, err
+			}
+			rule.Branch = raw
+		case "ref":
+			if err := validateQueuePriorityGlob(key, raw); err != nil {
+				return rule, err
+			}
+			rule.Ref = raw
+		case "author":
+			if err := validateQueuePriorityGlob(key, raw); err != nil {
+				return rule, err
+			}
+			rule.Author = raw
+		case "sender":
+			if err := validateQueuePriorityGlob(key, raw); err != nil {
+				return rule, err
+			}
+			rule.Sender = raw
+		case "pr_label", "pull_label", "pull_request_label":
+			if err := validateQueuePriorityGlob(key, raw); err != nil {
+				return rule, err
+			}
+			rule.PullLabel = raw
+		case "event_reason":
+			if err := validateQueuePriorityGlob(key, raw); err != nil {
+				return rule, err
+			}
+			rule.EventReason = raw
+		case "min_rerun_count":
+			min, err := strconv.ParseInt(raw, 10, 64)
+			if err != nil {
+				return rule, fmt.Errorf("invalid queue priority min_rerun_count %q in %q: %w", raw, value, err)
+			}
+			if min < 0 {
+				return rule, fmt.Errorf("invalid queue priority min_rerun_count %q in %q: must be greater than or equal to zero", raw, value)
+			}
+			rule.MinRerunCount = min
+		default:
+			return rule, fmt.Errorf("unknown queue priority rule field %q in %q", key, value)
+		}
+	}
+
+	if !hasPriority {
+		return rule, fmt.Errorf("queue priority rule %q is missing priority", value)
+	}
+	return rule, nil
+}
+
+func validateQueuePriorityGlob(key, pattern string) error {
+	if _, err := doublestar.Match(pattern, ""); err != nil {
+		return fmt.Errorf("invalid queue priority glob for %q: %w", key, err)
+	}
+	return nil
+}
+
+// QueuePriority returns the sum of all matching priority rules.
+func QueuePriority(repo *Repo, pipeline *Pipeline, rules []QueuePriorityRule) int {
+	priority := 0
+	for _, rule := range rules {
+		if rule.Match(repo, pipeline) {
+			priority += rule.Priority
+		}
+	}
+	return priority
+}
+
+// Match reports whether the rule matches the pipeline metadata.
+func (r QueuePriorityRule) Match(repo *Repo, pipeline *Pipeline) bool {
+	if repo == nil || pipeline == nil {
+		return false
+	}
+	if r.Repo != "" && !globMatch(r.Repo, repo.FullName) {
+		return false
+	}
+	if r.Event != "" && r.Event != pipeline.Event {
+		return false
+	}
+	if r.Branch != "" && !globMatch(r.Branch, pipeline.Branch) {
+		return false
+	}
+	if r.Ref != "" && !globMatch(r.Ref, pipeline.Ref) {
+		return false
+	}
+	if r.Author != "" && !globMatch(r.Author, pipeline.Author) {
+		return false
+	}
+	if r.Sender != "" && !globMatch(r.Sender, pipeline.Sender) {
+		return false
+	}
+	if r.PullLabel != "" && !matchAny(r.PullLabel, pipeline.PullRequestLabels) {
+		return false
+	}
+	if r.EventReason != "" && !matchAny(r.EventReason, pipeline.EventReason) {
+		return false
+	}
+	if r.MinRerunCount > 0 && pipeline.RerunCount < r.MinRerunCount {
+		return false
+	}
+	return true
+}
+
+func matchAny(pattern string, values []string) bool {
+	for _, value := range values {
+		if globMatch(pattern, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func globMatch(pattern, value string) bool {
+	matched, err := doublestar.Match(pattern, value)
+	return err == nil && matched
+}

--- a/server/model/queue_priority.go
+++ b/server/model/queue_priority.go
@@ -15,148 +15,107 @@
 package model
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"go.yaml.in/yaml/v4"
 )
 
 // QueuePriorityRule adds or subtracts priority from a pipeline's queued tasks
 // when all configured match fields match. Higher resulting task priority runs
 // earlier in the queue.
 type QueuePriorityRule struct {
-	Priority      int
-	Repo          string
-	Event         WebhookEvent
-	Branch        string
-	Ref           string
-	Author        string
-	Sender        string
-	PullLabel     string
-	EventReason   string
-	MinRerunCount int64
+	Priority      int          `yaml:"priority"`
+	Repo          string       `yaml:"repo"`
+	Event         WebhookEvent `yaml:"event"`
+	Branch        string       `yaml:"branch"`
+	Ref           string       `yaml:"ref"`
+	Author        string       `yaml:"author"`
+	Sender        string       `yaml:"sender"`
+	PullLabel     string       `yaml:"pr_label"`
+	EventReason   string       `yaml:"event_reason"`
+	MinRerunCount int64        `yaml:"min_rerun_count"`
 }
 
-// ParseQueuePriorityRules parses a list of whitespace-separated key=value rule
-// strings. Every rule must include priority=<int>.
-func ParseQueuePriorityRules(values []string) ([]QueuePriorityRule, error) {
-	rules := make([]QueuePriorityRule, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
+type queuePriorityRuleFile struct {
+	Rules []queuePriorityRuleConfig `yaml:"rules"`
+}
 
-		rule, err := parseQueuePriorityRule(value)
+type queuePriorityRuleConfig struct {
+	Priority      *int         `yaml:"priority"`
+	Repo          string       `yaml:"repo"`
+	Event         WebhookEvent `yaml:"event"`
+	Branch        string       `yaml:"branch"`
+	Ref           string       `yaml:"ref"`
+	Author        string       `yaml:"author"`
+	Sender        string       `yaml:"sender"`
+	PullLabel     string       `yaml:"pr_label"`
+	EventReason   string       `yaml:"event_reason"`
+	MinRerunCount int64        `yaml:"min_rerun_count"`
+}
+
+// ParseQueuePriorityRuleFile parses a YAML queue priority config.
+func ParseQueuePriorityRuleFile(data []byte) ([]QueuePriorityRule, error) {
+	var file queuePriorityRuleFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, err
+	}
+	rules := make([]QueuePriorityRule, 0, len(file.Rules))
+	for i := range file.Rules {
+		rule, err := file.Rules[i].asRule()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid rule %d: %w", i+1, err)
 		}
 		rules = append(rules, rule)
 	}
 	return rules, nil
 }
 
-// ParseQueuePriorityRuleFile parses one queue priority rule per non-empty,
-// non-comment line.
-func ParseQueuePriorityRuleFile(data []byte) ([]QueuePriorityRule, error) {
-	var values []string
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		values = append(values, line)
+func (r queuePriorityRuleConfig) asRule() (QueuePriorityRule, error) {
+	if r.Priority == nil {
+		return QueuePriorityRule{}, fmt.Errorf("missing priority")
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
+	rule := QueuePriorityRule{
+		Priority:      *r.Priority,
+		Repo:          r.Repo,
+		Event:         r.Event,
+		Branch:        r.Branch,
+		Ref:           r.Ref,
+		Author:        r.Author,
+		Sender:        r.Sender,
+		PullLabel:     r.PullLabel,
+		EventReason:   r.EventReason,
+		MinRerunCount: r.MinRerunCount,
 	}
-	return ParseQueuePriorityRules(values)
+	return rule, rule.Validate()
 }
 
-func parseQueuePriorityRule(value string) (QueuePriorityRule, error) {
-	var rule QueuePriorityRule
-	hasPriority := false
-
-	for _, field := range strings.Fields(value) {
-		key, raw, ok := strings.Cut(field, "=")
-		if !ok || strings.TrimSpace(key) == "" {
-			return rule, fmt.Errorf("invalid queue priority rule field %q in %q", field, value)
-		}
-		if raw == "" {
-			return rule, fmt.Errorf("empty queue priority rule value for %q in %q", key, value)
-		}
-
-		switch strings.ReplaceAll(strings.ToLower(key), "-", "_") {
-		case "priority":
-			priority, err := strconv.Atoi(raw)
-			if err != nil {
-				return rule, fmt.Errorf("invalid queue priority %q in %q: %w", raw, value, err)
-			}
-			rule.Priority = priority
-			hasPriority = true
-		case "repo":
-			if err := validateQueuePriorityGlob(key, raw); err != nil {
-				return rule, err
-			}
-			rule.Repo = raw
-		case "event":
-			event := WebhookEvent(raw)
-			if err := event.Validate(); err != nil {
-				return rule, err
-			}
-			rule.Event = event
-		case "branch":
-			if err := validateQueuePriorityGlob(key, raw); err != nil {
-				return rule, err
-			}
-			rule.Branch = raw
-		case "ref":
-			if err := validateQueuePriorityGlob(key, raw); err != nil {
-				return rule, err
-			}
-			rule.Ref = raw
-		case "author":
-			if err := validateQueuePriorityGlob(key, raw); err != nil {
-				return rule, err
-			}
-			rule.Author = raw
-		case "sender":
-			if err := validateQueuePriorityGlob(key, raw); err != nil {
-				return rule, err
-			}
-			rule.Sender = raw
-		case "pr_label", "pull_label", "pull_request_label":
-			if err := validateQueuePriorityGlob(key, raw); err != nil {
-				return rule, err
-			}
-			rule.PullLabel = raw
-		case "event_reason":
-			if err := validateQueuePriorityGlob(key, raw); err != nil {
-				return rule, err
-			}
-			rule.EventReason = raw
-		case "min_rerun_count":
-			min, err := strconv.ParseInt(raw, 10, 64)
-			if err != nil {
-				return rule, fmt.Errorf("invalid queue priority min_rerun_count %q in %q: %w", raw, value, err)
-			}
-			if min < 0 {
-				return rule, fmt.Errorf("invalid queue priority min_rerun_count %q in %q: must be greater than or equal to zero", raw, value)
-			}
-			rule.MinRerunCount = min
-		default:
-			return rule, fmt.Errorf("unknown queue priority rule field %q in %q", key, value)
+// Validate checks a queue priority rule loaded from config.
+func (r QueuePriorityRule) Validate() error {
+	if r.Event != "" {
+		if err := r.Event.Validate(); err != nil {
+			return err
 		}
 	}
-
-	if !hasPriority {
-		return rule, fmt.Errorf("queue priority rule %q is missing priority", value)
+	for key, pattern := range map[string]string{
+		"repo":         r.Repo,
+		"branch":       r.Branch,
+		"ref":          r.Ref,
+		"author":       r.Author,
+		"sender":       r.Sender,
+		"pr_label":     r.PullLabel,
+		"event_reason": r.EventReason,
+	} {
+		if pattern != "" {
+			if err := validateQueuePriorityGlob(key, pattern); err != nil {
+				return err
+			}
+		}
 	}
-	return rule, nil
+	if r.MinRerunCount < 0 {
+		return fmt.Errorf("min_rerun_count must be greater than or equal to zero")
+	}
+	return nil
 }
 
 func validateQueuePriorityGlob(key, pattern string) error {

--- a/server/model/queue_priority.go
+++ b/server/model/queue_priority.go
@@ -15,6 +15,8 @@
 package model
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
@@ -55,6 +57,24 @@ func ParseQueuePriorityRules(values []string) ([]QueuePriorityRule, error) {
 		rules = append(rules, rule)
 	}
 	return rules, nil
+}
+
+// ParseQueuePriorityRuleFile parses one queue priority rule per non-empty,
+// non-comment line.
+func ParseQueuePriorityRuleFile(data []byte) ([]QueuePriorityRule, error) {
+	var values []string
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		values = append(values, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return ParseQueuePriorityRules(values)
 }
 
 func parseQueuePriorityRule(value string) (QueuePriorityRule, error) {

--- a/server/model/queue_priority_test.go
+++ b/server/model/queue_priority_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQueuePriorityRules(t *testing.T) {
+	rules, err := ParseQueuePriorityRules([]string{
+		"priority=100 repo=postgis/postgis event=push branch=stable-*",
+		"priority=-20 event=pull_request event_reason=synchronized sender=renovate*",
+	})
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+
+	assert.Equal(t, 100, rules[0].Priority)
+	assert.Equal(t, "postgis/postgis", rules[0].Repo)
+	assert.Equal(t, EventPush, rules[0].Event)
+	assert.Equal(t, "stable-*", rules[0].Branch)
+
+	assert.Equal(t, -20, rules[1].Priority)
+	assert.Equal(t, EventPull, rules[1].Event)
+	assert.Equal(t, "synchronized", rules[1].EventReason)
+	assert.Equal(t, "renovate*", rules[1].Sender)
+}
+
+func TestParseQueuePriorityRulesRejectsInvalidRule(t *testing.T) {
+	tests := []string{
+		"event=push",
+		"priority=bad event=push",
+		"priority=10 nope=value",
+		"priority=10 event=bogus",
+		"priority=10 min_rerun_count=nope",
+		"priority=10 min_rerun_count=-1",
+		"priority=10 branch=[",
+	}
+
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			_, err := ParseQueuePriorityRules([]string{value})
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestQueuePriority(t *testing.T) {
+	repo := &Repo{FullName: "postgis/postgis"}
+	pipeline := &Pipeline{
+		Event:             EventPull,
+		Branch:            "stable-3.6",
+		Ref:               "refs/pull/42/head",
+		Author:            "contributor",
+		Sender:            "renovate-postgis",
+		PullRequestLabels: []string{"needs-ci"},
+		EventReason:       []string{"synchronized"},
+		RerunCount:        2,
+	}
+	rules, err := ParseQueuePriorityRules([]string{
+		"priority=80 repo=postgis/postgis branch=stable-*",
+		"priority=30 event=pull_request pr_label=needs-*",
+		"priority=-25 sender=renovate*",
+		"priority=-10 event_reason=synchronized",
+		"priority=5 min_rerun_count=2",
+		"priority=900 repo=other/project",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 80, QueuePriority(repo, pipeline, rules))
+}

--- a/server/model/queue_priority_test.go
+++ b/server/model/queue_priority_test.go
@@ -40,6 +40,21 @@ func TestParseQueuePriorityRules(t *testing.T) {
 	assert.Equal(t, "renovate*", rules[1].Sender)
 }
 
+func TestParseQueuePriorityRuleFile(t *testing.T) {
+	rules, err := ParseQueuePriorityRuleFile([]byte(`
+# default branches first
+priority=100 event=push branch=master
+priority=-20 event=pull_request event_reason=synchroniz*
+`))
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+
+	assert.Equal(t, 100, rules[0].Priority)
+	assert.Equal(t, "master", rules[0].Branch)
+	assert.Equal(t, -20, rules[1].Priority)
+	assert.Equal(t, "synchroniz*", rules[1].EventReason)
+}
+
 func TestParseQueuePriorityRulesRejectsInvalidRule(t *testing.T) {
 	tests := []string{
 		"event=push",

--- a/server/model/queue_priority_test.go
+++ b/server/model/queue_priority_test.go
@@ -21,30 +21,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseQueuePriorityRules(t *testing.T) {
-	rules, err := ParseQueuePriorityRules([]string{
-		"priority=100 repo=postgis/postgis event=push branch=stable-*",
-		"priority=-20 event=pull_request event_reason=synchronized sender=renovate*",
-	})
-	require.NoError(t, err)
-	require.Len(t, rules, 2)
-
-	assert.Equal(t, 100, rules[0].Priority)
-	assert.Equal(t, "postgis/postgis", rules[0].Repo)
-	assert.Equal(t, EventPush, rules[0].Event)
-	assert.Equal(t, "stable-*", rules[0].Branch)
-
-	assert.Equal(t, -20, rules[1].Priority)
-	assert.Equal(t, EventPull, rules[1].Event)
-	assert.Equal(t, "synchronized", rules[1].EventReason)
-	assert.Equal(t, "renovate*", rules[1].Sender)
-}
-
 func TestParseQueuePriorityRuleFile(t *testing.T) {
 	rules, err := ParseQueuePriorityRuleFile([]byte(`
 # default branches first
-priority=100 event=push branch=master
-priority=-20 event=pull_request event_reason=synchroniz*
+rules:
+  - priority: 100
+    event: push
+    branch: master
+  - priority: -20
+    event: pull_request
+    event_reason: synchroniz*
 `))
 	require.NoError(t, err)
 	require.Len(t, rules, 2)
@@ -55,20 +41,17 @@ priority=-20 event=pull_request event_reason=synchroniz*
 	assert.Equal(t, "synchroniz*", rules[1].EventReason)
 }
 
-func TestParseQueuePriorityRulesRejectsInvalidRule(t *testing.T) {
+func TestParseQueuePriorityRuleFileRejectsInvalidRule(t *testing.T) {
 	tests := []string{
-		"event=push",
-		"priority=bad event=push",
-		"priority=10 nope=value",
-		"priority=10 event=bogus",
-		"priority=10 min_rerun_count=nope",
-		"priority=10 min_rerun_count=-1",
-		"priority=10 branch=[",
+		"rules:\n  - event: push\n",
+		"rules:\n  - event: bogus\n    priority: 10\n",
+		"rules:\n  - priority: 10\n    min_rerun_count: -1\n",
+		"rules:\n  - priority: 10\n    branch: '['\n",
 	}
 
 	for _, value := range tests {
 		t.Run(value, func(t *testing.T) {
-			_, err := ParseQueuePriorityRules([]string{value})
+			_, err := ParseQueuePriorityRuleFile([]byte(value))
 			assert.Error(t, err)
 		})
 	}
@@ -86,15 +69,14 @@ func TestQueuePriority(t *testing.T) {
 		EventReason:       []string{"synchronized"},
 		RerunCount:        2,
 	}
-	rules, err := ParseQueuePriorityRules([]string{
-		"priority=80 repo=postgis/postgis branch=stable-*",
-		"priority=30 event=pull_request pr_label=needs-*",
-		"priority=-25 sender=renovate*",
-		"priority=-10 event_reason=synchronized",
-		"priority=5 min_rerun_count=2",
-		"priority=900 repo=other/project",
-	})
-	require.NoError(t, err)
+	rules := []QueuePriorityRule{
+		{Priority: 80, Repo: "postgis/postgis", Branch: "stable-*"},
+		{Priority: 30, Event: EventPull, PullLabel: "needs-*"},
+		{Priority: -25, Sender: "renovate*"},
+		{Priority: -10, EventReason: "synchronized"},
+		{Priority: 5, MinRerunCount: 2},
+		{Priority: 900, Repo: "other/project"},
+	}
 
 	assert.Equal(t, 80, QueuePriority(repo, pipeline, rules))
 }

--- a/server/model/task.go
+++ b/server/model/task.go
@@ -43,6 +43,9 @@ type Task struct {
 	// Created is the unix timestamp the task's pipeline was created at. It
 	// defines the queue ordering across pipelines.
 	Created int64 `json:"created" xorm:"NOT NULL DEFAULT 0 'created'"`
+	// Priority controls queue ordering. Higher priority tasks run before lower
+	// priority tasks, with Created and Name preserving FIFO behavior for ties.
+	Priority int `json:"priority" xorm:"NOT NULL DEFAULT 0 'priority'"`
 } //	@name	Task
 
 // TableName return database table name for xorm.

--- a/server/pipeline/approve.go
+++ b/server/pipeline/approve.go
@@ -57,6 +57,11 @@ func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipe
 	// must already be pending when the new workflows are persisted.
 	currentPipeline.Status = model.StatusPending
 
+	priorityRules, err := loadQueuePriorityRules(ctx, forge, user, repo, currentPipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	currentPipeline, pipelineItems, parseErr, err := createPipelineItems(ctx, forge, store, currentPipeline, user, repo, yamls, nil, true)
 	if handleParseErrors(currentPipeline, parseErr) {
 		if err := updatePipelineWithErr(ctx, forge, store, currentPipeline, repo, user, parseErr); err != nil {
@@ -77,7 +82,7 @@ func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipe
 
 	publishPipeline(ctx, forge, currentPipeline, repo, user)
 
-	currentPipeline, err = start(ctx, forge, store, currentPipeline, user, repo, pipelineItems)
+	currentPipeline, err = start(ctx, forge, store, currentPipeline, user, repo, pipelineItems, priorityRules)
 	if err != nil {
 		msg := fmt.Sprintf("failure to start pipeline for %s: %v", repo.FullName, err)
 		log.Error().Err(err).Msg(msg)

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -115,6 +115,11 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 	if err != nil {
 		return pipeline, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, err)
 	}
+	if len(priorityRules) > 0 && server.Config.Services.Scheduler != nil {
+		if err := server.Config.Services.Scheduler.ReprioritizeRepo(ctx, repo, priorityRules); err != nil {
+			log.Error().Err(err).Str("repo", repo.FullName).Msg("failed to reprioritize queued tasks")
+		}
+	}
 
 	currentPipeline, pipelineItems, parseErr, err := createPipelineItems(ctx, _forge, _store, pipeline, repoUser, repo, forgeYamlConfigs, nil, false)
 	*pipeline = *currentPipeline

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -111,6 +111,11 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		return nil, errors.New(msg)
 	}
 
+	priorityRules, err := loadQueuePriorityRules(ctx, _forge, repoUser, repo, pipeline)
+	if err != nil {
+		return pipeline, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, err)
+	}
+
 	currentPipeline, pipelineItems, parseErr, err := createPipelineItems(ctx, _forge, _store, pipeline, repoUser, repo, forgeYamlConfigs, nil, false)
 	*pipeline = *currentPipeline
 	if handleParseErrors(pipeline, parseErr) {
@@ -140,7 +145,7 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		return nil, err
 	}
 
-	pipeline, err = start(ctx, _forge, _store, pipeline, repoUser, repo, pipelineItems)
+	pipeline, err = start(ctx, _forge, _store, pipeline, repoUser, repo, pipelineItems, priorityRules)
 	if err != nil {
 		msg := fmt.Sprintf("failed to start pipeline for %s", repo.FullName)
 		log.Error().Err(err).Msg(msg)

--- a/server/pipeline/queue.go
+++ b/server/pipeline/queue.go
@@ -22,6 +22,7 @@ import (
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/builder"
 	"go.woodpecker-ci.org/woodpecker/v3/rpc"
+	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 )
 
@@ -38,6 +39,7 @@ func pipelineTasks(repo *model.Repo, activePipeline *model.Pipeline, pipelineIte
 			PipelineID: activePipeline.ID,
 			RepoID:     repo.ID,
 			Created:    activePipeline.Created,
+			Priority:   model.QueuePriority(repo, activePipeline, server.Config.Pipeline.QueuePriorityRules),
 		}
 		// fall back to the current time if the pipeline has no creation
 		// timestamp, so the queue always has a defined ordering key.

--- a/server/pipeline/queue.go
+++ b/server/pipeline/queue.go
@@ -22,13 +22,12 @@ import (
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/builder"
 	"go.woodpecker-ci.org/woodpecker/v3/rpc"
-	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 )
 
 // pipelineTasks builds the queue tasks for a pipeline's workflow items.
 // Enqueuing happens via the scheduler (see scheduler.StartPipeline).
-func pipelineTasks(repo *model.Repo, activePipeline *model.Pipeline, pipelineItems []*builder.Item) ([]*model.Task, error) {
+func pipelineTasks(repo *model.Repo, activePipeline *model.Pipeline, pipelineItems []*builder.Item, priorityRules []model.QueuePriorityRule) ([]*model.Task, error) {
 	var tasks []*model.Task
 	for _, item := range pipelineItems {
 		task := &model.Task{
@@ -39,7 +38,7 @@ func pipelineTasks(repo *model.Repo, activePipeline *model.Pipeline, pipelineIte
 			PipelineID: activePipeline.ID,
 			RepoID:     repo.ID,
 			Created:    activePipeline.Created,
-			Priority:   model.QueuePriority(repo, activePipeline, server.Config.Pipeline.QueuePriorityRules),
+			Priority:   model.QueuePriority(repo, activePipeline, priorityRules),
 		}
 		// fall back to the current time if the pipeline has no creation
 		// timestamp, so the queue always has a defined ordering key.

--- a/server/pipeline/queue_priority.go
+++ b/server/pipeline/queue_priority.go
@@ -24,7 +24,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 )
 
-const queuePriorityConfigPath = ".woodpecker/queue-priority"
+const queuePriorityConfigPath = ".woodpecker/queue-priority.yml"
 
 func loadQueuePriorityRules(ctx context.Context, forge forge.Forge, user *model.User, repo *model.Repo, pipeline *model.Pipeline) ([]model.QueuePriorityRule, error) {
 	if repo.Branch == "" {

--- a/server/pipeline/queue_priority.go
+++ b/server/pipeline/queue_priority.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge"
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+)
+
+const queuePriorityConfigPath = ".woodpecker/queue-priority"
+
+func loadQueuePriorityRules(ctx context.Context, forge forge.Forge, user *model.User, repo *model.Repo, pipeline *model.Pipeline) ([]model.QueuePriorityRule, error) {
+	if repo.Branch == "" {
+		return nil, nil
+	}
+
+	defaultHead, err := forge.BranchHead(ctx, user, repo, repo.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve default branch %q for queue priority config: %w", repo.Branch, err)
+	}
+
+	configPipeline := *pipeline
+	configPipeline.Commit = defaultHead.SHA
+	data, err := forge.File(ctx, user, repo, &configPipeline, queuePriorityConfigPath)
+	if errors.Is(err, &forge_types.ErrConfigNotFound{}) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not load queue priority config %q: %w", queuePriorityConfigPath, err)
+	}
+
+	rules, err := model.ParseQueuePriorityRuleFile(data)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse queue priority config %q: %w", queuePriorityConfigPath, err)
+	}
+	return rules, nil
+}

--- a/server/pipeline/queue_priority_test.go
+++ b/server/pipeline/queue_priority_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge/mocks"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+)
+
+func TestLoadQueuePriorityRulesUsesDefaultBranchHead(t *testing.T) {
+	forge := mocks.NewMockForge(t)
+	user := &model.User{}
+	repo := &model.Repo{FullName: "postgis/postgis", Branch: "master"}
+	pipeline := &model.Pipeline{
+		Commit:      "pull-request-head",
+		Event:       model.EventPull,
+		EventReason: []string{"synchronized"},
+	}
+
+	forge.On("BranchHead", mock.Anything, user, repo, "master").
+		Return(&model.Commit{SHA: "master-head"}, nil)
+	forge.On("File", mock.Anything, user, repo, mock.MatchedBy(func(p *model.Pipeline) bool {
+		return p.Commit == "master-head"
+	}), queuePriorityConfigPath).
+		Return([]byte("priority=-20 event=pull_request event_reason=synchroniz*\n"), nil)
+
+	rules, err := loadQueuePriorityRules(t.Context(), forge, user, repo, pipeline)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, -20, model.QueuePriority(repo, pipeline, rules))
+}

--- a/server/pipeline/queue_priority_test.go
+++ b/server/pipeline/queue_priority_test.go
@@ -40,7 +40,7 @@ func TestLoadQueuePriorityRulesUsesDefaultBranchHead(t *testing.T) {
 	forge.On("File", mock.Anything, user, repo, mock.MatchedBy(func(p *model.Pipeline) bool {
 		return p.Commit == "master-head"
 	}), queuePriorityConfigPath).
-		Return([]byte("priority=-20 event=pull_request event_reason=synchroniz*\n"), nil)
+		Return([]byte("rules:\n  - priority: -20\n    event: pull_request\n    event_reason: synchroniz*\n"), nil)
 
 	rules, err := loadQueuePriorityRules(t.Context(), forge, user, repo, pipeline)
 	require.NoError(t, err)

--- a/server/pipeline/queue_test.go
+++ b/server/pipeline/queue_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/builder"
-	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 )
 
@@ -67,7 +66,7 @@ func TestQueuePipelineConcurrency(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tasks, err := pipelineTasks(repo, activePipeline, []*builder.Item{tc.item})
+			tasks, err := pipelineTasks(repo, activePipeline, []*builder.Item{tc.item}, nil)
 			require.NoError(t, err)
 			require.Len(t, tasks, 1)
 
@@ -82,21 +81,18 @@ func TestQueuePipelinePriority(t *testing.T) {
 	repo := &model.Repo{ID: 7, FullName: "postgis/postgis"}
 	item := &builder.Item{Workflow: &builder.Workflow{ID: 1, Name: "build"}}
 
-	server.Config.Pipeline.QueuePriorityRules = []model.QueuePriorityRule{
+	priorityRules := []model.QueuePriorityRule{
 		{Priority: 100, Event: model.EventPush, Branch: "master"},
 		{Priority: 80, Event: model.EventPush, Branch: "stable-*"},
 		{Priority: -20, Event: model.EventPull, EventReason: "synchronized"},
 	}
-	t.Cleanup(func() {
-		server.Config.Pipeline.QueuePriorityRules = nil
-	})
 
 	tasks, err := pipelineTasks(repo, &model.Pipeline{
 		ID:          42,
 		Event:       model.EventPush,
 		Branch:      "stable-3.6",
 		EventReason: []string{"push"},
-	}, []*builder.Item{item})
+	}, []*builder.Item{item}, priorityRules)
 	require.NoError(t, err)
 	require.Len(t, tasks, 1)
 	assert.Equal(t, 80, tasks[0].Priority)
@@ -105,7 +101,7 @@ func TestQueuePipelinePriority(t *testing.T) {
 		ID:          43,
 		Event:       model.EventPull,
 		EventReason: []string{"synchronized"},
-	}, []*builder.Item{item})
+	}, []*builder.Item{item}, priorityRules)
 	require.NoError(t, err)
 	require.Len(t, tasks, 1)
 	assert.Equal(t, -20, tasks[0].Priority)
@@ -117,7 +113,7 @@ func TestQueuePipelineCreated(t *testing.T) {
 
 	runOnce := func(t *testing.T, pipeline *model.Pipeline) *model.Task {
 		t.Helper()
-		tasks, err := pipelineTasks(repo, pipeline, []*builder.Item{item})
+		tasks, err := pipelineTasks(repo, pipeline, []*builder.Item{item}, nil)
 		require.NoError(t, err)
 		require.Len(t, tasks, 1)
 		return tasks[0]

--- a/server/pipeline/queue_test.go
+++ b/server/pipeline/queue_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/builder"
+	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 )
 
@@ -75,6 +76,39 @@ func TestQueuePipelineConcurrency(t *testing.T) {
 			assert.Equal(t, tc.expectedGroup, task.ConcurrencyGroup)
 		})
 	}
+}
+
+func TestQueuePipelinePriority(t *testing.T) {
+	repo := &model.Repo{ID: 7, FullName: "postgis/postgis"}
+	item := &builder.Item{Workflow: &builder.Workflow{ID: 1, Name: "build"}}
+
+	server.Config.Pipeline.QueuePriorityRules = []model.QueuePriorityRule{
+		{Priority: 100, Event: model.EventPush, Branch: "master"},
+		{Priority: 80, Event: model.EventPush, Branch: "stable-*"},
+		{Priority: -20, Event: model.EventPull, EventReason: "synchronized"},
+	}
+	t.Cleanup(func() {
+		server.Config.Pipeline.QueuePriorityRules = nil
+	})
+
+	tasks, err := pipelineTasks(repo, &model.Pipeline{
+		ID:          42,
+		Event:       model.EventPush,
+		Branch:      "stable-3.6",
+		EventReason: []string{"push"},
+	}, []*builder.Item{item})
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, 80, tasks[0].Priority)
+
+	tasks, err = pipelineTasks(repo, &model.Pipeline{
+		ID:          43,
+		Event:       model.EventPull,
+		EventReason: []string{"synchronized"},
+	}, []*builder.Item{item})
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, -20, tasks[0].Priority)
 }
 
 func TestQueuePipelineCreated(t *testing.T) {

--- a/server/pipeline/restart.go
+++ b/server/pipeline/restart.go
@@ -89,6 +89,16 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 		return nil, errors.New(msg)
 	}
 
+	priorityRules, err := loadQueuePriorityRules(ctx, forge, user, repo, newPipeline)
+	if err != nil {
+		if newPipeline, uErr := UpdateToStatusError(store, *newPipeline, err); uErr != nil {
+			log.Error().Err(uErr).Msgf("error setting error status of pipeline for %s#%d", repo.FullName, newPipeline.Number)
+		} else {
+			updatePipelineStatus(ctx, forge, newPipeline, repo, user)
+		}
+		return nil, err
+	}
+
 	newPipeline, pipelineItems, parseErr, err := createPipelineItems(ctx, forge, store, newPipeline, user, repo, pipelineFiles, envs, false)
 	if handleParseErrors(newPipeline, parseErr) {
 		if newPipeline, uErr := UpdateToStatusError(store, *newPipeline, parseErr); uErr != nil {
@@ -108,7 +118,7 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 
 	publishPipeline(ctx, forge, newPipeline, repo, user)
 
-	newPipeline, err = start(ctx, forge, store, newPipeline, user, repo, pipelineItems)
+	newPipeline, err = start(ctx, forge, store, newPipeline, user, repo, pipelineItems, priorityRules)
 	if err != nil {
 		msg := fmt.Sprintf("failure to start pipeline for %s", repo.FullName)
 		log.Error().Err(err).Msg(msg)

--- a/server/pipeline/start.go
+++ b/server/pipeline/start.go
@@ -27,14 +27,14 @@ import (
 )
 
 // start a pipeline, make sure it was stored persistent in the store before.
-func start(ctx context.Context, forge forge.Forge, store store.Store, activePipeline *model.Pipeline, user *model.User, repo *model.Repo, pipelineItems []*builder.Item) (*model.Pipeline, error) {
+func start(ctx context.Context, forge forge.Forge, store store.Store, activePipeline *model.Pipeline, user *model.User, repo *model.Repo, pipelineItems []*builder.Item, priorityRules []model.QueuePriorityRule) (*model.Pipeline, error) {
 	// call to cancel previous pipelines if needed
 	if err := cancelPreviousPipelines(ctx, forge, store, activePipeline, repo, user); err != nil {
 		// should be not breaking
 		log.Error().Err(err).Msg("failed to cancel previous pipelines")
 	}
 
-	tasks, err := pipelineTasks(repo, activePipeline, pipelineItems)
+	tasks, err := pipelineTasks(repo, activePipeline, pipelineItems, priorityRules)
 	if err != nil {
 		return nil, err
 	}

--- a/server/queue/fifo.go
+++ b/server/queue/fifo.go
@@ -312,8 +312,9 @@ func (q *fifo) filterWaiting() {
 }
 
 func (q *fifo) assignToWorker() (*list.Element, *worker) {
+	var bestElement *list.Element
+	var bestTask *model.Task
 	var bestWorker *worker
-	var bestScore int
 
 	for element := q.pending.Front(); element != nil; element = element.Next() {
 		task, _ := element.Value.(*model.Task)
@@ -326,20 +327,30 @@ func (q *fifo) assignToWorker() (*list.Element, *worker) {
 			continue
 		}
 
+		var taskBestWorker *worker
+		var taskBestScore int
 		for worker := range q.workers {
 			matched, score := worker.filter(task)
-			if matched && score > bestScore {
-				bestWorker = worker
-				bestScore = score
+			if matched && (taskBestWorker == nil || score > taskBestScore) {
+				taskBestWorker = worker
+				taskBestScore = score
 			}
 		}
-		if bestWorker != nil {
-			log.Debug().Msgf("queue: assigned task: %v with deps %v to worker with score %d", task.ID, task.Dependencies, bestScore)
-			return element, bestWorker
+		if taskBestWorker == nil {
+			continue
+		}
+
+		if bestTask == nil || queueOrderLess(task, bestTask) {
+			bestElement = element
+			bestTask = task
+			bestWorker = taskBestWorker
 		}
 	}
 
-	return nil, nil
+	if bestTask != nil {
+		log.Debug().Msgf("queue: assigned task: %v with deps %v to worker", bestTask.ID, bestTask.Dependencies)
+	}
+	return bestElement, bestWorker
 }
 
 // canRunConcurrent reports whether the given task may currently start without
@@ -407,15 +418,23 @@ func (q *fifo) canRunConcurrent(task *model.Task) bool {
 	return running+ahead < task.ConcurrencyLimit
 }
 
-// taskOrderLess reports whether task a was instantiated before task b. Ordering
-// is by the Created timestamp (the pipeline creation time), with the workflow
-// name as a deterministic tiebreaker for tasks created within the same second.
-// The task ID is intentionally not used for ordering.
+// taskOrderLess reports whether task a was instantiated before task b. It is
+// used for concurrency reservations, where queue priority must not violate
+// same-workflow commit ordering.
 func taskOrderLess(a, b *model.Task) bool {
 	if a.Created != b.Created {
 		return a.Created < b.Created
 	}
 	return a.Name < b.Name
+}
+
+// queueOrderLess reports whether task a should be assigned before task b.
+// Higher priority runs first; equal priorities retain FIFO task ordering.
+func queueOrderLess(a, b *model.Task) bool {
+	if a.Priority != b.Priority {
+		return a.Priority > b.Priority
+	}
+	return taskOrderLess(a, b)
 }
 
 func (q *fifo) resubmitExpiredPipelines() {

--- a/server/queue/fifo.go
+++ b/server/queue/fifo.go
@@ -225,6 +225,25 @@ func (q *fifo) Info(_ context.Context) InfoT {
 	return stats
 }
 
+// Reprioritize updates priorities for pending and dependency-waiting tasks.
+func (q *fifo) Reprioritize(_ context.Context, priorities map[string]int) error {
+	q.Lock()
+	defer q.Unlock()
+
+	updateListTaskPriorities(q.pending, priorities)
+	updateListTaskPriorities(q.waitingOnDeps, priorities)
+	return nil
+}
+
+func updateListTaskPriorities(tasks *list.List, priorities map[string]int) {
+	for element := tasks.Front(); element != nil; element = element.Next() {
+		task, _ := element.Value.(*model.Task)
+		if priority, ok := priorities[task.ID]; ok {
+			task.Priority = priority
+		}
+	}
+}
+
 // Pause stops the queue from handing out new work items in Poll.
 func (q *fifo) Pause() {
 	q.Lock()

--- a/server/queue/fifo_test.go
+++ b/server/queue/fifo_test.go
@@ -964,6 +964,27 @@ func TestFifoPriority(t *testing.T) {
 		assert.NoError(t, q.Done(ctx, got.ID, model.StatusSuccess))
 		waitForProcess()
 	})
+
+	t.Run("reprioritize changes next poll order", func(t *testing.T) {
+		oldFirst := &model.Task{ID: "priority-old-first", Created: 100, Priority: 0}
+		newFirst := &model.Task{ID: "priority-new-first", Created: 200, Priority: 0}
+
+		assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{oldFirst, newFirst}))
+		assert.NoError(t, q.Reprioritize(ctx, map[string]int{"priority-new-first": 50}))
+		waitForProcess()
+
+		got, err := q.Poll(ctx, 1, filterFnTrue)
+		assert.NoError(t, err)
+		assert.Equal(t, "priority-new-first", got.ID)
+		assert.NoError(t, q.Done(ctx, got.ID, model.StatusSuccess))
+		waitForProcess()
+
+		got, err = q.Poll(ctx, 1, filterFnTrue)
+		assert.NoError(t, err)
+		assert.Equal(t, "priority-old-first", got.ID)
+		assert.NoError(t, q.Done(ctx, got.ID, model.StatusSuccess))
+		waitForProcess()
+	})
 }
 
 func TestFifoLeaseManagement(t *testing.T) {

--- a/server/queue/fifo_test.go
+++ b/server/queue/fifo_test.go
@@ -891,6 +891,79 @@ func TestFifoConcurrency(t *testing.T) {
 			&model.Task{ID: "2", Created: 100, Name: "alpha"},
 		))
 	})
+
+	t.Run("queue ordering uses priority before Created", func(t *testing.T) {
+		assert.True(t, queueOrderLess(
+			&model.Task{ID: "2", Created: 200, Priority: 10},
+			&model.Task{ID: "1", Created: 100, Priority: 1},
+		))
+		assert.False(t, taskOrderLess(
+			&model.Task{ID: "2", Created: 200, Priority: 10},
+			&model.Task{ID: "1", Created: 100, Priority: 1},
+		), "concurrency reservation ordering must ignore queue priority")
+	})
+}
+
+func TestFifoPriority(t *testing.T) {
+	ctx, cancel, q := setupTestQueue(t)
+	defer cancel(nil)
+
+	t.Run("higher priority later task runs first", func(t *testing.T) {
+		low := &model.Task{ID: "low", Created: 100, Priority: 0}
+		high := &model.Task{ID: "high", Created: 200, Priority: 10}
+
+		assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{low, high}))
+		waitForProcess()
+
+		got, err := q.Poll(ctx, 1, filterFnTrue)
+		assert.NoError(t, err)
+		assert.Equal(t, "high", got.ID)
+
+		assert.NoError(t, q.Done(ctx, got.ID, model.StatusSuccess))
+		waitForProcess()
+
+		got, err = q.Poll(ctx, 1, filterFnTrue)
+		assert.NoError(t, err)
+		assert.Equal(t, "low", got.ID)
+		assert.NoError(t, q.Done(ctx, got.ID, model.StatusSuccess))
+		waitForProcess()
+	})
+
+	t.Run("waiting high priority task does not block runnable task", func(t *testing.T) {
+		parent := &model.Task{ID: "priority-parent", Created: 100}
+		child := &model.Task{
+			ID:           "priority-child",
+			Created:      200,
+			Priority:     50,
+			Dependencies: []string{"priority-parent"},
+			DepStatus:    make(map[string]model.StatusValue),
+			RunOn:        []string{"success"},
+		}
+		other := &model.Task{ID: "priority-other", Created: 300, Priority: 0}
+
+		assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{parent, child, other}))
+		waitForProcess()
+
+		got, err := q.Poll(ctx, 1, filterFnTrue)
+		assert.NoError(t, err)
+		assert.Equal(t, "priority-parent", got.ID)
+		waitForProcess()
+
+		got, err = q.Poll(ctx, 1, filterFnTrue)
+		assert.NoError(t, err)
+		assert.Equal(t, "priority-other", got.ID)
+		assert.NoError(t, q.Done(ctx, got.ID, model.StatusSuccess))
+		waitForProcess()
+
+		assert.NoError(t, q.Done(ctx, "priority-parent", model.StatusSuccess))
+		waitForProcess()
+
+		got, err = q.Poll(ctx, 1, filterFnTrue)
+		assert.NoError(t, err)
+		assert.Equal(t, "priority-child", got.ID)
+		assert.NoError(t, q.Done(ctx, got.ID, model.StatusSuccess))
+		waitForProcess()
+	})
 }
 
 func TestFifoLeaseManagement(t *testing.T) {

--- a/server/queue/mocks/mock_Queue.go
+++ b/server/queue/mocks/mock_Queue.go
@@ -546,6 +546,60 @@ func (_c *MockQueue_PushAtOnce_Call) RunAndReturn(run func(c context.Context, ta
 	return _c
 }
 
+// Reprioritize provides a mock function for the type MockQueue
+func (_mock *MockQueue) Reprioritize(c context.Context, priorities map[string]int) error {
+	ret := _mock.Called(c, priorities)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reprioritize")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]int) error); ok {
+		r0 = returnFunc(c, priorities)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockQueue_Reprioritize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reprioritize'
+type MockQueue_Reprioritize_Call struct {
+	*mock.Call
+}
+
+// Reprioritize is a helper method to define mock.On call
+//   - c context.Context
+//   - priorities map[string]int
+func (_e *MockQueue_Expecter) Reprioritize(c interface{}, priorities interface{}) *MockQueue_Reprioritize_Call {
+	return &MockQueue_Reprioritize_Call{Call: _e.mock.On("Reprioritize", c, priorities)}
+}
+
+func (_c *MockQueue_Reprioritize_Call) Run(run func(c context.Context, priorities map[string]int)) *MockQueue_Reprioritize_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 map[string]int
+		if args[1] != nil {
+			arg1 = args[1].(map[string]int)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockQueue_Reprioritize_Call) Return(err error) *MockQueue_Reprioritize_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockQueue_Reprioritize_Call) RunAndReturn(run func(c context.Context, priorities map[string]int) error) *MockQueue_Reprioritize_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Resume provides a mock function for the type MockQueue
 func (_mock *MockQueue) Resume() {
 	_mock.Called()

--- a/server/queue/persistent.go
+++ b/server/queue/persistent.go
@@ -120,3 +120,17 @@ func (q *persistentQueue) ErrorAtOnce(c context.Context, ids []string, err error
 	}
 	return nil
 }
+
+// Reprioritize updates pending queue priorities and persists them in the task
+// backup store used for queue restore after server restart.
+func (q *persistentQueue) Reprioritize(c context.Context, priorities map[string]int) error {
+	if err := q.Queue.Reprioritize(c, priorities); err != nil {
+		return err
+	}
+	for id, priority := range priorities {
+		if err := q.store.TaskUpdatePriority(id, priority); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/server/queue/persistent_test.go
+++ b/server/queue/persistent_test.go
@@ -66,3 +66,21 @@ func TestPersistentQueuePollReturnsLiveTask(t *testing.T) {
 	assert.NotNil(t, got)
 	assert.Equal(t, "1", got.ID)
 }
+
+func TestPersistentQueueReprioritizeUpdatesStore(t *testing.T) {
+	ctx, cancel, q := setupTestQueue(t)
+	defer cancel(nil)
+
+	store := store_mocks.NewMockStore(t)
+	store.EXPECT().TaskUpdatePriority("1", 10).Return(nil).Once()
+
+	pq := &persistentQueue{Queue: q, store: store}
+
+	task := genDummyTask()
+	assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{task}))
+	assert.NoError(t, pq.Reprioritize(ctx, map[string]int{"1": 10}))
+
+	info := q.Info(ctx)
+	assert.Len(t, info.Pending, 1)
+	assert.Equal(t, 10, info.Pending[0].Priority)
+}

--- a/server/queue/queue.go
+++ b/server/queue/queue.go
@@ -133,6 +133,9 @@ type Queue interface {
 	// Info returns internal queue information.
 	Info(c context.Context) InfoT
 
+	// Reprioritize updates priorities for pending and dependency-waiting tasks.
+	Reprioritize(c context.Context, priorities map[string]int) error
+
 	// Pause stops the queue from handing out new work items in Poll
 	Pause()
 

--- a/server/scheduler/impl.go
+++ b/server/scheduler/impl.go
@@ -149,6 +149,34 @@ func (p *impl) StartPipeline(c context.Context, repo *model.Repo, pipeline *mode
 	return p.q.PushAtOnce(c, tasks)
 }
 
+func (p *impl) ReprioritizeRepo(c context.Context, repo *model.Repo, rules []model.QueuePriorityRule) error {
+	priorities := map[string]int{}
+	info := p.q.Info(c)
+	collect := func(tasks []*model.Task) error {
+		for _, task := range tasks {
+			if task.RepoID != repo.ID {
+				continue
+			}
+			pipeline, err := p.store.GetPipeline(task.PipelineID)
+			if err != nil {
+				return err
+			}
+			priorities[task.ID] = model.QueuePriority(repo, pipeline, rules)
+		}
+		return nil
+	}
+	if err := collect(info.Pending); err != nil {
+		return err
+	}
+	if err := collect(info.WaitingOnDeps); err != nil {
+		return err
+	}
+	if len(priorities) == 0 {
+		return nil
+	}
+	return p.q.Reprioritize(c, priorities)
+}
+
 // CancelWorkflows evicts the given workflows from the queue, signaling a
 // cancellation (queue.ErrCancel) to any agents currently waiting on them.
 // An empty list is a no-op.

--- a/server/scheduler/impl.go
+++ b/server/scheduler/impl.go
@@ -149,34 +149,6 @@ func (p *impl) StartPipeline(c context.Context, repo *model.Repo, pipeline *mode
 	return p.q.PushAtOnce(c, tasks)
 }
 
-func (p *impl) ReprioritizeRepo(c context.Context, repo *model.Repo, rules []model.QueuePriorityRule) error {
-	priorities := map[string]int{}
-	info := p.q.Info(c)
-	collect := func(tasks []*model.Task) error {
-		for _, task := range tasks {
-			if task.RepoID != repo.ID {
-				continue
-			}
-			pipeline, err := p.store.GetPipeline(task.PipelineID)
-			if err != nil {
-				return err
-			}
-			priorities[task.ID] = model.QueuePriority(repo, pipeline, rules)
-		}
-		return nil
-	}
-	if err := collect(info.Pending); err != nil {
-		return err
-	}
-	if err := collect(info.WaitingOnDeps); err != nil {
-		return err
-	}
-	if len(priorities) == 0 {
-		return nil
-	}
-	return p.q.Reprioritize(c, priorities)
-}
-
 // CancelWorkflows evicts the given workflows from the queue, signaling a
 // cancellation (queue.ErrCancel) to any agents currently waiting on them.
 // An empty list is a no-op.

--- a/server/scheduler/mocks/mock_Scheduler.go
+++ b/server/scheduler/mocks/mock_Scheduler.go
@@ -656,6 +656,65 @@ func (_c *MockScheduler_StartPipeline_Call) RunAndReturn(run func(c context.Cont
 	return _c
 }
 
+// ReprioritizeRepo provides a mock function for the type MockScheduler
+func (_mock *MockScheduler) ReprioritizeRepo(c context.Context, repo *model.Repo, rules []model.QueuePriorityRule) error {
+	ret := _mock.Called(c, repo, rules)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReprioritizeRepo")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.Repo, []model.QueuePriorityRule) error); ok {
+		r0 = returnFunc(c, repo, rules)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockScheduler_ReprioritizeRepo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReprioritizeRepo'
+type MockScheduler_ReprioritizeRepo_Call struct {
+	*mock.Call
+}
+
+// ReprioritizeRepo is a helper method to define mock.On call
+//   - c context.Context
+//   - repo *model.Repo
+//   - rules []model.QueuePriorityRule
+func (_e *MockScheduler_Expecter) ReprioritizeRepo(c interface{}, repo interface{}, rules interface{}) *MockScheduler_ReprioritizeRepo_Call {
+	return &MockScheduler_ReprioritizeRepo_Call{Call: _e.mock.On("ReprioritizeRepo", c, repo, rules)}
+}
+
+func (_c *MockScheduler_ReprioritizeRepo_Call) Run(run func(c context.Context, repo *model.Repo, rules []model.QueuePriorityRule)) *MockScheduler_ReprioritizeRepo_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *model.Repo
+		if args[1] != nil {
+			arg1 = args[1].(*model.Repo)
+		}
+		var arg2 []model.QueuePriorityRule
+		if args[2] != nil {
+			arg2 = args[2].([]model.QueuePriorityRule)
+		}
+		run(arg0, arg1, arg2)
+	})
+	return _c
+}
+
+func (_c *MockScheduler_ReprioritizeRepo_Call) Return(err error) *MockScheduler_ReprioritizeRepo_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockScheduler_ReprioritizeRepo_Call) RunAndReturn(run func(c context.Context, repo *model.Repo, rules []model.QueuePriorityRule) error) *MockScheduler_ReprioritizeRepo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Subscribe provides a mock function for the type MockScheduler
 func (_mock *MockScheduler) Subscribe(c context.Context, t pubsub.Topics, r pubsub.Receiver) error {
 	ret := _mock.Called(c, t, r)

--- a/server/scheduler/queue_priority.go
+++ b/server/scheduler/queue_priority.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"context"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+)
+
+func (p *impl) ReprioritizeRepo(c context.Context, repo *model.Repo, rules []model.QueuePriorityRule) error {
+	priorities := map[string]int{}
+	info := p.q.Info(c)
+	collect := func(tasks []*model.Task) error {
+		for _, task := range tasks {
+			if task.RepoID != repo.ID {
+				continue
+			}
+			pipeline, err := p.store.GetPipeline(task.PipelineID)
+			if err != nil {
+				return err
+			}
+			priorities[task.ID] = model.QueuePriority(repo, pipeline, rules)
+		}
+		return nil
+	}
+	if err := collect(info.Pending); err != nil {
+		return err
+	}
+	if err := collect(info.WaitingOnDeps); err != nil {
+		return err
+	}
+	if len(priorities) == 0 {
+		return nil
+	}
+	return p.q.Reprioritize(c, priorities)
+}

--- a/server/scheduler/queue_priority_test.go
+++ b/server/scheduler/queue_priority_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/queue"
+	queue_mocks "go.woodpecker-ci.org/woodpecker/v3/server/queue/mocks"
+	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+func TestReprioritizeRepoUpdatesPendingAndWaitingTasks(t *testing.T) {
+	repo := &model.Repo{ID: 7, FullName: "postgis/postgis"}
+	otherRepoTask := &model.Task{ID: "other", RepoID: 8, PipelineID: 3}
+	pendingTask := &model.Task{ID: "pending", RepoID: 7, PipelineID: 1}
+	waitingTask := &model.Task{ID: "waiting", RepoID: 7, PipelineID: 2}
+	rules := []model.QueuePriorityRule{
+		{Priority: 100, Event: model.EventPush, Branch: "master"},
+		{Priority: -20, Event: model.EventPull, EventReason: "synchroniz*"},
+	}
+
+	store := store_mocks.NewMockStore(t)
+	store.EXPECT().GetPipeline(int64(1)).Return(&model.Pipeline{Event: model.EventPush, Branch: "master"}, nil).Once()
+	store.EXPECT().GetPipeline(int64(2)).Return(&model.Pipeline{Event: model.EventPull, EventReason: []string{"synchronized"}}, nil).Once()
+
+	queue := queue_mocks.NewMockQueue(t)
+	queue.EXPECT().Info(mock.Anything).Return(queueInfo(pendingTask, waitingTask, otherRepoTask)).Once()
+	queue.EXPECT().Reprioritize(mock.Anything, map[string]int{
+		"pending": 100,
+		"waiting": -20,
+	}).Return(nil).Once()
+
+	scheduler := &impl{store: store, q: queue}
+	require.NoError(t, scheduler.ReprioritizeRepo(t.Context(), repo, rules))
+}
+
+func queueInfo(pending, waiting, other *model.Task) queue.InfoT {
+	return queue.InfoT{
+		Pending:       []*model.Task{pending, other},
+		WaitingOnDeps: []*model.Task{waiting},
+	}
+}

--- a/server/scheduler/scheduler.go
+++ b/server/scheduler/scheduler.go
@@ -58,6 +58,7 @@ type Scheduler interface {
 	// Consolidated operations.
 	PublishPipelineEvent(c context.Context, repo *model.Repo, pipeline *model.Pipeline) error
 	StartPipeline(c context.Context, repo *model.Repo, pipeline *model.Pipeline, tasks []*model.Task) error
+	ReprioritizeRepo(c context.Context, repo *model.Repo, rules []model.QueuePriorityRule) error
 
 	// CancelWorkflows cancels the given workflows: it evicts them from the
 	// queue and signals the cancellation to any agents waiting on them. This is

--- a/server/store/datastore/task.go
+++ b/server/store/datastore/task.go
@@ -28,6 +28,11 @@ func (s storage) TaskInsert(task *model.Task) error {
 	return wrapInsert(s.engine.Insert(task))
 }
 
+func (s storage) TaskUpdatePriority(id string, priority int) error {
+	_, err := s.engine.Where("id = ?", id).Cols("priority").Update(&model.Task{Priority: priority})
+	return err
+}
+
 func (s storage) TaskDelete(id string) error {
 	return wrapDelete(s.engine.Where("id = ?", id).Delete(new(model.Task)))
 }

--- a/server/store/datastore/task_test.go
+++ b/server/store/datastore/task_test.go
@@ -31,6 +31,7 @@ func TestTaskList(t *testing.T) {
 		Data:      []byte("foo"),
 		Labels:    map[string]string{"foo": "bar"},
 		DepStatus: map[string]model.StatusValue{"test": "dep"},
+		Priority:  42,
 	}))
 
 	list, err := store.TaskList()
@@ -39,6 +40,7 @@ func TestTaskList(t *testing.T) {
 	assert.Equal(t, "some_random_id", list[0].ID)
 	assert.Equal(t, "foo", string(list[0].Data))
 	assert.EqualValues(t, map[string]model.StatusValue{"test": "dep"}, list[0].DepStatus)
+	assert.Equal(t, 42, list[0].Priority)
 
 	assert.NoError(t, store.TaskDelete("some_random_id"))
 

--- a/server/store/datastore/task_test.go
+++ b/server/store/datastore/task_test.go
@@ -42,6 +42,12 @@ func TestTaskList(t *testing.T) {
 	assert.EqualValues(t, map[string]model.StatusValue{"test": "dep"}, list[0].DepStatus)
 	assert.Equal(t, 42, list[0].Priority)
 
+	assert.NoError(t, store.TaskUpdatePriority("some_random_id", -10))
+	list, err = store.TaskList()
+	assert.NoError(t, err)
+	assert.Len(t, list, 1, "Expected one task in list")
+	assert.Equal(t, -10, list[0].Priority)
+
 	assert.NoError(t, store.TaskDelete("some_random_id"))
 
 	list, err = store.TaskList()

--- a/server/store/mocks/mock_Store.go
+++ b/server/store/mocks/mock_Store.go
@@ -6065,6 +6065,60 @@ func (_c *MockStore_TaskInsert_Call) RunAndReturn(run func(task *model.Task) err
 	return _c
 }
 
+// TaskUpdatePriority provides a mock function for the type MockStore
+func (_mock *MockStore) TaskUpdatePriority(id string, priority int) error {
+	ret := _mock.Called(id, priority)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TaskUpdatePriority")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, int) error); ok {
+		r0 = returnFunc(id, priority)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_TaskUpdatePriority_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TaskUpdatePriority'
+type MockStore_TaskUpdatePriority_Call struct {
+	*mock.Call
+}
+
+// TaskUpdatePriority is a helper method to define mock.On call
+//   - id string
+//   - priority int
+func (_e *MockStore_Expecter) TaskUpdatePriority(id interface{}, priority interface{}) *MockStore_TaskUpdatePriority_Call {
+	return &MockStore_TaskUpdatePriority_Call{Call: _e.mock.On("TaskUpdatePriority", id, priority)}
+}
+
+func (_c *MockStore_TaskUpdatePriority_Call) Run(run func(id string, priority int)) *MockStore_TaskUpdatePriority_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockStore_TaskUpdatePriority_Call) Return(err error) *MockStore_TaskUpdatePriority_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_TaskUpdatePriority_Call) RunAndReturn(run func(id string, priority int) error) *MockStore_TaskUpdatePriority_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TaskList provides a mock function for the type MockStore
 func (_mock *MockStore) TaskList() ([]*model.Task, error) {
 	ret := _mock.Called()

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -152,6 +152,7 @@ type Store interface {
 	// TaskList TODO: paginate & opt filter
 	TaskList() ([]*model.Task, error)
 	TaskInsert(*model.Task) error
+	TaskUpdatePriority(string, int) error
 	TaskDelete(string) error
 
 	// ServerConfig


### PR DESCRIPTION
## Summary

- add configurable server-side queue priority rules for queued tasks
- match rules on repo, event, branch, ref, author, sender, PR labels, event reason, and rerun count
- make the FIFO queue pick the highest-priority runnable task first, while preserving FIFO ordering for ties and concurrency reservations
- expose the persisted task priority in queue API/OpenAPI output
- read optional YAML rules from `.woodpecker/queue-priority.yml` on the repository's default branch
- reprioritize existing pending/dependency-waiting tasks for the same repo when the rules are loaded again

## Motivation

This is a small implementation path for https://github.com/woodpecker-ci/woodpecker/discussions/2261, which asks for fairer queue scheduling and mentions prioritizing main/dev branch pipelines over arbitrary pull requests.

The priority is kept outside the pipeline YAML so individual pipeline runs cannot raise their own place in the queue. Woodpecker reads the rules from the repository's default branch, which lets maintainers prefer default/stable branch builds, deprioritize bot senders, or push PR update/rebase events later without a larger scheduler framework. Reloading the config during pipeline creation also updates older queued tasks for that repository, so a long queue can adapt after maintainers push new rules.

Example:

```yaml
# .woodpecker/queue-priority.yml
rules:
  - priority: 100
    event: push
    branch: master
  - priority: 80
    event: push
    branch: stable-*
  - priority: -10
    event: pull_request
  - priority: -20
    event: pull_request
    event_reason: synchroniz*
  - priority: -30
    sender: renovate*
```

Related but not duplicate: woodpecker-ci/woodpecker#775 asks agents to pick the oldest jobs, and woodpecker-ci/woodpecker#6754 is a draft scheduler/store refactor.

This is intentionally compatible with woodpecker-ci/woodpecker#6754 rather than a replacement for that refactor: the queue priority reprioritization method lives in its own scheduler file, and merge-tree checks succeed in both merge directions.

## Testing

```sh
go test -race -timeout 180s -tags test go.woodpecker-ci.org/woodpecker/v3/server/model go.woodpecker-ci.org/woodpecker/v3/server/pipeline go.woodpecker-ci.org/woodpecker/v3/server/queue go.woodpecker-ci.org/woodpecker/v3/server/api go.woodpecker-ci.org/woodpecker/v3/server/store/datastore go.woodpecker-ci.org/woodpecker/v3/server/scheduler go.woodpecker-ci.org/woodpecker/v3/server/forge/gitea go.woodpecker-ci.org/woodpecker/v3/server/forge/forgejo go.woodpecker-ci.org/woodpecker/v3/server/forge/github
make generate-openapi
git merge-tree HEAD origin/pr-6754
git merge-tree origin/pr-6754 HEAD
```
