### PR TITLE
Find the preceding pipeline by number instead of id

### DIFF
--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -452,7 +452,7 @@ func GetPipelineMetadata(c *gin.Context) {
 		return
 	}
 
-	prevPipeline, err := _store.GetPipelineLastBefore(repo, currentPipeline.Branch, currentPipeline.ID)
+	prevPipeline, err := _store.GetPipelineLastBefore(repo, currentPipeline.Branch, currentPipeline.Number)
 	if err != nil && !errors.Is(err, types.ErrRecordNotExist) {
 		handleDBError(c, err)
 		return

--- a/server/pipeline/items.go
+++ b/server/pipeline/items.go
@@ -43,7 +43,7 @@ func parsePipeline(ctx context.Context, forge forge.Forge, store store.Store, cu
 	}
 
 	// get the previous pipeline so that we can send status change notifications
-	prev, err := store.GetPipelineLastBefore(repo, currentPipeline.Branch, currentPipeline.ID)
+	prev, err := store.GetPipelineLastBefore(repo, currentPipeline.Branch, currentPipeline.Number)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Error().Err(err).Str("repo", repo.FullName).Msgf("error getting last pipeline before pipeline number '%d'", currentPipeline.Number)
 	}

--- a/server/pipeline/items_test.go
+++ b/server/pipeline/items_test.go
@@ -176,7 +176,7 @@ steps:
 	forge.On("URL").Return("https://github.com")
 
 	store := store_mocks.NewMockStore(t)
-	store.On("GetPipelineLastBefore", mock.Anything, mock.Anything, pipeline.ID).Return(&model.Pipeline{}, nil)
+	store.On("GetPipelineLastBefore", mock.Anything, mock.Anything, pipeline.Number).Return(&model.Pipeline{}, nil)
 
 	mockManager := manager_mocks.NewMockManager(t)
 	server.Config.Services.Manager = mockManager

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -57,11 +57,13 @@ func (s storage) GetPipelineLastByBranch(repo *model.Repo, branch string) (*mode
 		Get(pipeline))
 }
 
+// GetPipelineLastBefore returns the pipeline of a branch that precedes the
+// given pipeline number.
 func (s storage) GetPipelineLastBefore(repo *model.Repo, branch string, num int64) (*model.Pipeline, error) {
 	pipeline := new(model.Pipeline)
 	return pipeline, wrapGet(s.engine.
 		Desc("number").
-		Where(builder.Lt{"id": num}.
+		Where(builder.Lt{"number": num}.
 			And(builder.Eq{"repo_id": repo.ID, "branch": branch})).
 		Get(pipeline))
 }

--- a/server/store/datastore/pipeline_test.go
+++ b/server/store/datastore/pipeline_test.go
@@ -115,7 +115,7 @@ func TestPipelines(t *testing.T) {
 	}
 	require.NoError(t, store.CreatePipeline(pipeline3))
 
-	GetPipeline, err5 := store.GetPipelineLastBefore(&model.Repo{ID: 1}, pipeline3.Branch, pipeline3.ID)
+	GetPipeline, err5 := store.GetPipelineLastBefore(&model.Repo{ID: 1}, pipeline3.Branch, pipeline3.Number)
 	require.NoError(t, err5)
 	assert.EqualValues(t, pipeline2, GetPipeline)
 }
@@ -337,4 +337,27 @@ func TestGetRepoLatestPipelinesUsesNumber(t *testing.T) {
 	assert.EqualValues(t, model.StatusRunning, latest[1].Status)
 	assert.EqualValues(t, 2, latest[2].Number)
 	assert.EqualValues(t, model.StatusKilled, latest[2].Status)
+}
+
+// TestGetPipelineLastBeforeUsesNumber checks the preceding pipeline is found
+// by number, in the case where the two sequences disagree: the pipelines are
+// created in number order while their ids run the other way. TiDB can produce
+// that state, as it allocates auto-increment values from per-node caches
+// instead of in insertion order.
+func TestGetPipelineLastBeforeUsesNumber(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Repo), new(model.Pipeline))
+	defer closer()
+
+	repo := &model.Repo{ID: 1, Owner: "bradrydzewski", Name: "test", FullName: "bradrydzewski/test"}
+
+	assert.NoError(t, wrapInsert(store.engine.Insert([]*model.Pipeline{
+		{ID: 900, RepoID: repo.ID, Number: 1, Branch: "main", Status: model.StatusSuccess},
+		{ID: 800, RepoID: repo.ID, Number: 2, Branch: "main", Status: model.StatusFailure},
+		{ID: 700, RepoID: repo.ID, Number: 3, Branch: "main", Status: model.StatusRunning},
+	})))
+
+	previous, err := store.GetPipelineLastBefore(repo, "main", 3)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 2, previous.Number)
+	assert.EqualValues(t, model.StatusFailure, previous.Status)
 }


### PR DESCRIPTION
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->

`GetPipelineLastBefore` measures with two different rulers: it filters on `id` and orders by `number`.

```go
Desc("number").
Where(builder.Lt{"id": num}.
	And(builder.Eq{"repo_id": repo.ID, "branch": branch})).
```

Ordering by `number` is right — the server assigns numbers per repo in creation order. Filtering on `id` reaches into a different space: ids are global and handed out by the database. The query is only correct while those two rank a repo's pipelines identically, and nothing guarantees that they do.

TiDB breaks the ranking outright, allocating ids from per-node caches so a pipeline created later can hold a lower id; the filter then admits the wrong set and the query returns the highest `number` within it. And because the parameter is documented as a pipeline number, a caller that follows the documentation compares a per-repo number against global ids — wrong on every engine, including SQLite.

The surrounding code already reads as though the parameter were a number. `store.go` documents it as "gets the last pipeline before pipeline number N", the parameter is called `num`, and the caller in `server/pipeline/items.go` logs its own failure as `error getting last pipeline before pipeline number '%d'` using `currentPipeline.Number` — while passing `currentPipeline.ID` into the call. Switching the filter to `number` makes the query, the parameter name, the documentation and that log message agree.

## Changes

The filter becomes `Lt{"number": num}`, and both callers pass `currentPipeline.Number` instead of `currentPipeline.ID`. Both sides of the comparison are then values the server assigns, so the query no longer depends on how any database hands out ids. `(repo_id, number)` is already indexed as `UNIQUE(s)`, so the lookup is served by an index either way.

## Test

`TestGetPipelineLastBeforeUsesNumber` stores three pipelines on a branch whose numbers ascend while their ids descend, then asks for the one before number 3.

With the previous filter the test fails outright rather than returning the wrong row: the ids are 900, 800 and 700, so `WHERE id < 3` matches nothing and the query reports no record. With the fix it returns number 2.