### PR TITLE
highlight the nodeSelector doesn't work by default

### DIFF
--- a/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
+++ b/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
@@ -158,6 +158,8 @@ And then overwrite the `nodeSelector` in the `backend_options` section of the st
 You can use [WOODPECKER_BACKEND_K8S_POD_NODE_SELECTOR](#backend_k8s_pod_node_selector) if you want to set the node selector per Agent
 or [PodNodeSelector](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podnodeselector) admission controller if you want to set the node selector by per-namespace basis.
 
+By default, setting `nodeSelector` from a step's backend options is **not allowed**, as it would otherwise let any user with push access pin pipeline pods onto chosen nodes. To enable it, set [`WOODPECKER_BACKEND_K8S_POD_NODE_SELECTOR_ALLOW_FROM_STEP`](#backend_k8s_pod_node_selector_allow_from_step) on the agent.
+
 ### Tolerations
 
 When you use `nodeSelector` and the node pool is configured with Taints, you need to specify the Tolerations. Tolerations allow the scheduler to schedule Pods with matching taints.


### PR DESCRIPTION
https://github.com/woodpecker-ci/woodpecker/pull/6809 introduced a new environment variable that disables the ability to use `nodeSelector` by default but didn't highlight that in the `nodeSelector` documentation.

This resulted in a brief prod outage where our ARM64 architecture images were being built on AMD64 architecture workers, resulting in unavailable images 😞 

This PR just adds documentation indicating the presence of the necessary gate environment variable.