### PR TITLE
perf(pipeline): post per-workflow commit statuses once and concurrently

### DIFF
--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -117,7 +117,9 @@ func PostHook(c *gin.Context) {
 	// 2. Parse the webhook data
 	//
 
+	hookParseStart := time.Now()
 	repoFromForge, pipelineFromForge, err := _forge.Hook(c, c.Request)
+	hookParseDuration := time.Since(hookParseStart)
 	if err != nil {
 		if errors.Is(err, &types.ErrIgnoreEvent{}) {
 			msg := fmt.Sprintf("forge driver: %s", err)
@@ -217,6 +219,8 @@ func PostHook(c *gin.Context) {
 	// respond synchronously with the created pipeline (preserving the old
 	// behavior and API response). If it takes longer we respond 202 Accepted and
 	// let creation finish in the background.
+	log.Debug().Str("repo", repo.FullName).Dur("hook_parse", hookParseDuration).Msg("webhook parse timing")
+
 	bgCtx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), backgroundPipelineCreationTimeout)
 
 	done := make(chan struct{})

--- a/server/pipeline/approve.go
+++ b/server/pipeline/approve.go
@@ -75,14 +75,18 @@ func Approve(ctx context.Context, store store.Store, currentPipeline *model.Pipe
 		return nil, fmt.Errorf("error updating pipeline. %w", err)
 	}
 
-	publishPipeline(ctx, forge, currentPipeline, repo, user)
+	// the forge statuses are posted by start() right after
+	publishPipelineEvent(ctx, currentPipeline, repo)
 
-	currentPipeline, err = start(ctx, forge, store, currentPipeline, user, repo, pipelineItems)
+	startedPipeline, err := start(ctx, forge, store, currentPipeline, user, repo, pipelineItems)
 	if err != nil {
 		msg := fmt.Sprintf("failure to start pipeline for %s: %v", repo.FullName, err)
 		log.Error().Err(err).Msg(msg)
+		if uErr := updatePipelineWithErr(ctx, forge, store, currentPipeline, repo, user, err); uErr != nil {
+			log.Error().Err(uErr).Msgf("error setting error status of pipeline for %s#%d", repo.FullName, currentPipeline.Number)
+		}
 		return nil, errors.New(msg)
 	}
 
-	return currentPipeline, nil
+	return startedPipeline, nil
 }

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -74,8 +75,10 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 	}
 
 	// fetch the pipeline file from the forge
+	phaseStart := time.Now()
 	configService := server.Config.Services.Manager.ConfigServiceFromRepo(repo)
 	forgeYamlConfigs, configFetchErr := configService.Fetch(ctx, _forge, repoUser, repo, pipeline, nil, false)
+	configFetchDuration := time.Since(phaseStart)
 	switch {
 	case errors.Is(configFetchErr, &forge_types.ErrConfigNotFound{}):
 		log.Debug().Str("repo", repo.FullName).Err(configFetchErr).Msgf("cannot find config '%s' in '%s' with user: '%s'", repo.Config, pipeline.Ref, repoUser.Login)
@@ -111,7 +114,9 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		return nil, errors.New(msg)
 	}
 
+	phaseStart = time.Now()
 	currentPipeline, pipelineItems, parseErr, err := createPipelineItems(ctx, _forge, _store, pipeline, repoUser, repo, forgeYamlConfigs, nil, false)
+	compileDuration := time.Since(phaseStart)
 	*pipeline = *currentPipeline
 	if handleParseErrors(pipeline, parseErr) {
 		log.Debug().Str("repo", repo.FullName).Err(parseErr).Msg("failed to parse yaml")
@@ -130,22 +135,38 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		return nil, ErrFiltered
 	}
 
+	phaseStart = time.Now()
 	publishPipeline(ctx, _forge, pipeline, repo, repoUser)
+	publishDuration := time.Since(phaseStart)
 
 	if pipeline.Status == model.StatusBlocked {
 		return pipeline, nil
 	}
 
+	phaseStart = time.Now()
 	if err := updatePipelinePending(ctx, _forge, _store, pipeline, repo, repoUser); err != nil {
 		return nil, err
 	}
+	pendingDuration := time.Since(phaseStart)
 
+	phaseStart = time.Now()
 	pipeline, err = start(ctx, _forge, _store, pipeline, repoUser, repo, pipelineItems)
 	if err != nil {
 		msg := fmt.Sprintf("failed to start pipeline for %s", repo.FullName)
 		log.Error().Err(err).Msg(msg)
 		return nil, errors.New(msg)
 	}
+
+	log.Debug().
+		Str("repo", repo.FullName).
+		Int64("pipeline", pipeline.Number).
+		Int("workflows", len(pipeline.Workflows)).
+		Dur("config_fetch", configFetchDuration).
+		Dur("compile", compileDuration).
+		Dur("publish_created", publishDuration).
+		Dur("publish_pending", pendingDuration).
+		Dur("start", time.Since(phaseStart)).
+		Msg("pipeline creation timing")
 
 	return pipeline, nil
 }

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -136,26 +136,34 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 	}
 
 	phaseStart = time.Now()
