### PR TITLE
fix(gitlab): skip projects on membership lookup 404 errors

### DIFF
--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -314,9 +314,12 @@ func (g *GitLab) Repos(ctx context.Context, user *model.User, p *model.ListOptio
 		// The projects list API already reports the current user's access level
 		var projectMember *gitlab.ProjectMember
 		if embeddedAccessLevel(project) == gitlab.NoPermissions {
-			var err error
-			projectMember, _, err = client.ProjectMembers.GetInheritedProjectMember(project.ID, int64(intUserID), gitlab.WithContext(ctx))
+			var resp *gitlab.Response
+			projectMember, resp, err = client.ProjectMembers.GetInheritedProjectMember(project.ID, int64(intUserID), gitlab.WithContext(ctx))
 			if err != nil {
+				if resp != nil && resp.StatusCode == http.StatusNotFound {
+					continue
+				}
 				return nil, err
 			}
 		}
@@ -329,7 +332,7 @@ func (g *GitLab) Repos(ctx context.Context, user *model.User, p *model.ListOptio
 		repos = append(repos, repo)
 	}
 
-	return repos, err
+	return repos, nil
 }
 
 func (g *GitLab) PullRequests(ctx context.Context, u *model.User, r *model.Repo, p *model.ListOptions) ([]*model.PullRequest, error) {

--- a/server/forge/gitlab/gitlab_test.go
+++ b/server/forge/gitlab/gitlab_test.go
@@ -692,3 +692,29 @@ func TestGitLabReposUsesEmbeddedPermissions(t *testing.T) {
 	assert.True(t, repos[1].Perm.Push)
 	assert.False(t, repos[1].Perm.Admin)
 }
+
+func TestGitLabReposSkipsProjectOnMembershipLookupNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[` +
+			`{"id":4,"path_with_namespace":"diaspora/diaspora-client","visibility":"private","permissions":` +
+			`{"project_access":{"access_level":40},"group_access":null}},` +
+			`{"id":7,"path_with_namespace":"other/personal-project","visibility":"private","permissions":null}` +
+			`]`))
+	})
+	mux.HandleFunc("/api/v4/projects/7/members/all/3", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "404 Not Found", http.StatusNotFound)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := load(server.URL + "?client_id=test&client_secret=test")
+	user := model.User{Login: "test_user", AccessToken: "token", ForgeRemoteID: "3"}
+
+	repos, err := client.Repos(t.Context(), &user, &model.ListOptions{Page: 1, PerPage: 10})
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+
+	assert.Equal(t, "diaspora/diaspora-client", repos[0].FullName)
+}


### PR DESCRIPTION
## What

When listing repos from a GitLab forge, projects that the user has no access to (or projects with deleted/restricted memberships) make the membership lookup return 404. Instead of failing the whole list, skip such projects and keep returning the repos we can resolve.

## Why

Fixes the GitLab admin login / repo list returning a 404 error when the forge contains projects the authenticated user cannot see.

## Test

Added `TestGitLabReposSkipsProjectOnMembershipLookupNotFound` to cover the 404 skip path.