### PR TITLE
Enforce unique name for services and steps if dag is used

### DIFF
--- a/docs/docs/20-usage/20-workflow-syntax.md
+++ b/docs/docs/20-usage/20-workflow-syntax.md
@@ -522,6 +522,10 @@ steps:
 
 :::
 
+:::warning
+As soon as one step uses `depends_on`, steps are looked up by name, so all step names of the workflow must be unique. Duplicate names are rejected.
+:::
+
 ### `volumes`
 
 Woodpecker gives the ability to define Docker volumes in the YAML. You can use this parameter to mount files or folders on the host machine into your containers.

--- a/docs/docs/20-usage/60-services.md
+++ b/docs/docs/20-usage/60-services.md
@@ -6,6 +6,7 @@ The below configuration composes database and cache containers.
 Services are accessed using custom hostnames.
 In the example below, the MySQL service is assigned the hostname `database` and is available at `database:3306`.
 Because the name becomes the hostname, every service in the list syntax must set `name` explicitly. In the map syntax the map key is used as the name.
+Service names must be unique within a workflow, otherwise the hostname would resolve to an arbitrary one of them.
 
 ```yaml
 steps:

--- a/docs/docs/20-usage/60-services.md
+++ b/docs/docs/20-usage/60-services.md
@@ -5,6 +5,7 @@ The below configuration composes database and cache containers.
 
 Services are accessed using custom hostnames.
 In the example below, the MySQL service is assigned the hostname `database` and is available at `database:3306`.
+Because the name becomes the hostname, every service in the list syntax must set `name` explicitly. In the map syntax the map key is used as the name.
 
 ```yaml
 steps:

--- a/pipeline/frontend/yaml/compiler/dag.go
+++ b/pipeline/frontend/yaml/compiler/dag.go
@@ -69,6 +69,11 @@ func (c dagCompiler) compileSequence() ([]*backend_types.Stage, error) {
 func (c dagCompiler) compileByDependsOn() ([]*backend_types.Stage, error) {
 	stepMap := make(map[string]*dagCompilerStep, len(c.steps))
 	for _, s := range c.steps {
+		// a step is looked up by name to resolve 'depends_on', so a second step
+		// under the same name would silently replace the first one
+		if _, exists := stepMap[s.name]; exists {
+			return nil, &ErrStepDuplicateName{name: s.name}
+		}
 		stepMap[s.name] = s
 	}
 	return convertDAGToStages(stepMap)

--- a/pipeline/frontend/yaml/compiler/dag_test.go
+++ b/pipeline/frontend/yaml/compiler/dag_test.go
@@ -261,3 +261,36 @@ func TestIsDag(t *testing.T) {
 	c = newDAGCompiler(steps)
 	assert.True(t, c.isDAG())
 }
+
+func TestDuplicateStepNameInDAG(t *testing.T) {
+	steps := []*dagCompilerStep{
+		{
+			name:      "build",
+			position:  0,
+			step:      &backend_types.Step{Name: "build"},
+			dependsOn: constraint.DependsOn{{Name: "clone"}},
+		},
+		{
+			name:     "clone",
+			position: 1,
+			step:     &backend_types.Step{Name: "clone"},
+		},
+		{
+			name:      "build",
+			position:  2,
+			step:      &backend_types.Step{Name: "build"},
+			dependsOn: constraint.DependsOn{{Name: "clone"}},
+		},
+	}
+	_, err := newDAGCompiler(steps).compile()
+	assert.ErrorIs(t, err, &ErrStepDuplicateName{})
+
+	// without a dependency the steps run as a sequence, where duplicate names are fine
+	steps = []*dagCompilerStep{
+		{name: "build", position: 0, step: &backend_types.Step{Name: "build"}},
+		{name: "build", position: 1, step: &backend_types.Step{Name: "build"}},
+	}
+	stages, err := newDAGCompiler(steps).compile()
+	assert.NoError(t, err)
+	assert.Len(t, stages, 2)
+}

--- a/pipeline/frontend/yaml/compiler/errors.go
+++ b/pipeline/frontend/yaml/compiler/errors.go
@@ -57,6 +57,19 @@ func (*ErrStepFilteredDependency) Is(target error) bool {
 	return ok
 }
 
+type ErrStepDuplicateName struct {
+	name string
+}
+
+func (err *ErrStepDuplicateName) Error() string {
+	return fmt.Sprintf("step name '%s' is used more than once, step names must be unique to be referenced by 'depends_on'", err.name)
+}
+
+func (*ErrStepDuplicateName) Is(target error) bool {
+	_, ok := target.(*ErrStepDuplicateName)
+	return ok
+}
+
 type ErrStepDependencyCycle struct {
 	path []string
 }

--- a/pipeline/frontend/yaml/linter/linter.go
+++ b/pipeline/frontend/yaml/linter/linter.go
@@ -99,6 +99,9 @@ func (l *Linter) lintFile(config *WorkflowConfig) error {
 	if err := l.lintContainers(config, "services"); err != nil {
 		linterErr = multierr.Append(linterErr, err)
 	}
+	if err := l.lintServiceNames(config); err != nil {
+		linterErr = multierr.Append(linterErr, err)
+	}
 
 	if err := l.lintSchema(config); err != nil {
 		linterErr = multierr.Append(linterErr, err)
@@ -135,6 +138,30 @@ func (l *Linter) lintCloneSteps(config *WorkflowConfig) error {
 			)
 		}
 	}
+	return linterErr
+}
+
+// lintServiceNames rejects services sharing a name. A service's name becomes
+// the network alias other containers address it by, so two services with the
+// same name make that hostname resolve to either of them at random.
+func (l *Linter) lintServiceNames(config *WorkflowConfig) error {
+	var linterErr error
+
+	seen := make(map[string]struct{}, len(config.Workflow.Services.ContainerList))
+	for _, container := range config.Workflow.Services.ContainerList {
+		if _, ok := seen[container.Name]; ok {
+			linterErr = multierr.Append(
+				linterErr,
+				newLinterError(
+					fmt.Sprintf("Service names must be unique, `%s` is used more than once", container.Name),
+					config.File, fmt.Sprintf("services.%s", container.Name), false,
+				),
+			)
+			continue
+		}
+		seen[container.Name] = struct{}{}
+	}
+
 	return linterErr
 }
 

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -217,6 +217,14 @@ func TestLintErrors(t *testing.T) {
 			from: "steps: { build: { image: golang }, publish: { image: golang, depends_on: [ binary ] } }",
 			want: "One or more of the specified dependencies do not exist",
 		},
+		{
+			from: "{steps: { build: { image: golang } }, services: [ { name: database, image: mysql }, { name: database, image: postgres } ] }",
+			want: "Service names must be unique, `database` is used more than once",
+		},
+		{
+			from: "steps:\n  build:\n    image: golang\nservices:\n  database:\n    image: mysql\n  database:\n    image: postgres\n",
+			want: "Service names must be unique, `database` is used more than once",
+		},
 	}
 
 	for _, test := range testdata {

--- a/pipeline/frontend/yaml/linter/linter_test.go
+++ b/pipeline/frontend/yaml/linter/linter_test.go
@@ -221,10 +221,6 @@ func TestLintErrors(t *testing.T) {
 			from: "{steps: { build: { image: golang } }, services: [ { name: database, image: mysql }, { name: database, image: postgres } ] }",
 			want: "Service names must be unique, `database` is used more than once",
 		},
-		{
-			from: "steps:\n  build:\n    image: golang\nservices:\n  database:\n    image: mysql\n  database:\n    image: postgres\n",
-			want: "Service names must be unique, `database` is used more than once",
-		},
 	}
 
 	for _, test := range testdata {

--- a/pipeline/frontend/yaml/linter/schema/.woodpecker/test-broken-service-without-name.yaml
+++ b/pipeline/frontend/yaml/linter/schema/.woodpecker/test-broken-service-without-name.yaml
@@ -1,0 +1,8 @@
+steps:
+  - name: build
+    image: golang
+    commands:
+      - go build
+
+services:
+  - image: mysql

--- a/pipeline/frontend/yaml/linter/schema/schema.json
+++ b/pipeline/frontend/yaml/linter/schema/schema.json
@@ -969,20 +969,35 @@
       "description": "Read more: https://woodpecker-ci.org/docs/usage/services",
       "oneOf": [
         {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/service"
-          },
-          "minProperties": 1
+          "$ref": "#/definitions/services_map"
         },
         {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/service"
-          },
-          "minLength": 1
+          "$ref": "#/definitions/services_list"
         }
       ]
