### PR TITLE
Reject invalid started and done workflow states

### DIFF
--- a/server/rpc/errors.go
+++ b/server/rpc/errors.go
@@ -24,4 +24,6 @@ var (
 
 	ErrAgentIllegalRepo            = errors.New("agent is not allowed to interact with repo")
 	ErrAgentIllegalWorkflowAgentID = errors.New("agent is not allowed to interact with workflow where it's id is not already locked")
+
+	ErrAgentImpossibleWorkflowState = errors.New("agent reported an impossible workflow state, the agent is probably outdated and speaks an incompatible protocol")
 )

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -278,6 +278,11 @@ func (s *RPC) Init(c context.Context, strWorkflowID string, state rpc.WorkflowSt
 		return err
 	}
 
+	// sanitize agent input: reject states no compatible agent can produce
+	if err := checkAgentReportedInitState(agent.ID, state); err != nil {
+		return err
+	}
+
 	if currentPipeline.Status == model.StatusPending {
 		if currentPipeline, err = pipeline.UpdateToStatusRunning(s.store, *currentPipeline, state.Started); err != nil {
 			log.Error().Err(err).Msgf("init: cannot update pipeline %d state", currentPipeline.ID)
@@ -345,6 +350,11 @@ func (s *RPC) Done(c context.Context, strWorkflowID string, state rpc.WorkflowSt
 
 	// check workflow's own state to prevent finishing an already-finished or blocked workflow
 	if err := checkWorkflowState(workflow.State); err != nil {
+		return err
+	}
+
+	// sanitize agent input: reject states no compatible agent can produce
+	if err := checkAgentReportedDoneState(agent.ID, state); err != nil {
 		return err
 	}
 

--- a/server/rpc/sanitize.go
+++ b/server/rpc/sanitize.go
@@ -138,6 +138,31 @@ func checkWorkflowAllowsStepUpdate(workflowState model.StatusValue, step *model.
 	return retErr
 }
 
+// checkAgentReportedInitState validates the workflow state an agent reports
+// on Init. An agent always stamps Started before calling Init and cannot know
+// a cancel result yet, so a zero Started or a set Canceled flag cannot come
+// from a compatible agent.
+func checkAgentReportedInitState(agentID int64, state rpc.WorkflowState) error {
+	if state.Started == 0 || state.Canceled {
+		retErr := ErrAgentImpossibleWorkflowState
+		log.Error().Err(retErr).Int64("agentID", agentID).Msgf("init: impossible workflow state reported: %#v", state)
+		return retErr
+	}
+	return nil
+}
+
+// checkAgentReportedDoneState validates the workflow state an agent reports
+// on Done. A canceled workflow was necessarily started, so Canceled combined
+// with a zero Started timestamp cannot come from a compatible agent.
+func checkAgentReportedDoneState(agentID int64, state rpc.WorkflowState) error {
+	if state.Canceled && state.Started == 0 {
+		retErr := ErrAgentImpossibleWorkflowState
+		log.Error().Err(retErr).Int64("agentID", agentID).Msgf("done: impossible workflow state reported: %#v", state)
+		return retErr
+	}
+	return nil
+}
+
 // checkWorkflowState checks if a workflow's own state allows it to be
 // initialized or marked as done. A workflow that is already in a terminal
 // state (success, failure, killed, …) must not be re-run, and a blocked

--- a/server/rpc/sanitize_test.go
+++ b/server/rpc/sanitize_test.go
@@ -311,3 +311,53 @@ func TestAllowAppendingLogsDrainBoundary(t *testing.T) {
 		assert.ErrorIs(t, allowAppendingLogs(p, step), ErrAgentIllegalLogStreaming)
 	})
 }
+
+func TestCheckAgentReportedInitState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("started set and not canceled is allowed", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, checkAgentReportedInitState(1, rpc.WorkflowState{Started: time.Now().Unix()}))
+	})
+
+	t.Run("zero started is rejected", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorIs(t, checkAgentReportedInitState(1, rpc.WorkflowState{}), ErrAgentImpossibleWorkflowState)
+	})
+
+	t.Run("canceled on init is rejected", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorIs(t, checkAgentReportedInitState(1, rpc.WorkflowState{Started: time.Now().Unix(), Canceled: true}), ErrAgentImpossibleWorkflowState)
+	})
+
+	t.Run("pre proto version 16 init signature is rejected", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorIs(t, checkAgentReportedInitState(1, rpc.WorkflowState{Canceled: true}), ErrAgentImpossibleWorkflowState)
+	})
+}
+
+func TestCheckAgentReportedDoneState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Unix()
+
+	t.Run("finished workflow is allowed", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, checkAgentReportedDoneState(1, rpc.WorkflowState{Started: now, Finished: now}))
+	})
+
+	t.Run("canceled workflow with started set is allowed", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, checkAgentReportedDoneState(1, rpc.WorkflowState{Started: now, Finished: now, Canceled: true}))
+	})
+
+	t.Run("zero-value state used to finalize skipped workflows is allowed", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, checkAgentReportedDoneState(1, rpc.WorkflowState{}))
+	})
+
+	t.Run("pre proto version 16 done signature is rejected", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorIs(t, checkAgentReportedDoneState(1, rpc.WorkflowState{Canceled: true}), ErrAgentImpossibleWorkflowState)
+	})
+}


### PR DESCRIPTION
Add additional checks to prevent incompatible agents reporting invalid workflow state to create strange results in database/UI that can not be traced back to what is happening and why workflows are failing (when they actually are not).
