### PR TITLE
fix(gitlab): avoid N+1 member lookups in Repos()

### DIFF
--- a/server/forge/gitlab/convert.go
+++ b/server/forge/gitlab/convert.go
@@ -76,8 +76,8 @@ func (g *GitLab) convertGitLabRepo(_repo *gitlab.Project, projectMember *gitlab.
 		IsSCMPrivate:  _repo.Visibility == gitlab.InternalVisibility || _repo.Visibility == gitlab.PrivateVisibility,
 		Perm: &model.Perm{
 			Pull:  isRead(_repo, projectMember),
-			Push:  isWrite(projectMember),
-			Admin: isAdmin(projectMember),
+			Push:  isWrite(_repo, projectMember),
+			Admin: isAdmin(_repo, projectMember),
 		},
 		PREnabled: _repo.MergeRequestsAccessLevel != gitlab.DisabledAccessControl,
 	}

--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -309,12 +309,24 @@ func (g *GitLab) Repos(ctx context.Context, user *model.User, p *model.ListOptio
 	repos := make([]*model.Repo, 0, len(projects))
 
 	for i := range projects {
-		projectMember, _, err := client.ProjectMembers.GetInheritedProjectMember(projects[i].ID, int64(intUserID), gitlab.WithContext(ctx))
-		if err != nil {
-			return nil, err
+		project := projects[i]
+
+		// The projects list API already reports the current user's access
+		// level via the `permissions` attribute, so in the common case we can
+		// skip the per-project membership lookup. GitLab may however omit it
+		// (e.g. when access is inherited from a nested parent group), in
+		// which case we fall back to a single explicit lookup per affected
+		// project.
+		var projectMember *gitlab.ProjectMember
+		if embeddedAccessLevel(project) == gitlab.NoPermissions {
+			var err error
+			projectMember, _, err = client.ProjectMembers.GetInheritedProjectMember(project.ID, int64(intUserID), gitlab.WithContext(ctx))
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		repo, err := g.convertGitLabRepo(projects[i], projectMember)
+		repo, err := g.convertGitLabRepo(project, projectMember)
 		if err != nil {
 			return nil, err
 		}

--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -311,12 +311,7 @@ func (g *GitLab) Repos(ctx context.Context, user *model.User, p *model.ListOptio
 	for i := range projects {
 		project := projects[i]
 
-		// The projects list API already reports the current user's access
-		// level via the `permissions` attribute, so in the common case we can
-		// skip the per-project membership lookup. GitLab may however omit it
-		// (e.g. when access is inherited from a nested parent group), in
-		// which case we fall back to a single explicit lookup per affected
-		// project.
+		// The projects list API already reports the current user's access level
 		var projectMember *gitlab.ProjectMember
 		if embeddedAccessLevel(project) == gitlab.NoPermissions {
 			var err error

--- a/server/forge/gitlab/gitlab_test.go
+++ b/server/forge/gitlab/gitlab_test.go
@@ -18,11 +18,14 @@ package gitlab
 import (
 	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/gitlab/fixtures"
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
@@ -641,4 +644,51 @@ func TestExtractFromPath(t *testing.T) {
 			assert.EqualValues(t, tc.wantName, name)
 		})
 	}
+}
+
+func TestGitLabReposUsesEmbeddedPermissions(t *testing.T) {
+	var memberCalls atomic.Int64
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, _ *http.Request) {
+		// project 4 reports the current user's permissions inline,
+		// project 6 does not (e.g. access inherited from a nested parent group)
+		_, _ = w.Write([]byte(`[` +
+			`{"id":4,"path_with_namespace":"diaspora/diaspora-client","visibility":"private","permissions":` +
+			`{"project_access":{"access_level":10},"group_access":{"access_level":50}}},` +
+			`{"id":6,"path_with_namespace":"brightbox/puppet","visibility":"private","permissions":null}` +
+			`]`))
+	})
+	mux.HandleFunc("/api/v4/projects/4/members/all/3", func(w http.ResponseWriter, _ *http.Request) {
+		memberCalls.Add(1)
+		http.Error(w, "unexpected membership lookup for project with embedded permissions", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/api/v4/projects/6/members/all/3", func(w http.ResponseWriter, _ *http.Request) {
+		memberCalls.Add(1)
+		_, _ = w.Write([]byte(`{"id":3,"username":"test_user","access_level":30}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := load(server.URL + "?client_id=test&client_secret=test")
+	user := model.User{Login: "test_user", AccessToken: "token", ForgeRemoteID: "3"}
+
+	repos, err := client.Repos(t.Context(), &user, &model.ListOptions{Page: 1, PerPage: 10})
+	require.NoError(t, err)
+	require.Len(t, repos, 2)
+
+	// only the project without embedded permissions should trigger a
+	// membership lookup, i.e. no N+1 requests
+	assert.Equal(t, int64(1), memberCalls.Load())
+
+	// project 4: owner via group access -> read, write and admin
+	assert.True(t, repos[0].Perm.Pull)
+	assert.True(t, repos[0].Perm.Push)
+	assert.True(t, repos[0].Perm.Admin)
+
+	// project 6: permissions missing -> fallback lookup reports developer -> read and write, but no admin
+	assert.True(t, repos[1].Perm.Pull)
+	assert.True(t, repos[1].Perm.Push)
+	assert.False(t, repos[1].Perm.Admin)
 }

--- a/server/forge/gitlab/helper.go
+++ b/server/forge/gitlab/helper.go
@@ -48,17 +48,49 @@ func newClient(url, accessToken string, skipVerify bool) (*gitlab.Client, error)
 // isRead is a helper function that returns true if the
 // user has Read-only access to the repository.
 func isRead(proj *gitlab.Project, projectMember *gitlab.ProjectMember) bool {
-	return proj.Visibility == gitlab.InternalVisibility || proj.Visibility == gitlab.PrivateVisibility || projectMember != nil && projectMember.AccessLevel >= gitlab.ReporterPermissions
+	return proj.Visibility == gitlab.InternalVisibility || proj.Visibility == gitlab.PrivateVisibility || userAccessLevel(proj, projectMember) >= gitlab.ReporterPermissions
 }
 
 // isWrite is a helper function that returns true if the
 // user has Read-Write access to the repository.
-func isWrite(projectMember *gitlab.ProjectMember) bool {
-	return projectMember != nil && projectMember.AccessLevel >= gitlab.DeveloperPermissions
+func isWrite(proj *gitlab.Project, projectMember *gitlab.ProjectMember) bool {
+	return userAccessLevel(proj, projectMember) >= gitlab.DeveloperPermissions
 }
 
 // isAdmin is a helper function that returns true if the
 // user has Admin access to the repository.
-func isAdmin(projectMember *gitlab.ProjectMember) bool {
-	return projectMember != nil && projectMember.AccessLevel >= gitlab.MaintainerPermissions
+func isAdmin(proj *gitlab.Project, projectMember *gitlab.ProjectMember) bool {
+	return userAccessLevel(proj, projectMember) >= gitlab.MaintainerPermissions
+}
+
+// userAccessLevel returns the effective access level of the current user for
+// the given project. The explicit (inherited) membership lookup is
+// authoritative when available; otherwise the `permissions` attribute embedded
+// in the project response is used. If neither provides a level,
+// gitlab.NoPermissions is returned.
+func userAccessLevel(proj *gitlab.Project, projectMember *gitlab.ProjectMember) gitlab.AccessLevelValue {
+	if projectMember != nil {
+		return projectMember.AccessLevel
+	}
+	return embeddedAccessLevel(proj)
+}
+
+// embeddedAccessLevel returns the access level of the current user as reported
+// by the `permissions` attribute of a project response (the maximum of the
+// project and group access level). The projects list API includes this
+// attribute, which allows listing repositories without issuing an extra
+// request per project.
+// See https://docs.gitlab.com/api/projects/.
+func embeddedAccessLevel(proj *gitlab.Project) gitlab.AccessLevelValue {
+	if proj == nil || proj.Permissions == nil {
+		return gitlab.NoPermissions
+	}
+	level := gitlab.NoPermissions
+	if proj.Permissions.ProjectAccess != nil {
+		level = max(level, proj.Permissions.ProjectAccess.AccessLevel)
+	}
+	if proj.Permissions.GroupAccess != nil {
+		level = max(level, proj.Permissions.GroupAccess.AccessLevel)
+	}
+	return level
 }

--- a/server/forge/gitlab/helper.go
+++ b/server/forge/gitlab/helper.go
@@ -63,11 +63,7 @@ func isAdmin(proj *gitlab.Project, projectMember *gitlab.ProjectMember) bool {
 	return userAccessLevel(proj, projectMember) >= gitlab.MaintainerPermissions
 }
 
-// userAccessLevel returns the effective access level of the current user for
-// the given project. The explicit (inherited) membership lookup is
-// authoritative when available; otherwise the `permissions` attribute embedded
-// in the project response is used. If neither provides a level,
-// gitlab.NoPermissions is returned.
+// userAccessLevel returns the effective access level of the current user for the project.
 func userAccessLevel(proj *gitlab.Project, projectMember *gitlab.ProjectMember) gitlab.AccessLevelValue {
 	if projectMember != nil {
 		return projectMember.AccessLevel
@@ -75,11 +71,7 @@ func userAccessLevel(proj *gitlab.Project, projectMember *gitlab.ProjectMember) 
 	return embeddedAccessLevel(proj)
 }
 
-// embeddedAccessLevel returns the access level of the current user as reported
-// by the `permissions` attribute of a project response (the maximum of the
-// project and group access level). The projects list API includes this
-// attribute, which allows listing repositories without issuing an extra
-// request per project.
+// embeddedAccessLevel returns the access level of the current user
 // See https://docs.gitlab.com/api/projects/.
 func embeddedAccessLevel(proj *gitlab.Project) gitlab.AccessLevelValue {
 	if proj == nil || proj.Permissions == nil {


### PR DESCRIPTION
Closes #6882

Repos() made one GET /api/v4/projects/:id/members/all/:user_id call per project — an N+1 that broke login for GitLab admins (404 on projects accessible via admin rights but without explicit membership, aborting the whole sync) and caused timeouts for users with many repos.

The projects list API already reports the current user's access level via the permissions attribute (project_access/group_access), so we now use that. A per-project membership lookup only happens when the embedded permissions are missing (e.g. access inherited from a nested parent group — GitLab's known gap), preserving prior behavior where the data is available.

Adds TestGitLabReposUsesEmbeddedPermissions asserting exactly one membership call (no N+1) and correct Pull/Push/Admin mapping.