### PR TITLE
Order the user feed by creation time instead of id

### DIFF
--- a/server/store/datastore/feed.go
+++ b/server/store/datastore/feed.go
@@ -64,7 +64,7 @@ func (s storage) UserFeed(user *model.User) ([]*model.Feed, error) {
 		Join("INNER", "perms", "repos.id = perms.repo_id").
 		Join("INNER", "pipelines", "repos.id = pipelines.repo_id").
 		Where(userPushOrAdminCondition(user.ID)).
-		Desc("pipelines.id").
+		Desc("pipelines.created", "pipelines.id").
 		Limit(perPage).
 		Find(&feed)
 

--- a/server/store/datastore/feed_test.go
+++ b/server/store/datastore/feed_test.go
@@ -242,3 +242,55 @@ func TestRepoListLatestUsesNumber(t *testing.T) {
 	assert.Len(t, pipelines, 1)
 	assert.EqualValues(t, model.StatusRunning, pipelines[0].Status)
 }
+
+// TestUserFeedOrdersByCreated checks the feed is ordered by creation time
+// rather than by id, in the case where the two sequences disagree: the newest
+// pipeline is given the lowest id. TiDB can produce that state, as it
+// allocates auto-increment values from per-node caches instead of in insertion
+// order.
+//
+// The feed is capped at perPage, so the order decides which pipelines are
+// returned at all, not only how they are arranged.
+func TestUserFeedOrdersByCreated(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Repo), new(model.User), new(model.Perm), new(model.Pipeline), new(model.Org))
+	defer closer()
+
+	user := &model.User{
+		Login:       "joe",
+		Email:       "foo@bar.com",
+		AccessToken: "e42080dddf012c718e476da161d21ad5",
+	}
+	assert.NoError(t, store.CreateUser(user))
+
+	repo := &model.Repo{
+		Owner:         "bradrydzewski",
+		Name:          "test",
+		FullName:      "bradrydzewski/test",
+		ForgeRemoteID: "1",
+		IsActive:      true,
+	}
+	assert.NoError(t, store.CreateRepo(repo))
+	assert.NoError(t, store.PermUpsert(&model.Perm{UserID: user.ID, RepoID: repo.ID, Push: true}))
+
+	assert.NoError(t, wrapInsert(store.engine.Insert([]*model.Pipeline{
+		{ID: 900, RepoID: repo.ID, Number: 1, Status: model.StatusSuccess},
+		{ID: 800, RepoID: repo.ID, Number: 2, Status: model.StatusFailure},
+		{ID: 700, RepoID: repo.ID, Number: 3, Status: model.StatusRunning},
+	})))
+
+	// xorm stamps `created` itself on insert, so set the wanted times after
+	for id, created := range map[int64]int64{900: 100, 800: 200, 700: 300} {
+		_, err := store.engine.Exec("UPDATE pipelines SET created = ? WHERE id = ?", created, id)
+		assert.NoError(t, err)
+	}
+
+	feed, err := store.UserFeed(user)
+	assert.NoError(t, err)
+
+	created := make([]int64, 0, len(feed))
+	for _, entry := range feed {
+		created = append(created, entry.Created)
+	}
+
+	assert.Equal(t, []int64{300, 200, 100}, created)
+}


### PR DESCRIPTION
<!--

Please check the following tips:
1. Avoid using force-push and commands that require it (such as `commit --amend` and `rebase origin/main`). This makes it more difficult for the maintainers to review your work. Add new commits on top of the current branch, and merge the new state of `main` into your branch with plain `merge`.
2. Provide a meaningful title for this pull request. It will be used as the commit message when this pull request is merged. Add as many commits as you like with any messages you like, they will be squashed into one commit.
3. If this pull request fixes an issue, refer to the issue with messages like `Closes #1234`, or `Fixes #1234` in the pull description.
4. Please check that you are targeting the `main` branch. Pull requests on release branches are only allowed for backports.
5. Make sure you have read contribution guidelines: https://woodpecker-ci.org/docs/development/getting-started
6. It is recommended to enable "Allow edits by maintainers", so maintainers can help you more easily.

-->

`UserFeed` was sorted by `pipelines.id`, treating the auto-increment primary key as a record of creation order. That holds on a single-node engine; distributed engines allocate ids from per-node caches, so a pipeline created later can hold a lower id.

The effect is not a visibly jumbled feed. `web/src/store/pipelines.ts` re-sorts whatever arrives by `created`:

```js
function comparePipelines(a, b) { return (b.created || -1) - (a.created || -1); }
```

So the display order is already right, and the server and the client simply disagree about what "most recent" means. What the client cannot fix is membership: the query is capped at `perPage`, so when `id` order diverges from `created` order the server returns the wrong 50 rows, and pipelines that belong in the feed are absent from it.

## Fix

Sort by `created`, which the UI already uses as the ordering key, with `id` as a tie-breaker — `created` has second resolution, so pipelines started together share a value and would have uncertain order otherwise.

## Test

`TestUserFeedOrdersByCreated` stores three pipelines whose creation times ascend while their ids descend. Against the previous behavior it fails with the feed exactly reversed, oldest first.