### PR TITLE
Do not run openapi generation twice on fail

### DIFF
--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -68,7 +68,7 @@ steps:
     commands:
       - 'make generate-openapi'
       - 'DIFF=$(git diff | head)'
-      - '[ -n "$DIFF" ] && { echo "openapi not up to date, exec `make generate-openapi` and commit"; exit 1; } || true'
+      - '[ -n "$DIFF" ] && { echo "openapi not up to date, exec make generate-openapi and commit"; exit 1; } || true'
     when: *when
 
   lint-license-header:


### PR DESCRIPTION
see e.g. https://ci.woodpecker-ci.org/repos/3780/pipeline/36751/37#L64

It looks like ```echo "... `make generate-openapi\` ..."``` executes `make generate-openapi` :thinking: never saw that before