### PR TITLE
perf(github): fetch config directories with a single GraphQL request

### DIFF
--- a/server/forge/github/fixtures/handler.go
+++ b/server/forge/github/fixtures/handler.go
@@ -16,6 +16,7 @@ package fixtures
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -30,10 +31,69 @@ func Handler() http.Handler {
 	e.GET("/api/v3/repositories/:id", getRepoByID)
 	e.GET("/api/v3/orgs/:org/memberships/:user", getMembership)
 	e.GET("/api/v3/user/memberships/orgs/:org", getMembership)
+	e.POST("/api/graphql", graphqlDir)
+	e.GET("/api/v3/repos/:owner/:name/contents/*path", getContents)
 
 	return e
 }
 
+// graphqlDir mocks the single-request directory fetch used by Dir.
+func graphqlDir(c *gin.Context) {
+	if !strings.HasPrefix(c.GetHeader("Authorization"), "Bearer ") {
+		c.String(http.StatusUnauthorized, "")
+		return
+	}
+	var req struct {
+		Variables struct {
+			Expression string `json:"expression"`
+		} `json:"variables"`
+	}
+	_ = c.ShouldBindJSON(&req)
+	switch {
+	case strings.HasSuffix(req.Variables.Expression, ":somedir"):
+		c.String(http.StatusOK, `{"data": {"repository": {"object": {"__typename": "Tree", "entries": [
+			{"name": "a.yaml", "type": "blob", "mode": 33188, "object": {"text": "pipeline:", "isTruncated": false, "isBinary": false}},
+			{"name": "sub", "type": "tree", "mode": 16384, "object": {}}
+		]}}}}`)
+	case strings.HasSuffix(req.Variables.Expression, ":symlink-dir"):
+		// symlink blobs carry the link target as text, the forge must fall
+		// back to the REST path which resolves them
+		c.String(http.StatusOK, `{"data": {"repository": {"object": {"__typename": "Tree", "entries": [
+			{"name": "link.yaml", "type": "blob", "mode": 40960, "object": {"text": "../target.yaml", "isTruncated": false, "isBinary": false}}
+		]}}}}`)
+	case strings.HasSuffix(req.Variables.Expression, ":rest-fallback-dir"):
+		// force the caller onto the per-file REST fallback
+		c.String(http.StatusBadGateway, "")
+	case strings.HasSuffix(req.Variables.Expression, ":null-repo-dir"):
+		// a 200 that carries no repository object at all: this must not be
+		// mistaken for "the path does not exist"
+		c.String(http.StatusOK, `{"data": {"repository": null}}`)
+	default:
+		c.String(http.StatusOK, `{"data": {"repository": {"object": null}}}`)
+	}
+}
+
+// getContents serves the per-file REST fallback.
+func getContents(c *gin.Context) {
+	if !strings.HasPrefix(c.GetHeader("Authorization"), "Bearer ") {
+		c.String(http.StatusUnauthorized, "")
+		return
+	}
+	if strings.HasSuffix(c.Param("path"), "rest-fallback-dir") {
+		c.String(http.StatusOK, `[{"type": "file", "name": "b.yaml", "path": "rest-fallback-dir/b.yaml"}, {"type": "dir", "name": "nested", "path": "rest-fallback-dir/nested"}]`)
+		return
+	}
+	if strings.HasSuffix(c.Param("path"), "null-repo-dir") {
+		c.String(http.StatusOK, `[{"type": "file", "name": "c.yaml", "path": "null-repo-dir/c.yaml"}]`)
+		return
+	}
+	if strings.HasSuffix(c.Param("path"), "symlink-dir") {
+		c.String(http.StatusOK, `[{"type": "symlink", "name": "link.yaml", "path": "symlink-dir/link.yaml"}]`)
+		return
+	}
+	// base64 of "pipeline:"
+	c.String(http.StatusOK, `{"type": "file", "encoding": "base64", "name": "config", "content": "cGlwZWxpbmU6"}`)
+}
 func getRepo(c *gin.Context) {
 	switch c.Param("name") {
 	case "repo_not_found":

--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -287,6 +287,18 @@ func (c *client) File(ctx context.Context, u *model.User, r *model.Repo, b *mode
 }
 
 func (c *client) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model.Pipeline, f string) ([]*forge_types.FileMeta, error) {
+	// fetch the whole directory with a single GraphQL request: fetching one
+	// file per request multiplies both the latency and the exposure to
+	// transient forge errors for directories with many files
+	dirFiles, err := c.dirFromGraphQL(ctx, u.AccessToken, r.Owner, r.Name, b.Commit, f)
+	if err == nil {
+		return dirFiles, nil
+	}
+	if errors.Is(err, &forge_types.ErrConfigNotFound{}) {
+		return nil, err
+	}
+	log.Debug().Err(err).Msgf("github: graphql fetch of directory %s failed, falling back to fetching per file", f)
+
 	client, err := c.newClientToken(ctx, u.AccessToken)
 	if err != nil {
 		return nil, err
@@ -302,10 +314,18 @@ func (c *client) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model
 		return nil, err
 	}
 
+	// directories are not descended into, like in the single-request fetch
+	entries := make([]*github.RepositoryContent, 0, len(data))
+	for _, file := range data {
+		if file.GetType() != "dir" {
+			entries = append(entries, file)
+		}
+	}
+
 	fc := make(chan *forge_types.FileMeta)
 	errChan := make(chan error)
 
-	for _, file := range data {
+	for _, file := range entries {
 		go func(path string) {
 			content, err := c.File(ctx, u, r, b, path)
 			if err != nil {
@@ -324,7 +344,7 @@ func (c *client) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model
 
 	var files []*forge_types.FileMeta
 
-	for range data {
+	for range entries {
 		select {
 		case err := <-errChan:
 			return nil, err

--- a/server/forge/github/github_test.go
+++ b/server/forge/github/github_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/github/fixtures"
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	"go.woodpecker-ci.org/woodpecker/v3/server/store"
 	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
@@ -94,6 +95,48 @@ func Test_github(t *testing.T) {
 	t.Run("repo not found error", func(t *testing.T) {
 		_, err := c.Repo(ctx, fakeUser, "0", fakeRepoNotFound.Owner, fakeRepoNotFound.Name)
 		assert.Error(t, err)
+	})
+
+	t.Run("dir is fetched with a single graphql request", func(t *testing.T) {
+		files, err := c.Dir(ctx, fakeUser, fakeRepo, &model.Pipeline{Commit: "abc123"}, "somedir")
+		assert.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, "somedir/a.yaml", files[0].Name)
+		assert.Equal(t, "pipeline:", string(files[0].Data))
+	})
+
+	t.Run("dir returns config-not-found for missing directories", func(t *testing.T) {
+		_, err := c.Dir(ctx, fakeUser, fakeRepo, &model.Pipeline{Commit: "abc123"}, "no-such-dir")
+		assert.ErrorIs(t, err, &forge_types.ErrConfigNotFound{})
+	})
+
+	t.Run("dir with symlinks falls back to per-file fetching", func(t *testing.T) {
+		// the graphql entry carries the link target as its text, so the fetch
+		// must be retried over REST rather than used as the file content
+		files, err := c.Dir(ctx, fakeUser, fakeRepo, &model.Pipeline{Commit: "abc123"}, "symlink-dir")
+		assert.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, "pipeline:", string(files[0].Data))
+		assert.NotEqual(t, "../target.yaml", string(files[0].Data), "the symlink target must not be used as the file content")
+	})
+
+	t.Run("dir falls back to per-file fetching when graphql fails", func(t *testing.T) {
+		files, err := c.Dir(ctx, fakeUser, fakeRepo, &model.Pipeline{Commit: "abc123"}, "rest-fallback-dir")
+		assert.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, "rest-fallback-dir/b.yaml", files[0].Name)
+		assert.Equal(t, "pipeline:", string(files[0].Data))
+	})
+
+	t.Run("dir falls back instead of reporting config-not-found for an unexpected graphql response", func(t *testing.T) {
+		// a 200 without a repository object must not be mistaken for a missing
+		// path: config-not-found makes the caller drop the pipeline silently
+		files, err := c.Dir(ctx, fakeUser, fakeRepo, &model.Pipeline{Commit: "abc123"}, "null-repo-dir")
+		require.NoError(t, err)
+		assert.NotErrorIs(t, err, &forge_types.ErrConfigNotFound{})
+		require.Len(t, files, 1)
+		assert.Equal(t, "null-repo-dir/c.yaml", files[0].Name)
+		assert.Equal(t, "pipeline:", string(files[0].Data))
 	})
 }
 

--- a/server/forge/github/graphql.go
+++ b/server/forge/github/graphql.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+)
+
+// graphqlURL derives the GraphQL endpoint from the REST API url.
+func (c *client) graphqlURL() (string, error) {
+	if c.API == defaultAPI {
+		return "https://api.github.com/graphql", nil
+	}
+	// GitHub Enterprise: https://host/api/v3/ -> https://host/api/graphql
+	if !strings.HasSuffix(c.API, "v3/") {
+		return "", fmt.Errorf("cannot derive graphql endpoint from api url %s", c.API)
+	}
+	return strings.TrimSuffix(c.API, "v3/") + "graphql", nil
+}
+
+// dirQuery fetches a directory including the contents of all its files in a
+// single request.
+const dirQuery = `query($owner: String!, $name: String!, $expression: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      __typename
+      ... on Tree {
+        entries {
+          name
+          type
+          mode
+          object {
+            ... on Blob {
+              text
+              isTruncated
+              isBinary
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+type graphqlDirResponse struct {
+	Data *struct {
+		// a pointer, so a response that does not carry a repository object at
+		// all is distinguishable from one where the repository resolved but the
+		// requested path did not exist
+		Repository *struct {
+			Object *struct {
+				TypeName string `json:"__typename"`
+				Entries  []struct {
+					Name   string `json:"name"`
+					Type   string `json:"type"`
+					Mode   int    `json:"mode"`
+					Object struct {
+						Text        *string `json:"text"`
+						IsTruncated bool    `json:"isTruncated"`
+						IsBinary    *bool   `json:"isBinary"`
+					} `json:"object"`
+				} `json:"entries"`
+			} `json:"object"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// dirFromGraphQL fetches all files of a repository directory with a single
+// GraphQL request instead of one REST request per file, so a directory with
+// many files neither multiplies the fetch latency nor the exposure to
+// transient forge errors.
+func (c *client) dirFromGraphQL(ctx context.Context, token, owner, name, ref, path string) ([]*forge_types.FileMeta, error) {
+	body, err := json.Marshal(map[string]any{
+		"query": dirQuery,
+		"variables": map[string]string{
+			"owner":      owner,
+			"name":       name,
+			"expression": ref + ":" + strings.TrimPrefix(path, "/"),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := c.graphqlURL()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	// reuse the REST client's http client, so the transport (and any client
+	// injected into the context) is shared instead of allocating a new
+	// connection pool per directory fetch
+	restClient, err := c.newClientToken(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	httpClient := restClient.Client()
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("graphql request failed with status %d", resp.StatusCode)
+	}
+
+	var result graphqlDirResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	if len(result.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", result.Errors[0].Message)
+	}
+
+	// only a response that actually resolved the repository can prove the path
+	// is missing. Anything else is an unexpected shape and must fall back to
+	// the REST path rather than be reported as "config not found", which would
+	// silently drop the pipeline
+	if result.Data == nil || result.Data.Repository == nil {
+		return nil, fmt.Errorf("graphql response for %s did not contain a repository object", path)
+	}
+
+	object := result.Data.Repository.Object
+	if object == nil {
+		// the path does not exist at this ref
+		return nil, &forge_types.ErrConfigNotFound{Configs: []string{path}}
+	}
+	if object.TypeName != "Tree" {
+		return nil, fmt.Errorf("%s is not a directory at this ref", path)
+	}
+
+	// symlink mode in git trees, see https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+	const gitModeSymlink = 0o120000
+
+	files := make([]*forge_types.FileMeta, 0, len(object.Entries))
+	for _, entry := range object.Entries {
+		// nested directories are not descended into
+		if entry.Type != "blob" {
+			continue
+		}
+		if entry.Mode == gitModeSymlink {
+			// the graphql api returns the link target instead of the linked
+			// content, the per-file REST fallback resolves symlinks properly
+			return nil, fmt.Errorf("%s in %s is a symlink", entry.Name, path)
+		}
+		if entry.Object.Text == nil || entry.Object.IsTruncated || (entry.Object.IsBinary != nil && *entry.Object.IsBinary) {
+			return nil, fmt.Errorf("file %s in %s is binary or too large for the graphql api", entry.Name, path)
+		}
+		files = append(files, &forge_types.FileMeta{
+			Name: path + "/" + entry.Name,
+			Data: []byte(*entry.Object.Text),
+		})
+	}
+	return files, nil
+}


### PR DESCRIPTION
Split out of #6851 as requested — this PR carries only the GitHub config-fetching change, rebased onto current `main`. The pipeline status-posting work is in a separate PR.

`Dir()` fetched a directory listing plus one REST request per file. Besides the latency, this makes config fetching fragile: with ~60 config files, a single transient forge error fails the whole fetch. During a recent period of intermittent GitHub 502s, virtually every pipeline creation on our instance failed with "fallback did not find config", because the probability of at least one of 60 requests failing was near 1.

`Dir()` now fetches the whole directory (names + contents) with a single GraphQL tree query, falling back to the per-file REST path for:

- symlinked entries (GraphQL returns the link target instead of the linked content)
- truncated or binary entries
- any transport or query error, or any response that does not carry a repository object

The GraphQL endpoint is derived for both github.com and GHES, and the request reuses the REST client's HTTP client rather than allocating its own transport.

Only a response that actually resolved the repository is allowed to report `ErrConfigNotFound` — that error makes the caller delete the pipeline and drop the webhook, so an unexpected response shape must fall back to REST instead. Covered by a regression test.

### Behavior change

Subdirectories inside a config directory are now skipped consistently on both paths. Previously the REST path errored on them (`"is a folder not a file"`), so a repo with a nested directory under its config folder failed config fetching entirely. Those repos will now build from the top-level config files. Flagging this explicitly since it changes which repos get pipelines — happy to split it out if you would rather have it separate.

Covered by tests with fixture-served GraphQL responses (symlink, REST fallback, unexpected-response and not-found cases), run with `-race`.
