### PR TITLE
fix(runtime): filter out cancelled workflows from runtime errors

### DIFF
--- a/pipeline/runtime/workflow.go
+++ b/pipeline/runtime/workflow.go
@@ -85,7 +85,8 @@ func (r *Runtime) Run(runnerCtx context.Context) error {
 	// A failing step is a successfully executed task from the runtime's point of
 	// view. It is reported through the step states, which make the workflow fail,
 	// so it must not surface as a runtime error. Use Err() to get it anyway.
-	if err := r.err.Get(); !pipeline_errors.IsStepFailure(err) {
+	// Cancelled workflows are also not runtime errors — they are expected terminations.
+	if err := r.err.Get(); !pipeline_errors.IsStepFailure(err) && !errors.Is(err, pipeline_errors.ErrCancel) {
 		return err
 	}
 


### PR DESCRIPTION
## Problem

Cancelled pipelines were being reported as workflow errors. The error check in `workflow.go` only filtered out step failures (non-zero exit codes, OOM kills) via `IsStepFailure()`, but the `ErrCancel` signal from context cancellation is an expected termination that should not surface as a runtime error.

This caused cancelled steps to create workflow error entries in the database.

## Fix

Added `errors.Is(err, pipeline_errors.ErrCancel)` to the filter alongside `IsStepFailure()` so that cancelled workflows terminate cleanly without creating error entries.

Closes #6935

## References

- Maintainer comment: https://github.com/woodpecker-ci/woodpecker/issues/6935#issuecomment-5149752173
- Related PR: https://github.com/woodpecker-ci/woodpecker/pull/6904