-	publishPipeline(ctx, _forge, pipeline, repo, repoUser)
-	publishDuration := time.Since(phaseStart)
+	publishPipelineEvent(ctx, pipeline, repo)
 
 	if pipeline.Status == model.StatusBlocked {
+		// blocked pipelines never reach start(), so their statuses are posted here
+		updatePipelineStatus(ctx, _forge, pipeline, repo, repoUser)
 		return pipeline, nil
 	}
+	publishDuration := time.Since(phaseStart)
 
 	phaseStart = time.Now()
-	if err := updatePipelinePending(ctx, _forge, _store, pipeline, repo, repoUser); err != nil {
+	if err := updatePipelinePending(ctx, _store, pipeline, repo); err != nil {
 		return nil, err
 	}
 	pendingDuration := time.Since(phaseStart)
 
 	phaseStart = time.Now()
-	pipeline, err = start(ctx, _forge, _store, pipeline, repoUser, repo, pipelineItems)
+	startedPipeline, err := start(ctx, _forge, _store, pipeline, repoUser, repo, pipelineItems)
 	if err != nil {
 		msg := fmt.Sprintf("failed to start pipeline for %s", repo.FullName)
 		log.Error().Err(err).Msg(msg)
+		// transition the pipeline to error and post the statuses, so neither the
+		// pipeline nor the commit is stuck in a pending state forever
+		if uErr := updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, err); uErr != nil {
+			log.Error().Err(uErr).Msgf("error setting error status of pipeline for %s#%d", repo.FullName, pipeline.Number)
+		}
 		return nil, errors.New(msg)
 	}
+	pipeline = startedPipeline
 
 	log.Debug().
 		Str("repo", repo.FullName).
@@ -179,12 +187,38 @@ func updatePipelineWithErr(ctx context.Context, _forge forge.Forge, _store store
 	// update value in ref
 	*pipeline = *_pipeline
 
+	// transition the persisted workflows as well: forges post the workflow
+	// states as commit statuses, so leaving them pending would publish
+	// statuses that never resolve
+	for _, workflow := range pipeline.Workflows {
+		if workflow.State != model.StatusPending {
+			continue
+		}
+		workflow.State = model.StatusError
+		workflow.Finished = pipeline.Finished
+		if uErr := _store.WorkflowUpdate(workflow); uErr != nil {
+			log.Error().Err(uErr).Msgf("cannot update workflow with id %d state", workflow.ID)
+		}
+
+		// the steps of an errored workflow would stay pending forever otherwise
+		for _, step := range workflow.Children {
+			if step.State != model.StatusPending {
+				continue
+			}
+			step.State = model.StatusError
+			step.Finished = pipeline.Finished
+			if uErr := _store.StepUpdate(step); uErr != nil {
+				log.Error().Err(uErr).Msgf("cannot update step with id %d state", step.ID)
+			}
+		}
+	}
+
 	publishPipeline(ctx, _forge, pipeline, repo, repoUser)
 
 	return nil
 }
 
