### PR TITLE
fix: update star history chart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It combines both plugins by the Woodpecker core team and community-maintained on
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=woodpecker-ci/woodpecker&type=Date)](https://star-history.com/#woodpecker-ci/woodpecker&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=woodpecker-ci/woodpecker&type=Date)](https://star-history.dera.page/#woodpecker-ci/woodpecker&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This updates the chart to use a working source so it displays correctly again.