### PR TITLE
Pick a repo's latest pipeline by number instead of id

### DIFF
--- a/server/store/datastore/feed.go
+++ b/server/store/datastore/feed.go
@@ -80,7 +80,7 @@ func (s storage) RepoListLatest(user *model.User) ([]*model.Feed, error) {
 		Join("LEFT", "pipelines", "pipelines.id = "+`(
 			SELECT pipelines.id FROM pipelines
 			WHERE pipelines.repo_id = repos.id
-			ORDER BY pipelines.id DESC
+			ORDER BY pipelines.number DESC
 			LIMIT 1
 			)`).
 		Where(userPushOrAdminCondition(user.ID)).

--- a/server/store/datastore/feed_test.go
+++ b/server/store/datastore/feed_test.go
@@ -203,3 +203,42 @@ func TestRepoListLatest(t *testing.T) {
 	assert.EqualValues(t, model.StatusKilled, pipelines[1].Status)
 	assert.Equal(t, repo2.ID, pipelines[1].RepoID)
 }
+
+// TestRepoListLatestUsesNumber checks the feed reports a repo's latest
+// pipeline by number rather than by id, in the case where the two sequences
+// disagree: the newest pipeline is given the lowest id. TiDB can produce that
+// state, as it allocates auto-increment values from per-node caches instead of
+// in insertion order.
+func TestRepoListLatestUsesNumber(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Repo), new(model.User), new(model.Perm), new(model.Pipeline), new(model.Org))
+	defer closer()
+
+	user := &model.User{
+		Login:       "joe",
+		Email:       "foo@bar.com",
+		AccessToken: "e42080dddf012c718e476da161d21ad5",
+	}
+	assert.NoError(t, store.CreateUser(user))
+
+	repo := &model.Repo{
+		ID:            1,
+		Owner:         "bradrydzewski",
+		Name:          "test",
+		FullName:      "bradrydzewski/test",
+		ForgeRemoteID: "1",
+		IsActive:      true,
+	}
+	assert.NoError(t, store.CreateRepo(repo))
+	assert.NoError(t, store.PermUpsert(&model.Perm{UserID: user.ID, RepoID: repo.ID, Push: true}))
+
+	// the newer pipeline deliberately carries the lower id
+	assert.NoError(t, wrapInsert(store.engine.Insert([]*model.Pipeline{
+		{ID: 900, RepoID: repo.ID, Number: 1, Status: model.StatusFailure},
+		{ID: 100, RepoID: repo.ID, Number: 2, Status: model.StatusRunning},
+	})))
+
+	pipelines, err := store.RepoListLatest(user)
+	assert.NoError(t, err)
+	assert.Len(t, pipelines, 1)
+	assert.EqualValues(t, model.StatusRunning, pipelines[0].Status)
+}

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -106,16 +106,32 @@ func (s storage) GetPipelineList(repo *model.Repo, p *model.ListOptions, f *mode
 func (s storage) GetRepoLatestPipelines(repoIDs []int64) ([]*model.Pipeline, error) {
 	pipelines := make([]*model.Pipeline, 0, len(repoIDs))
 
-	pipelineIDs := make([]int64, 0, len(repoIDs))
-	if err := s.engine.Select("MAX(id) AS id").
+	// The latest pipeline of a repo is the one holding the highest number,
+	// which is assigned per repo in the order pipelines are created.
+	type repoLatest struct {
+		RepoID int64 `xorm:"repo_id"`
+		Number int64 `xorm:"number"`
+	}
+
+	latest := make([]*repoLatest, 0, len(repoIDs))
+	if err := s.engine.Select("repo_id, MAX(number) AS number").
 		Table("pipelines").
 		Where(builder.In("repo_id", repoIDs)).
 		GroupBy("repo_id").
-		Find(&pipelineIDs); err != nil {
+		Find(&latest); err != nil {
 		return nil, err
 	}
 
-	return pipelines, s.engine.Where(builder.In("id", pipelineIDs)).Find(&pipelines)
+	if len(latest) == 0 {
+		return pipelines, nil
+	}
+
+	cond := builder.NewCond()
+	for _, l := range latest {
+		cond = cond.Or(builder.Eq{"repo_id": l.RepoID, "number": l.Number})
+	}
+
+	return pipelines, s.engine.Where(cond).Find(&pipelines)
 }
 
 // GetActivePipelineList get all pipelines that are pending, running or blocked.

--- a/server/store/datastore/pipeline_test.go
+++ b/server/store/datastore/pipeline_test.go
@@ -307,3 +307,34 @@ func TestDeletePipeline(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, count)
 }
+
+// TestGetRepoLatestPipelinesUsesNumber checks a repo's latest pipeline is
+// picked by number rather than by id, in the case where the two sequences
+// disagree: the newest pipeline of each repo is given the lowest id. TiDB can
+// produce that state, as it allocates auto-increment values from per-node
+// caches instead of in insertion order.
+func TestGetRepoLatestPipelinesUsesNumber(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Pipeline))
+	defer closer()
+
+	assert.NoError(t, wrapInsert(store.engine.Insert([]*model.Pipeline{
+		{ID: 900, RepoID: 1, Number: 1, Status: model.StatusFailure},
+		{ID: 100, RepoID: 1, Number: 2, Status: model.StatusRunning},
+		{ID: 800, RepoID: 2, Number: 1, Status: model.StatusFailure},
+		{ID: 200, RepoID: 2, Number: 2, Status: model.StatusKilled},
+	})))
+
+	pipelines, err := store.GetRepoLatestPipelines([]int64{1, 2})
+	assert.NoError(t, err)
+	assert.Len(t, pipelines, 2)
+
+	latest := make(map[int64]*model.Pipeline, len(pipelines))
+	for _, pipeline := range pipelines {
+		latest[pipeline.RepoID] = pipeline
+	}
+
+	assert.EqualValues(t, 2, latest[1].Number)
+	assert.EqualValues(t, model.StatusRunning, latest[1].Status)
+	assert.EqualValues(t, 2, latest[2].Number)
+	assert.EqualValues(t, model.StatusKilled, latest[2].Status)
+}