-func updatePipelinePending(ctx context.Context, _forge forge.Forge, _store store.Store, pipeline *model.Pipeline, repo *model.Repo, repoUser *model.User) error {
+func updatePipelinePending(ctx context.Context, _store store.Store, pipeline *model.Pipeline, repo *model.Repo) error {
 	_pipeline, err := UpdateToStatusPending(_store, *pipeline, "")
 	if err != nil {
 		return err
@@ -192,7 +226,8 @@ func updatePipelinePending(ctx context.Context, _forge forge.Forge, _store store
 	// update value in ref
 	*pipeline = *_pipeline
 
-	publishPipeline(ctx, _forge, pipeline, repo, repoUser)
+	// the forge statuses are posted by start() right after
+	publishPipelineEvent(ctx, pipeline, repo)
 
 	return nil
 }

--- a/server/pipeline/helper.go
+++ b/server/pipeline/helper.go
@@ -16,6 +16,8 @@ package pipeline
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 
 	"github.com/rs/zerolog/log"
 
@@ -23,12 +25,47 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 )
 
+// maxConcurrentStatusUpdates bounds the parallel commit-status calls per
+// pipeline. Forges rate limit concurrent writes from a single user much more
+// aggressively than sequential ones, so this stays deliberately low: it is
+// enough to keep pipelines with many workflows from taking tens of seconds,
+// without looking like a burst.
+const maxConcurrentStatusUpdates = 4
+
+// updatePipelineStatus posts one commit status per workflow. Every workflow is
+// attempted even if some fail, so a single forge error cannot leave the
+// remaining workflows without a status.
 func updatePipelineStatus(ctx context.Context, forge forge.Forge, pipeline *model.Pipeline, repo *model.Repo, user *model.User) {
+	// setting one status per workflow sequentially delays pipelines with many
+	// workflows by tens of seconds, so post them with bounded concurrency
+	var wg sync.WaitGroup
+	var failed atomic.Int64
+	sem := make(chan struct{}, maxConcurrentStatusUpdates)
+
 	for _, workflow := range pipeline.Workflows {
-		err := forge.Status(ctx, user, repo, pipeline, workflow)
-		if err != nil {
-			log.Error().Err(err).Msgf("error setting commit status for %s/%d", repo.FullName, pipeline.Number)
-			return
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				failed.Add(1)
+				return
+			}
+
+			if err := forge.Status(ctx, user, repo, pipeline, workflow); err != nil {
+				failed.Add(1)
+				log.Error().Err(err).Msgf("error setting commit status for %s/%d", repo.FullName, pipeline.Number)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// individual failures are logged above, but a pipeline whose statuses all
+	// failed is invisible on the forge and must not be silent
+	if n := failed.Load(); n > 0 {
+		log.Error().Msgf("failed to set %d of %d commit statuses for %s/%d", n, len(pipeline.Workflows), repo.FullName, pipeline.Number)
 	}
 }

--- a/server/pipeline/restart.go
+++ b/server/pipeline/restart.go
@@ -106,16 +106,20 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 		return nil, errors.New(msg)
 	}
 
-	publishPipeline(ctx, forge, newPipeline, repo, user)
+	// the forge statuses are posted by start() right after
+	publishPipelineEvent(ctx, newPipeline, repo)
 
-	newPipeline, err = start(ctx, forge, store, newPipeline, user, repo, pipelineItems)
+	startedPipeline, err := start(ctx, forge, store, newPipeline, user, repo, pipelineItems)
 	if err != nil {
 		msg := fmt.Sprintf("failure to start pipeline for %s", repo.FullName)
 		log.Error().Err(err).Msg(msg)
+		if uErr := updatePipelineWithErr(ctx, forge, store, newPipeline, repo, user, err); uErr != nil {
+			log.Error().Err(uErr).Msgf("error setting error status of pipeline for %s#%d", repo.FullName, newPipeline.Number)
+		}
 		return nil, errors.New(msg)
 	}
 
-	return newPipeline, nil
+	return startedPipeline, nil
 }
 
 func linkPipelineConfigs(store store.Store, configs []*model.Config, pipelineID int64) error {

--- a/server/pipeline/start.go
+++ b/server/pipeline/start.go
@@ -51,8 +51,16 @@ func start(ctx context.Context, forge forge.Forge, store store.Store, activePipe
 }
 
 func publishPipeline(ctx context.Context, forge forge.Forge, pipeline *model.Pipeline, repo *model.Repo, repoUser *model.User) {
+	publishPipelineEvent(ctx, pipeline, repo)
+	updatePipelineStatus(ctx, forge, pipeline, repo, repoUser)
+}
+
+// publishPipelineEvent informs UI subscribers about a pipeline change without
+// posting commit statuses to the forge. Pre-start pipeline transitions use it
+// so the forge statuses of a pipeline with many workflows are only posted
+// once, by start().
+func publishPipelineEvent(ctx context.Context, pipeline *model.Pipeline, repo *model.Repo) {
 	if err := server.Config.Services.Scheduler.PublishPipelineEvent(ctx, repo, pipeline); err != nil {
 		log.Error().Err(err).Msg("could not push pipeline status change to pubsub provider")
 	}
-	updatePipelineStatus(ctx, forge, pipeline, repo, repoUser)
 }


### PR DESCRIPTION
Split out of #6851 as requested — this PR carries only the pipeline status-posting changes, rebased onto current `main`. The GraphQL config fetch is in a separate PR.

Two related changes to the pipeline creation path, motivated by a production instance running pipelines with 60+ workflows.

### 1. Post per-workflow commit statuses concurrently

`updatePipelineStatus` posted one status per workflow sequentially. For a pipeline with 63 workflows that alone takes tens of seconds. Statuses are now posted with a bounded concurrency of 4 — deliberately low, since forges rate limit concurrent writes from a single user far more aggressively than sequential ones.

This also fixes an inconsistency: the old loop aborted on the first error, leaving every remaining workflow without a status. Now every workflow is attempted, individual failures are logged, and a summary is logged if any failed — so a pipeline whose statuses all failed is no longer silent.

### 2. Post forge statuses only once before start

Pipeline creation posted the full set of per-workflow statuses **three times** before the pipeline started — after compile, on the pending transition, and again in `start()` — all with identical pending state. The approval and restart flows had the same double-posting.

The pubsub events are kept for the UI, but forge statuses are now posted once, in `start()`. Blocked pipelines post their round in the blocked branch, since they never reach `start()`.

Combined effect of 1 + 2 measured on our instance (63-workflow pipeline, webhook to first workflow start): **~91s median → ~2s**. That measurement was taken at a concurrency of 10; it is 4 here, so expect a slightly higher number — the bulk of the win comes from dropping two of the three redundant rounds.

### Failure-path hardening

Previously a failure in `start()` left the pipeline pending forever with pending commit statuses. Now the pipeline, its workflows **and their steps** transition to error and terminal statuses are posted, matching the existing pattern in `decline.go`.

A per-phase timing summary (hook parse, config fetch, compile, status publishing, start) is logged at debug level to locate remaining latency.
