### PR TITLE
Rename `WOODPECKER_GRPC_VERIFY` to `WOODPECKER_GRPC_SKIP_VERIFY`

### DIFF
--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -110,12 +110,18 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 		log.Trace().Msg("use ssl for grpc")
 	}
 
+	skipInsecure := c.Bool("grpc-skip-insecure")
+	if c.IsSet("grpc-skip-insecure-deprecated") && !c.IsSet("grpc-skip-insecure") {
+		skipInsecure = c.Bool("grpc-skip-insecure-deprecated")
+		log.Warn().Msg("WOODPECKER_GRPC_VERIFY is deprecated, use WOODPECKER_GRPC_SKIP_VERIFY")
+	}
+
 	agentConn, err := agent_rpc.Dial(grpcClientCtx, agent_rpc.DialConfig{ //nolint:contextcheck
 		ServerAddr:       c.String("server"),
 		AgentToken:       c.String("grpc-token"),
 		AgentID:          agentConfig.AgentID,
 		Secure:           c.Bool("grpc-secure"),
-		SkipTLSVerify:    c.Bool("grpc-skip-insecure"),
+		SkipTLSVerify:    skipInsecure,
 		KeepaliveTime:    c.Duration("grpc-keepalive-time"),
 		KeepaliveTimeout: c.Duration("grpc-keepalive-timeout"),
 		AuthRefreshEvery: authInterceptorRefreshInterval,

--- a/cmd/agent/core/flags.go
+++ b/cmd/agent/core/flags.go
@@ -47,10 +47,17 @@ var flags = []cli.Flag{
 		Usage:   "should the connection to WOODPECKER_SERVER be made using a secure transport (tls)",
 	},
 	&cli.BoolFlag{
-		Sources: cli.EnvVars("WOODPECKER_GRPC_SKIP_VERIFY", "WOODPECKER_GRPC_VERIFY"), // TODO remove GRPC_VERIFY in next major
+		Sources: cli.EnvVars("WOODPECKER_GRPC_SKIP_VERIFY"),
 		Name:    "grpc-skip-insecure",
 		Usage:   "should the grpc server certificate be verified, only valid when WOODPECKER_GRPC_SECURE is true",
-		Value:   false,
+		Value:   true, // TODO change to false in next major to enable verification by default
+	},
+	// TODO remove this flag in next major
+	&cli.BoolFlag{
+		Sources: cli.EnvVars("WOODPECKER_GRPC_VERIFY"),
+		Name:    "grpc-skip-insecure-deprecated",
+		Usage:   "should the grpc server certificate be verified, only valid when WOODPECKER_GRPC_SECURE is true",
+		Value:   true,
 	},
 	&cli.DurationFlag{
 		Sources: cli.EnvVars("WOODPECKER_RETRY_TIMEOUT"),

--- a/cmd/agent/core/flags.go
+++ b/cmd/agent/core/flags.go
@@ -47,10 +47,10 @@ var flags = []cli.Flag{
 		Usage:   "should the connection to WOODPECKER_SERVER be made using a secure transport (tls)",
 	},
 	&cli.BoolFlag{
-		Sources: cli.EnvVars("WOODPECKER_GRPC_VERIFY"),
+		Sources: cli.EnvVars("WOODPECKER_GRPC_SKIP_VERIFY", "WOODPECKER_GRPC_VERIFY"), // TODO remove GRPC_VERIFY in next major
 		Name:    "grpc-skip-insecure",
 		Usage:   "should the grpc server certificate be verified, only valid when WOODPECKER_GRPC_SECURE is true",
-		Value:   true,
+		Value:   false,
 	},
 	&cli.DurationFlag{
 		Sources: cli.EnvVars("WOODPECKER_RETRY_TIMEOUT"),

--- a/docs/docs/30-administration/05-installation/10-docker-compose.md
+++ b/docs/docs/30-administration/05-installation/10-docker-compose.md
@@ -74,7 +74,7 @@ If the agents establish a connection via the Internet, TLS encryption should be 
      environment:
        - [...]
 +      - WOODPECKER_GRPC_SECURE=true # defaults to false
-+      - WOODPECKER_GRPC_VERIFY=true # default
++      - WOODPECKER_GRPC_SKIP_VERIFY=false # default
 ```
 
 As agents execute pipeline steps as Docker containers, they require access to the Docker daemon of the host machine:

--- a/docs/docs/30-administration/10-configuration/30-agent.md
+++ b/docs/docs/30-administration/10-configuration/30-agent.md
@@ -219,10 +219,10 @@ Configures if the connection to `WOODPECKER_SERVER` should be made using a secur
 
 ---
 
-### GRPC_VERIFY
+### GRPC_SKIP_VERIFY
 
-- Name: `WOODPECKER_GRPC_VERIFY`
-- Default: `true`
+- Name: `WOODPECKER_GRPC_SKIP_VERIFY`
+- Default: `false`
 
 Configures if the gRPC server certificate should be verified, only valid when `WOODPECKER_GRPC_SECURE` is `true`.
 

--- a/docs/docs/30-administration/10-configuration/30-agent.md
+++ b/docs/docs/30-administration/10-configuration/30-agent.md
@@ -222,7 +222,7 @@ Configures if the connection to `WOODPECKER_SERVER` should be made using a secur
 ### GRPC_SKIP_VERIFY
 
 - Name: `WOODPECKER_GRPC_SKIP_VERIFY`
-- Default: `false`
+- Default: `true`
 
 Configures if the gRPC server certificate should be verified, only valid when `WOODPECKER_GRPC_SECURE` is `true`.
 

--- a/docs/src/pages/migrations.md
+++ b/docs/src/pages/migrations.md
@@ -27,7 +27,7 @@ To enhance the usability of Woodpecker and meet evolving security standards, occ
 ### Admin-facing migrations
 
 - changed env var `WOODPECKER_CONFIG_SERVICE_ENDPOINT` to `WOODPECKER_CONFIG_EXTENSION_ENDPOINT`
-- changed env var `WOODPECKER_GRPC_VERIFY` to `WOODPECKER_GRPC_SKIP_VERIFY`
+- changed env var `WOODPECKER_GRPC_VERIFY` to `WOODPECKER_GRPC_SKIP_VERIFY`. ⚠️ The env var was inverted before, the naming was fixed. Setting to `true` disables verification.
 
 #### Extensions
 

--- a/docs/src/pages/migrations.md
+++ b/docs/src/pages/migrations.md
@@ -27,6 +27,7 @@ To enhance the usability of Woodpecker and meet evolving security standards, occ
 ### Admin-facing migrations
 
 - changed env var `WOODPECKER_CONFIG_SERVICE_ENDPOINT` to `WOODPECKER_CONFIG_EXTENSION_ENDPOINT`
+- changed env var `WOODPECKER_GRPC_VERIFY` to `WOODPECKER_GRPC_SKIP_VERIFY`
 
 #### Extensions
 


### PR DESCRIPTION
To make clear what it's doing. Also enable the tls verification by default