### PR TITLE
server: drop stale queued tasks for terminal workflows

### DIFF
--- a/server/queue/persistent.go
+++ b/server/queue/persistent.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 
@@ -40,6 +41,21 @@ func WithTaskStore(ctx context.Context, q Queue, s store.Store) Queue {
 type persistentQueue struct {
 	Queue
 	store store.Store
+}
+
+func isTerminalWorkflowState(state model.StatusValue) bool {
+	switch state {
+	case model.StatusSuccess,
+		model.StatusFailure,
+		model.StatusKilled,
+		model.StatusCanceled,
+		model.StatusSkipped,
+		model.StatusError,
+		model.StatusDeclined:
+		return true
+	default:
+		return false
+	}
 }
 
 // PushAtOnce pushes multiple tasks to the tail of this queue.
@@ -81,9 +97,58 @@ func (q *persistentQueue) Poll(c context.Context, agentID int64, f func(*model.T
 			log.Error().Err(deleteErr).Msgf("pull queue item: %s: failed to remove from backup", task.ID)
 		} else {
 			log.Debug().Msgf("pull queue item: %s: successfully removed from backup", task.ID)
+
+			workflowID, parseErr := strconv.ParseInt(task.ID, 10, 64)
+			if parseErr != nil {
+				log.Error().Err(parseErr).Msgf("pull queue item: %s: invalid workflow id", task.ID)
+				return task, err
+			}
+
+			workflow, loadErr := q.store.WorkflowLoad(workflowID)
+			if loadErr != nil {
+				if errors.Is(loadErr, types.ErrRecordNotExist) {
+					// A queued task without its workflow can never be initialized.
+					// Drop it now instead of letting the agent reject and later
+					// re-poll the same task after its lease expires.
+					log.Error().Err(loadErr).Msgf("pull queue item: %s: workflow missing, dropping stale task", task.ID)
+					if dropErr := q.Queue.Error(c, task.ID, loadErr); dropErr != nil {
+						log.Error().Err(dropErr).Msgf("pull queue item: %s: failed to drop stale task", task.ID)
+					}
+					return nil, nil
+				}
+				log.Error().Err(loadErr).Msgf("pull queue item: %s: failed to load workflow", task.ID)
+				return task, err
+			}
+
+			if isTerminalWorkflowState(workflow.State) {
+				// The task can still exist in the persistent queue while its
+				// workflow was completed through another path. Returning it to an
+				// agent makes RPC.Init reject it as already finished, while the
+				// in-memory task remains running and is resubmitted after timeout.
+				log.Warn().Str("state", string(workflow.State)).Msgf("pull queue item: %s: workflow already terminal, dropping stale task", task.ID)
+				if dropErr := q.Queue.Done(c, task.ID, workflow.State); dropErr != nil {
+					log.Error().Err(dropErr).Msgf("pull queue item: %s: failed to drop terminal task", task.ID)
+				}
+				return nil, nil
+			}
 		}
 	}
 	return task, err
+}
+
+// Done signals the task is complete.
+func (q *persistentQueue) Done(c context.Context, id string, exitStatus model.StatusValue) error {
+	if err := q.Queue.Done(c, id, exitStatus); err != nil {
+		return err
+	}
+
+	if deleteErr := q.store.TaskDelete(id); deleteErr != nil {
+		if !errors.Is(deleteErr, types.ErrRecordNotExist) {
+			return deleteErr
+		}
+		log.Debug().Msgf("task %s already removed from store", id)
+	}
+	return nil
 }
 
 // Error signals the task is done with an error.

--- a/server/queue/persistent_test.go
+++ b/server/queue/persistent_test.go
@@ -48,13 +48,73 @@ func TestPersistentQueuePollDropsStaleTask(t *testing.T) {
 	assert.Equal(t, 0, info.Stats.Running, "stale task must be removed from running")
 }
 