### PR DESCRIPTION
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->

Two code paths resolved "the latest pipeline of a repo", and both take the highest `id`:

- `RepoListLatest` orders its join subquery by `pipelines.id DESC LIMIT 1`, serving `GET /user/feed?latest=true`.
- `GetRepoLatestPipelines` selects `MAX(id)` grouped by `repo_id`, serving `GET /user/repos`.

That treats the auto-increment primary key as a record of creation order. It is on a single-node engine, and may not be on a distributed one: TiDB allocates auto-increment values from per-node caches, so a pipeline created later can receive a lower id than an earlier one. Both endpoints then report a stale pipeline as the repo's latest, and the repo list shows its status and commit. We found such pattern in 35 repos out of 51.

`Pipeline.Number` is the true reliable key. `CreatePipeline` assigns it as `MAX(number) + 1` scoped to the repo, so the server controls it rather than the database, and `UNIQUE(repo_id, number)` already indexes it.

## Changes

`RepoListLatest` orders the subquery by `number` instead. It was already scoped to a single repo, so the column swap is the whole fix.

`GetRepoLatestPipelines` groups on `MAX(number)` and resolves the rows through `(repo_id, number)`. It stays two queries, as before, and each pair hits the unique index.

## Tests

`TestGetRepoLatestPipelinesUsesNumber` and `TestRepoListLatestUsesNumber` insert pipelines with ids set explicitly so the newest pipeline holds the lowest id. Both fail against the previous behaviour, returning the older pipeline, and pass with this change.

The existing tests build their fixtures through `CreatePipeline`, which advances ids and numbers together, so neither ordering could ever disagree in them.