+    },
+    "services_map": {
+      "description": "Services keyed by name, where the map key is used as the service name. Read more: https://woodpecker-ci.org/docs/usage/services",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/service"
+      },
+      "minProperties": 1
+    },
+    "services_list": {
+      "description": "Services as a list. There is no map key to take the name from, so each service must set `name` itself. Read more: https://woodpecker-ci.org/docs/usage/services",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/service"
+          },
+          {
+            "required": ["name"]
+          }
+        ]
+      },
+      "minLength": 1
     },
     "service": {
       "description": "Read more: https://woodpecker-ci.org/docs/usage/services",
@@ -992,7 +1007,7 @@
       "required": ["image"],
       "properties": {
         "name": {
-          "description": "The name of the service. Can be used if using the array style services list",
+          "description": "The name of the service. It is used as the hostname other containers reach the service by, and is required when using the array style services list",
           "type": "string"
         },
         "image": {

--- a/pipeline/frontend/yaml/linter/schema/schema_test.go
+++ b/pipeline/frontend/yaml/linter/schema/schema_test.go
@@ -137,6 +137,11 @@ func TestSchema(t *testing.T) {
 			testFile: ".woodpecker/test-concurrency-invalid.yaml",
 			fail:     true,
 		},
+		{
+			name:     "Service without name in array syntax",
+			testFile: ".woodpecker/test-broken-service-without-name.yaml",
+			fail:     true,
+		},
 	}
 
 	for _, tt := range testTable {


### PR DESCRIPTION
Currently on duplicated names we have undefined behaviour and depending on the backend this will fail or be silently ignored and produce random outcome.

This gates against all of it by returning an error with explicit message instead.