-// A task that is still present in the backup store is polled normally.
+func TestPersistentQueuePollDropsTaskWithMissingWorkflow(t *testing.T) {
+	ctx, cancel, q := setupTestQueue(t)
+	defer cancel(nil)
+
+	store := store_mocks.NewMockStore(t)
+	store.EXPECT().TaskDelete("1").Return(nil).Once()
+	store.EXPECT().WorkflowLoad(int64(1)).Return(nil, types.ErrRecordNotExist).Once()
+
+	pq := &persistentQueue{Queue: q, store: store}
+
+	task := genDummyTask()
+	assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{task}))
+
+	got, err := pq.Poll(ctx, 1, filterFnTrue)
+	assert.NoError(t, err)
+	assert.Nil(t, got, "task without a workflow must not be returned to the agent")
+
+	info := q.Info(ctx)
+	assert.Equal(t, 0, info.Stats.Pending)
+	assert.Equal(t, 0, info.Stats.Running)
+}
+
+func TestPersistentQueuePollDropsTerminalWorkflowTask(t *testing.T) {
+	terminalStates := []model.StatusValue{
+		model.StatusSuccess,
+		model.StatusFailure,
+		model.StatusKilled,
+		model.StatusCanceled,
+		model.StatusSkipped,
+		model.StatusError,
+		model.StatusDeclined,
+	}
+
+	for _, state := range terminalStates {
+		t.Run(string(state), func(t *testing.T) {
+			ctx, cancel, q := setupTestQueue(t)
+			defer cancel(nil)
+
+			store := store_mocks.NewMockStore(t)
+			store.EXPECT().TaskDelete("1").Return(nil).Once()
+			store.EXPECT().WorkflowLoad(int64(1)).Return(&model.Workflow{ID: 1, State: state}, nil).Once()
+
+			pq := &persistentQueue{Queue: q, store: store}
+
+			task := genDummyTask()
+			assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{task}))
+
+			got, err := pq.Poll(ctx, 1, filterFnTrue)
+			assert.NoError(t, err)
+			assert.Nil(t, got, "terminal workflow task must not be returned to the agent")
+
+			info := q.Info(ctx)
+			assert.Equal(t, 0, info.Stats.Pending)
+			assert.Equal(t, 0, info.Stats.Running)
+		})
+	}
+}
+
+// A task that is still present in the backup store and whose workflow is still
+// active is polled normally.
 func TestPersistentQueuePollReturnsLiveTask(t *testing.T) {
 	ctx, cancel, q := setupTestQueue(t)
 	defer cancel(nil)
 
 	store := store_mocks.NewMockStore(t)
 	store.EXPECT().TaskDelete("1").Return(nil).Once()
+	store.EXPECT().WorkflowLoad(int64(1)).Return(&model.Workflow{ID: 1, State: model.StatusPending}, nil).Once()
 
 	pq := &persistentQueue{Queue: q, store: store}
 
@@ -65,4 +125,46 @@ func TestPersistentQueuePollReturnsLiveTask(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, got)
 	assert.Equal(t, "1", got.ID)
+}
+
+func TestPersistentQueueDoneRemovesPendingTaskFromBackup(t *testing.T) {
+	ctx, cancel, q := setupTestQueue(t)
+	defer cancel(nil)
+
+	store := store_mocks.NewMockStore(t)
+	store.EXPECT().TaskDelete("1").Return(nil).Once()
+
+	pq := &persistentQueue{Queue: q, store: store}
+
+	task := genDummyTask()
+	assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{task}))
+	assert.NoError(t, pq.Done(ctx, task.ID, model.StatusSuccess))
+
+	info := q.Info(ctx)
+	assert.Equal(t, 0, info.Stats.Pending)
+	assert.Equal(t, 0, info.Stats.Running)
+}
+
+func TestPersistentQueueDoneIgnoresAlreadyRemovedBackupTask(t *testing.T) {
+	ctx, cancel, q := setupTestQueue(t)
+	defer cancel(nil)
+
+	store := store_mocks.NewMockStore(t)
+	store.EXPECT().TaskDelete("1").Return(nil).Once()
+	store.EXPECT().WorkflowLoad(int64(1)).Return(&model.Workflow{ID: 1, State: model.StatusPending}, nil).Once()
+	store.EXPECT().TaskDelete("1").Return(types.ErrRecordNotExist).Once()
+
+	pq := &persistentQueue{Queue: q, store: store}
+
+	task := genDummyTask()
+	assert.NoError(t, q.PushAtOnce(ctx, []*model.Task{task}))
+
+	got, err := pq.Poll(ctx, 1, filterFnTrue)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.NoError(t, pq.Done(ctx, task.ID, model.StatusSuccess))
+
+	info := q.Info(ctx)
+	assert.Equal(t, 0, info.Stats.Pending)
+	assert.Equal(t, 0, info.Stats.Running)
 }


### PR DESCRIPTION
## What does this PR do?

Prevents stale tasks from being handed to agents when their workflow is already
in a terminal state or no longer exists.

The persistent queue can contain a task that is still present in the task store
while the corresponding workflow has already been completed through another
path. In that case, the task may be polled again, `RPC.Init` rejects it because
the workflow is already finished, and the task can later be resubmitted after
its lease expires.

This change makes the persistent queue verify the workflow before returning a
task to an agent.

It also ensures that `persistentQueue.Done()` removes the task from the
persistent task store.

## Changes

- drop queued tasks whose workflow no longer exists;
- drop queued tasks whose workflow is already in a terminal state;
- remove completed tasks from the persistent task store in `Done()`;
- keep active/pending workflow tasks working as before;
- add regression tests for:
  - missing workflows;
  - success;
  - failure;
  - killed;
  - canceled;
  - skipped;
  - error;
  - declined;
  - persistent task cleanup on `Done()`.

## Why?

This prevents stale queue entries from being repeatedly assigned to agents and
avoids a loop where an already-finished workflow is polled, rejected by
`RPC.Init`, and later resubmitted.

This complements #6765, which handles the opposite stale-queue case where the
task is already missing from the persistent store but is still present in the
in-memory queue.

## Testing

Added unit tests in `server/queue/persistent_test.go` covering terminal workflow
states, missing workflows, normal active workflow polling, and task-store
cleanup after `Done()`.
