### PR TITLE
k8s backend: fix step example using incorrect "detached" property

### DIFF
--- a/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
+++ b/docs/docs/30-administration/10-configuration/11-backends/20-kubernetes.md
@@ -487,7 +487,7 @@ steps:
 
   - name: docker
     image: docker:dind # use 'docker:<major-version>-dind' or similar in production
-    detached: true
+    detach: true
     privileged: true
     environment:
       DOCKER_TLS_CERTDIR: /woodpecker/dind-certs


### PR DESCRIPTION
I was following the kubernetes backend documentation and noticed that my "service" (docker:dind) wasn't actually running in the background. I realized that's because the examples uses `detached: true` instead of **detach** (I've verified [here](https://github.com/woodpecker-ci/woodpecker/blob/f1ae0817bd282bde23cebf44f14cf382b15b22cf/pipeline/backend/types/step.go#L25))