### PR TITLE
Introduce token for scoped access

### DIFF
--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -4036,6 +4036,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/repos/{repo_id}/token/rotate": {
+            "post": {
+                "description": "Replaces every token of the repository with a freshly generated one and drops the ones no longer in use. URLs carrying an old token, such as badge URLs, stop working.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Repositories"
+                ],
+                "summary": "Rotate all tokens of the repository",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cpersonal access token\u003e",
+                        "description": "Insert your personal access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "the repository id",
+                        "name": "repo_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Token"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/secrets": {
             "get": {
                 "produces": [

--- a/cmd/server/openapi/docs.go
+++ b/cmd/server/openapi/docs.go
@@ -267,6 +267,12 @@ const docTemplate = `{
                         "name": "repo_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "the badge token of the repository, required for non-public repos",
+                        "name": "token",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -292,6 +298,12 @@ const docTemplate = `{
                         "name": "repo_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "the badge token of the repository, required for non-public repos",
+                        "name": "token",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -3981,6 +3993,49 @@ const docTemplate = `{
                 }
             }
         },
+        "/repos/{repo_id}/token": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Repositories"
+                ],
+                "summary": "Get a token of the repository",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cpersonal access token\u003e",
+                        "description": "Insert your personal access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "the repository id",
+                        "name": "repo_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "badge",
+                        "description": "the type of the token",
+                        "name": "type",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Token"
+                        }
+                    }
+                }
+            }
+        },
         "/secrets": {
             "get": {
                 "produces": [
@@ -5875,6 +5930,35 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "Token": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "repo_id": {
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/TokenType"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "TokenType": {
+            "type": "string",
+            "enum": [
+                "badge"
+            ],
+            "x-enum-varnames": [
+                "TokenTypeBadge"
+            ]
         },
         "User": {
             "type": "object",

--- a/docs/docs/20-usage/80-badges.md
+++ b/docs/docs/20-usage/80-badges.md
@@ -22,3 +22,20 @@ If you'd like to respect other or further events, you can add the `events` query
 -<scheme>://<hostname>/api/badges/<repo-id>/status.svg
 +<scheme>://<hostname>/api/badges/<repo-id>/status.svg?events=manual,cron
 ```
+
+## Badge token
+
+Public repositories serve their badge to everyone. Every other repository requires its badge token, otherwise the badge only states that the repository does not exist or the token is missing. The same applies to the [CCTray](https://cctray.org/v1/) endpoint `cc.xml`.
+
+```diff
+-<scheme>://<hostname>/api/badges/<repo-id>/status.svg
++<scheme>://<hostname>/api/badges/<repo-id>/status.svg?token=<badge-token>
+```
+
+The badge settings of a repository already contain the token where one is needed. It can also be fetched via the API:
+
+```uri
+<scheme>://<hostname>/api/repos/<repo-id>/token?type=badge
+```
+
+Anyone holding the token can read the pipeline status of the repository, so treat it like a secret and only add it to badge URLs that are as visible as the status itself.

--- a/server/api/badge.go
+++ b/server/api/badge.go
@@ -35,15 +35,21 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
 )
 
-// GetBadge
-//
-//	@Summary	Get status of pipeline as SVG badge
-//	@Router		/badges/{repo_id}/status.svg [get]
-//	@Produce	image/svg+xml
-//	@Success	200
-//	@Tags		Badges
-//	@Param		repo_id	path	int	true	"the repository id"
-func GetBadge(c *gin.Context) {
+// badgeUnavailableLabel is shown whenever the state of a repo may not be
+// served. It is used both for repos that do not exist and for repos the caller
+// holds no badge token for, so the endpoints do not tell anonymous callers
+// which repos exist.
+const badgeUnavailableLabel = "repo does not exist or token missing"
+
+// badgeDefaultName is the subject a badge carries if it shows the state of a
+// whole pipeline rather than that of a single workflow or step.
+const badgeDefaultName = "pipeline"
+
+// resolveBadgeRepo returns the repo addressed by the request, or nil if it does
+// not exist or its state may not be served. Public repos are served to
+// everyone, every other repo requires the badge token of that repo as `token`
+// query parameter.
+func resolveBadgeRepo(c *gin.Context) *model.Repo {
 	_store := store.FromContext(c)
 
 	var repo *model.Repo
@@ -52,17 +58,58 @@ func GetBadge(c *gin.Context) {
 	if c.Param("repo_name") != "" {
 		repo, err = _store.GetRepoName(c.Param("repo_id_or_owner") + "/" + c.Param("repo_name"))
 	} else {
-		var repoID int64
-		repoID, err = strconv.ParseInt(c.Param("repo_id_or_owner"), 10, 64)
-		if err != nil {
-			c.AbortWithStatus(http.StatusBadRequest)
-			return
+		repoID, parseErr := strconv.ParseInt(c.Param("repo_id_or_owner"), 10, 64)
+		if parseErr != nil {
+			return nil
 		}
 		repo, err = _store.GetRepo(repoID)
 	}
 
 	if err != nil {
-		handleDBError(c, err)
+		if !errors.Is(err, types.ErrRecordNotExist) {
+			log.Error().Err(err).Msg("could not get repo for badge")
+		}
+		return nil
+	}
+
+	if repo.Visibility == model.VisibilityPublic {
+		return repo
+	}
+
+	token, err := _store.TokenFind(repo, model.TokenTypeBadge)
+	if err != nil {
+		if !errors.Is(err, types.ErrRecordNotExist) {
+			log.Error().Err(err).Msg("could not get badge token")
+		}
+		return nil
+	}
+
+	// an empty stored value would match a request without a token at all
+	if token.Value == "" || !token.Matches(c.Query("token")) {
+		return nil
+	}
+
+	return repo
+}
+
+// GetBadge
+//
+//	@Summary	Get status of pipeline as SVG badge
+//	@Router		/badges/{repo_id}/status.svg [get]
+//	@Produce	image/svg+xml
+//	@Success	200
+//	@Tags		Badges
+//	@Param		repo_id	path	int		true	"the repository id"
+//	@Param		token	query	string	false	"the badge token of the repository, required for non-public repos"
+func GetBadge(c *gin.Context) {
+	_store := store.FromContext(c)
+
+	// we serve an SVG, so set content type appropriately.
+	c.Writer.Header().Set("Content-Type", "image/svg+xml")
+
+	repo := resolveBadgeRepo(c)
+	if repo == nil {
+		writeUnavailableBadge(c)
 		return
 	}
 
@@ -94,7 +141,7 @@ func GetBadge(c *gin.Context) {
 		}
 	}
 
-	name := "pipeline"
+	name := badgeDefaultName
 	var status *model.StatusValue = nil
 
 	pl, err := _store.GetPipelineBadge(repo, branch, events)
@@ -105,9 +152,6 @@ func GetBadge(c *gin.Context) {
 	} else {
 		status = &pl.Status
 	}
-
-	// we serve an SVG, so set content type appropriately.
-	c.Writer.Header().Set("Content-Type", "image/svg+xml")
 
 	// Allow workflow (and step) specific badges
 	workflowName := c.Query("workflow")
@@ -146,12 +190,30 @@ func GetBadge(c *gin.Context) {
 		}
 	}
 
+	writeBadge(c, name, status)
+}
+
+// writeBadge renders the badge for the given name and status and writes it to
+// the response.
+func writeBadge(c *gin.Context, name string, status *model.StatusValue) {
 	badge, err := badges.Generate(name, status)
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Failed to generate badge.")
-	} else {
-		c.String(http.StatusOK, badge)
+		return
 	}
+	c.String(http.StatusOK, badge)
+}
+
+// writeUnavailableBadge renders the badge shown for repos whose state may not
+// be served. It states the reason instead of a status, as there is none to
+// show.
+func writeUnavailableBadge(c *gin.Context) {
+	badge, err := badges.RenderBytes(badgeDefaultName, badgeUnavailableLabel, badges.ColorGray)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "Failed to generate badge.")
+		return
+	}
+	c.String(http.StatusOK, string(badge))
 }
 
 // GetCC
@@ -164,26 +226,14 @@ func GetBadge(c *gin.Context) {
 //	@Produce		xml
 //	@Success		200
 //	@Tags			Badges
-//	@Param			repo_id	path	int	true	"the repository id"
+//	@Param			repo_id	path	int		true	"the repository id"
+//	@Param			token	query	string	false	"the badge token of the repository, required for non-public repos"
 func GetCC(c *gin.Context) {
 	_store := store.FromContext(c)
-	var repo *model.Repo
-	var err error
 
-	if c.Param("repo_name") != "" {
-		repo, err = _store.GetRepoName(c.Param("repo_id_or_owner") + "/" + c.Param("repo_name"))
-	} else {
-		var repoID int64
-		repoID, err = strconv.ParseInt(c.Param("repo_id_or_owner"), 10, 64)
-		if err != nil {
-			c.AbortWithStatus(http.StatusBadRequest)
-			return
-		}
-		repo, err = _store.GetRepo(repoID)
-	}
-
-	if err != nil {
-		handleDBError(c, err)
+	repo := resolveBadgeRepo(c)
+	if repo == nil {
+		c.XML(http.StatusOK, ccmenu.NewPlaceholder(badgeUnavailableLabel))
 		return
 	}
 
@@ -193,6 +243,7 @@ func GetCC(c *gin.Context) {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
+	// only reachable for repos the caller may see, so it leaks nothing
 	if len(pipelines) == 0 {
 		c.AbortWithStatus(http.StatusNotFound)
 		return

--- a/server/api/badge_test.go
+++ b/server/api/badge_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+// badgeFixture seeds a repo with the given visibility, one successful pipeline
+// and a badge token.
+func badgeFixture(t *testing.T, s store.Store, name string, visibility model.RepoVisibility) (*model.Repo, *model.Token) {
+	t.Helper()
+	repo := &model.Repo{
+		ForgeRemoteID: model.ForgeRemoteID(name),
+		Owner:         "owner",
+		Name:          name,
+		FullName:      "owner/" + name,
+		Branch:        "main",
+		Visibility:    visibility,
+		IsActive:      true,
+	}
+	require.NoError(t, s.CreateRepo(repo))
+
+	pipeline := &model.Pipeline{
+		RepoID: repo.ID,
+		Branch: "main",
+		Event:  model.EventPush,
+		Status: model.StatusSuccess,
+	}
+	require.NoError(t, s.CreatePipeline(pipeline))
+
+	token := model.NewToken(repo.ID, model.TokenTypeBadge)
+	require.NoError(t, s.TokenCreate(token))
+
+	return repo, token
+}
+
+// getBadge calls GetBadge for the given repo id path param and query string.
+func getBadge(t *testing.T, s store.Store, repoID, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	tc := newTestContext(t, s)
+	withParam("repo_id_or_owner", repoID)(tc)
+	tc.Ctx.Request = httptest.NewRequest(http.MethodGet, "/?"+query, nil)
+	GetBadge(tc.Ctx)
+	return tc.Recorder
+}
+
+// getCC calls GetCC for the given repo id path param and query string.
+func getCC(t *testing.T, s store.Store, repoID, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	tc := newTestContext(t, s)
+	withParam("repo_id_or_owner", repoID)(tc)
+	tc.Ctx.Request = httptest.NewRequest(http.MethodGet, "/?"+query, nil)
+	GetCC(tc.Ctx)
+	return tc.Recorder
+}
+
+func TestGetBadgePublicRepo(t *testing.T) {
+	s := newTestStore(t)
+	repo, _ := badgeFixture(t, s, "public", model.VisibilityPublic)
+
+	t.Run("without token", func(t *testing.T) {
+		rec := getBadge(t, s, strItoa(repo.ID), "")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "success")
+	})
+
+	// a token is not rejected either, it is simply not needed here
+	t.Run("with wrong token", func(t *testing.T) {
+		plain := getBadge(t, s, strItoa(repo.ID), "")
+		rec := getBadge(t, s, strItoa(repo.ID), "token=nope")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, plain.Body.String(), rec.Body.String())
+	})
+}
+
+// A token row whose value ended up empty must not turn into a badge that any
+// caller can read by sending no token at all.
+func TestGetBadgeRejectsEmptyStoredToken(t *testing.T) {
+	repo := &model.Repo{ID: 42, Visibility: model.VisibilityPrivate}
+	s := store_mocks.NewMockStore(t)
+	s.EXPECT().GetRepo(repo.ID).Return(repo, nil)
+	s.EXPECT().TokenFind(repo, model.TokenTypeBadge).Return(&model.Token{
+		RepoID: repo.ID,
+		Type:   model.TokenTypeBadge,
+	}, nil)
+
+	rec := getBadge(t, s, strItoa(repo.ID), "")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), badgeUnavailableLabel)
+}
+
+func TestGetBadgeNonPublicRepoRequiresToken(t *testing.T) {
+	s := newTestStore(t)
+	private, privateToken := badgeFixture(t, s, "private", model.VisibilityPrivate)
+	internal, _ := badgeFixture(t, s, "internal", model.VisibilityInternal)
+
+	t.Run("valid token serves status", func(t *testing.T) {
+		rec := getBadge(t, s, strItoa(private.ID), "token="+privateToken.Value)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "success")
+	})
+
+	t.Run("missing token hides status", func(t *testing.T) {
+		rec := getBadge(t, s, strItoa(private.ID), "")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), badgeUnavailableLabel)
+		assert.NotContains(t, rec.Body.String(), "success")
+	})
+
+	t.Run("wrong token hides status", func(t *testing.T) {
+		rec := getBadge(t, s, strItoa(private.ID), "token=nope")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), badgeUnavailableLabel)
+	})
+
+	t.Run("internal repos need a token too", func(t *testing.T) {
+		rec := getBadge(t, s, strItoa(internal.ID), "")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), badgeUnavailableLabel)
+	})
+}
+
+// The response for a repo that may not be seen must be byte identical to the
+// one for a repo that does not exist, otherwise the endpoint tells anonymous
+// callers which repo ids and names exist.
+func TestGetBadgeDoesNotLeakExistence(t *testing.T) {
+	s := newTestStore(t)
+	private, _ := badgeFixture(t, s, "private", model.VisibilityPrivate)
+
+	missingByID := getBadge(t, s, "999999", "")
+	missingByName := func() *httptest.ResponseRecorder {
+		tc := newTestContext(t, s)
+		withParam("repo_id_or_owner", "owner")(tc)
+		withParam("repo_name", "does-not-exist")(tc)
+		GetBadge(tc.Ctx)
+		return tc.Recorder
+	}()
+	forbidden := getBadge(t, s, strItoa(private.ID), "")
+	malformed := getBadge(t, s, "not-a-number", "")
+
+	for name, rec := range map[string]*httptest.ResponseRecorder{
+		"missing by id":   missingByID,
+		"missing by name": missingByName,
+		"malformed id":    malformed,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, forbidden.Code, rec.Code)
+			assert.Equal(t, forbidden.Body.String(), rec.Body.String())
+			assert.Equal(t, "image/svg+xml", rec.Header().Get("Content-Type"))
+		})
+	}
+}
+
+// Query parameters must not change the denied response either, they would
+// otherwise expose branch, workflow or step names of a hidden repo.
+func TestGetBadgeDeniedResponseIgnoresQuery(t *testing.T) {
+	s := newTestStore(t)
+	private, _ := badgeFixture(t, s, "private", model.VisibilityPrivate)
+
+	plain := getBadge(t, s, strItoa(private.ID), "")
+	withQuery := getBadge(t, s, strItoa(private.ID), "branch=main&events=push&workflow=build&step=test")
+
+	assert.Equal(t, plain.Code, withQuery.Code)
+	assert.Equal(t, plain.Body.String(), withQuery.Body.String())
+}
+
+func TestGetCCTokenGate(t *testing.T) {
+	s := newTestStore(t)
+	public, _ := badgeFixture(t, s, "public", model.VisibilityPublic)
+	private, privateToken := badgeFixture(t, s, "private", model.VisibilityPrivate)
+
+	t.Run("public repo is served", func(t *testing.T) {
+		rec := getCC(t, s, strItoa(public.ID), "")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "owner/public")
+	})
+
+	t.Run("valid token serves private repo", func(t *testing.T) {
+		rec := getCC(t, s, strItoa(private.ID), "token="+privateToken.Value)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "owner/private")
+	})
+
+	// this is the reported leak: the cctray endpoint handed out the full name
+	// of every repo, including private ones
+	t.Run("missing token hides full name", func(t *testing.T) {
+		rec := getCC(t, s, strItoa(private.ID), "")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NotContains(t, rec.Body.String(), "owner/private")
+		assert.Contains(t, rec.Body.String(), badgeUnavailableLabel)
+	})
+
+	t.Run("hidden and missing repos look the same", func(t *testing.T) {
+		hidden := getCC(t, s, strItoa(private.ID), "")
+		missing := getCC(t, s, "999999", "")
+		assert.Equal(t, hidden.Code, missing.Code)
+		assert.Equal(t, hidden.Body.String(), missing.Body.String())
+		assert.True(t, strings.HasPrefix(missing.Header().Get("Content-Type"), "application/xml"))
+	})
+}

--- a/server/api/helpers_sqlite_test.go
+++ b/server/api/helpers_sqlite_test.go
@@ -95,8 +95,6 @@ func withRepo(r *model.Repo, perm *model.Perm) ctxOption {
 // withParam sets a gin URL path parameter (e.g. "cron", "repo_id", "secret").
 // The key is intentionally a parameter so the same helper serves every
 // endpoint group; it currently varies across the api test suite.
-//
-//nolint:unparam // key varies across endpoint test files sharing this helper
 func withParam(key, value string) ctxOption {
 	return func(tc *testContext) {
 		tc.Ctx.Params = append(tc.Ctx.Params, gin.Param{Key: key, Value: value})

--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -200,6 +200,15 @@ func PostRepo(c *gin.Context) {
 		return
 	}
 
+	// a badge token is required to access the badge endpoints of non-public
+	// repos, so every repo gets one on activation
+	if _, err := getOrCreateToken(_store, repo, model.TokenTypeBadge); err != nil {
+		msg := "could not create badge token."
+		log.Error().Err(err).Msg(msg)
+		c.String(http.StatusInternalServerError, msg)
+		return
+	}
+
 	repo.Perm = from.Perm
 	repo.Perm.Synced = time.Now().Unix()
 	repo.Perm.UserID = user.ID

--- a/server/api/token.go
+++ b/server/api/token.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/router/middleware/session"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
+)
+
+// getOrCreateToken returns the token of the given type of a repo, creating it
+// if the repo does not hold one yet. Repos get their tokens on activation, this
+// keeps repos activated by an older version working as well.
+func getOrCreateToken(s store.Store, repo *model.Repo, tokenType model.TokenType) (*model.Token, error) {
+	token, err := s.TokenFind(repo, tokenType)
+	if err == nil {
+		return token, nil
+	}
+	if !errors.Is(err, types.ErrRecordNotExist) {
+		return nil, err
+	}
+
+	token = model.NewToken(repo.ID, tokenType)
+	if err := s.TokenCreate(token); err != nil {
+		// a concurrent request won the race, its token is the valid one
+		if errors.Is(err, types.ErrInsertDuplicateDetected) {
+			return s.TokenFind(repo, tokenType)
+		}
+		return nil, err
+	}
+
+	return token, nil
+}
+
+// GetRepoToken
+//
+//	@Summary	Get a token of the repository
+//	@Router		/repos/{repo_id}/token [get]
+//	@Produce	json
+//	@Success	200	{object}	Token
+//	@Tags		Repositories
+//	@Param		Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
+//	@Param		repo_id			path	int		true	"the repository id"
+//	@Param		type			query	string	false	"the type of the token"	default(badge)
+func GetRepoToken(c *gin.Context) {
+	repo := session.Repo(c)
+
+	tokenType := model.TokenType(c.DefaultQuery("type", string(model.TokenTypeBadge)))
+	if !tokenType.Valid() {
+		c.String(http.StatusBadRequest, "Invalid token type '%s'", tokenType)
+		return
+	}
+
+	token, err := getOrCreateToken(store.FromContext(c), repo, tokenType)
+	if err != nil {
+		handleDBError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, token)
+}

--- a/server/api/token.go
+++ b/server/api/token.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	"go.woodpecker-ci.org/woodpecker/v3/server/router/middleware/session"
@@ -76,4 +77,35 @@ func GetRepoToken(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, token)
+}
+
+// RotateRepoTokens
+//
+//	@Summary		Rotate all tokens of the repository
+//	@Description	Replaces every token of the repository with a freshly generated one and drops the ones no longer in use. URLs carrying an old token, such as badge URLs, stop working.
+//	@Router			/repos/{repo_id}/token/rotate [post]
+//	@Produce		json
+//	@Success		200	{array}	Token
+//	@Tags			Repositories
+//	@Param			Authorization	header	string	true	"Insert your personal access token"	default(Bearer <personal access token>)
+//	@Param			repo_id			path	int		true	"the repository id"
+func RotateRepoTokens(c *gin.Context) {
+	_store := store.FromContext(c)
+	repo := session.Repo(c)
+
+	// Badge is the only persistent repo token today. Future short-lived kinds,
+	// such as tokens scoped to one pipeline execution, need separate rotation
+	// logic that only replaces existing rows.
+	rotated := []*model.Token{
+		model.NewToken(repo.ID, model.TokenTypeBadge),
+	}
+
+	if err := _store.TokenReplace(repo, rotated); err != nil {
+		msg := "could not rotate repo tokens."
+		log.Error().Err(err).Msg(msg)
+		c.String(http.StatusInternalServerError, msg)
+		return
+	}
+
+	c.JSON(http.StatusOK, rotated)
 }

--- a/server/api/token_test.go
+++ b/server/api/token_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+)
+
+func TestGetRepoToken(t *testing.T) {
+	s := newTestStore(t)
+
+	newRepo := func(t *testing.T, name string) *model.Repo {
+		t.Helper()
+		repo := &model.Repo{
+			ForgeRemoteID: model.ForgeRemoteID(name),
+			Owner:         "owner",
+			Name:          name,
+			FullName:      "owner/" + name,
+			IsActive:      true,
+		}
+		require.NoError(t, s.CreateRepo(repo))
+		return repo
+	}
+
+	call := func(t *testing.T, s store.Store, repo *model.Repo, query string) *httptest.ResponseRecorder {
+		t.Helper()
+		tc := newTestContext(t, s)
+		withRepo(repo, &model.Perm{Push: true})(tc)
+		tc.Ctx.Request = httptest.NewRequest(http.MethodGet, "/?"+query, nil)
+		GetRepoToken(tc.Ctx)
+		return tc.Recorder
+	}
+
+	t.Run("returns the badge token by default", func(t *testing.T) {
+		repo := newRepo(t, "with-token")
+		token := model.NewToken(repo.ID, model.TokenTypeBadge)
+		require.NoError(t, s.TokenCreate(token))
+
+		rec := call(t, s, repo, "")
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var got model.Token
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		assert.Equal(t, token.Value, got.Value)
+		assert.Equal(t, model.TokenTypeBadge, got.Type)
+		assert.Equal(t, repo.ID, got.RepoID)
+	})
+
+	t.Run("rejects unknown token types", func(t *testing.T) {
+		repo := newRepo(t, "bad-type")
+		rec := call(t, s, repo, "type=cron")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	// repos activated before badge tokens existed hold none, the endpoint
+	// equips them on first read instead of failing
+	t.Run("creates a missing token", func(t *testing.T) {
+		repo := newRepo(t, "without-token")
+
+		rec := call(t, s, repo, "")
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var got model.Token
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.NotEmpty(t, got.Value)
+
+		stored, err := s.TokenFind(repo, model.TokenTypeBadge)
+		require.NoError(t, err)
+		assert.Equal(t, stored.Value, got.Value)
+
+		// reading again must not hand out a different token
+		second := call(t, s, repo, "")
+		var again model.Token
+		require.NoError(t, json.Unmarshal(second.Body.Bytes(), &again))
+		assert.Equal(t, got.Value, again.Value)
+	})
+}

--- a/server/api/token_test.go
+++ b/server/api/token_test.go
@@ -98,3 +98,64 @@ func TestGetRepoToken(t *testing.T) {
 		assert.Equal(t, got.Value, again.Value)
 	})
 }
+
+func TestRotateRepoTokens(t *testing.T) {
+	s := newTestStore(t)
+
+	repo := &model.Repo{
+		ForgeRemoteID: "rotate",
+		Owner:         "owner",
+		Name:          "rotate",
+		FullName:      "owner/rotate",
+		IsActive:      true,
+	}
+	require.NoError(t, s.CreateRepo(repo))
+
+	old := model.NewToken(repo.ID, model.TokenTypeBadge)
+	require.NoError(t, s.TokenCreate(old))
+
+	rotated := rotateTokens(t, s, repo)
+
+	require.Len(t, rotated, 1)
+	assert.Equal(t, model.TokenTypeBadge, rotated[0].Type)
+	assert.NotEqual(t, old.Value, rotated[0].Value, "the old token has to stop working")
+
+	stored, err := s.TokenFind(repo, model.TokenTypeBadge)
+	require.NoError(t, err)
+	assert.Equal(t, rotated[0].Value, stored.Value)
+}
+
+// Rotating a repo that never had a token must equip it rather than fail.
+func TestRotateRepoTokensWithoutExisting(t *testing.T) {
+	s := newTestStore(t)
+
+	repo := &model.Repo{
+		ForgeRemoteID: "rotate-fresh",
+		Owner:         "owner",
+		Name:          "rotate-fresh",
+		FullName:      "owner/rotate-fresh",
+		IsActive:      true,
+	}
+	require.NoError(t, s.CreateRepo(repo))
+
+	rotated := rotateTokens(t, s, repo)
+
+	require.Len(t, rotated, 1)
+	_, err := s.TokenFind(repo, model.TokenTypeBadge)
+	assert.NoError(t, err)
+}
+
+func rotateTokens(t *testing.T, s store.Store, repo *model.Repo) []*model.Token {
+	t.Helper()
+
+	tc := newTestContext(t, s)
+	withRepo(repo, nil)(tc)
+	tc.Ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+	RotateRepoTokens(tc.Ctx)
+
+	require.Equal(t, http.StatusOK, tc.Recorder.Code)
+
+	var rotated []*model.Token
+	require.NoError(t, json.Unmarshal(tc.Recorder.Body.Bytes(), &rotated))
+	return rotated
+}

--- a/server/ccmenu/cc.go
+++ b/server/ccmenu/cc.go
@@ -43,6 +43,18 @@ type CCProject struct {
 	WebURL          string   `xml:"webUrl,attr"`
 }
 
+// NewPlaceholder returns a project carrying no repo information at all. It is
+// served for repos whose state may not be shown, so the response looks the same
+// as for a repo that does not exist.
+func NewPlaceholder(name string) *CCProjects {
+	return &CCProjects{Project: &CCProject{
+		Name:            name,
+		Activity:        "Sleeping",
+		LastBuildStatus: "Unknown",
+		LastBuildLabel:  "Unknown",
+	}}
+}
+
 func New(r *model.Repo, b *model.Pipeline, url string) *CCProjects {
 	proj := &CCProject{
 		Name:            r.FullName,

--- a/server/model/token.go
+++ b/server/model/token.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"crypto/subtle"
+	"fmt"
+
+	"go.woodpecker-ci.org/woodpecker/v3/shared/utils"
+)
+
+// TokenType tells for which feature a repo token grants access.
+type TokenType string //	@name	TokenType
+
+const (
+	// TokenTypeBadge grants read access to the badge endpoints of a repo.
+	TokenTypeBadge TokenType = "badge"
+)
+
+// tokenLength is the number of characters a generated token holds.
+const tokenLength = 52
+
+// Valid reports whether the token type is a known one.
+func (t TokenType) Valid() bool {
+	switch t {
+	case TokenTypeBadge:
+		return true
+	default:
+		return false
+	}
+}
+
+// Token is a secret bound to a repo, granting access to a single feature of it.
+type Token struct {
+	ID      int64     `json:"id"      xorm:"pk autoincr 'id'"`
+	RepoID  int64     `json:"repo_id" xorm:"NOT NULL UNIQUE(s) INDEX 'repo_id'"`
+	Type    TokenType `json:"type"    xorm:"NOT NULL UNIQUE(s) INDEX varchar(50) 'type'"`
+	Value   string    `json:"value"   xorm:"NOT NULL UNIQUE varchar(100) 'value'"`
+	Created int64     `json:"created" xorm:"created NOT NULL DEFAULT 0"`
+} //	@name	Token
+
+// TableName returns the database table name for xorm.
+func (Token) TableName() string {
+	return "tokens"
+}
+
+// Validate ensures the token is bound to a repo and has a known type and a value.
+func (t *Token) Validate() error {
+	if t.RepoID == 0 {
+		return fmt.Errorf("repo id is required")
+	}
+
+	if !t.Type.Valid() {
+		return fmt.Errorf("invalid token type '%s'", t.Type)
+	}
+
+	if t.Value == "" {
+		return fmt.Errorf("value is required")
+	}
+
+	return nil
+}
+
+// Matches compares the token value against the given one in constant time.
+func (t *Token) Matches(value string) bool {
+	return subtle.ConstantTimeCompare([]byte(t.Value), []byte(value)) == 1
+}
+
+// NewToken returns a token of the given type with a freshly generated value,
+// bound to the given repo.
+func NewToken(repoID int64, tokenType TokenType) *Token {
+	return &Token{
+		RepoID: repoID,
+		Type:   tokenType,
+		Value:  GenerateTokenValue(),
+	}
+}
+
+// GenerateTokenValue returns a new random token value.
+func GenerateTokenValue() string {
+	return utils.RandomString(tokenLength)
+}

--- a/server/model/token.go
+++ b/server/model/token.go
@@ -58,7 +58,7 @@ func (Token) TableName() string {
 
 // Validate ensures the token is bound to a repo and has a known type and a value.
 func (t *Token) Validate() error {
-	if t.RepoID == 0 {
+	if t.RepoID <= 0 {
 		return fmt.Errorf("repo id is required")
 	}
 

--- a/server/model/token_test.go
+++ b/server/model/token_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   Token
+		wantErr bool
+	}{
+		{
+			name:  "valid badge token",
+			token: Token{RepoID: 1, Type: TokenTypeBadge, Value: "secret"},
+		},
+		{
+			name:    "missing repo",
+			token:   Token{Type: TokenTypeBadge, Value: "secret"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown type",
+			token:   Token{RepoID: 1, Type: TokenType("cron"), Value: "secret"},
+			wantErr: true,
+		},
+		{
+			name:    "missing value",
+			token:   Token{RepoID: 1, Type: TokenTypeBadge},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.token.Validate()
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestTokenMatches(t *testing.T) {
+	token := Token{RepoID: 1, Type: TokenTypeBadge, Value: "secret"}
+
+	assert.True(t, token.Matches("secret"))
+	assert.False(t, token.Matches("secre"))
+	assert.False(t, token.Matches("secretsecret"))
+	assert.False(t, token.Matches(""))
+}
+
+func TestNewToken(t *testing.T) {
+	first := NewToken(3, TokenTypeBadge)
+	second := NewToken(3, TokenTypeBadge)
+
+	assert.NoError(t, first.Validate())
+	assert.Equal(t, int64(3), first.RepoID)
+	assert.Equal(t, TokenTypeBadge, first.Type)
+	assert.NotEqual(t, first.Value, second.Value)
+}

--- a/server/model/token_test.go
+++ b/server/model/token_test.go
@@ -36,6 +36,11 @@ func TestTokenValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "negative repo",
+			token:   Token{RepoID: -1, Type: TokenTypeBadge, Value: "secret"},
+			wantErr: true,
+		},
+		{
 			name:    "unknown type",
 			token:   Token{RepoID: 1, Type: TokenType("cron"), Value: "secret"},
 			wantErr: true,

--- a/server/router/api.go
+++ b/server/router/api.go
@@ -132,6 +132,9 @@ func apiRoutes(e *gin.RouterGroup) {
 					repo.DELETE("/logs/:pipeline_number", session.MustPush, session.SetPipeline(), api.DeletePipelineLogs)
 
 					// requires push permissions
+					repo.GET("/token", session.MustPush, api.GetRepoToken)
+
+					// requires push permissions
 					repo.GET("/secrets", session.MustPush, api.GetSecretList)
 					repo.POST("/secrets", session.MustPush, api.PostSecret)
 					repo.GET("/secrets/:secret", session.MustPush, api.GetSecret)

--- a/server/router/api.go
+++ b/server/router/api.go
@@ -133,6 +133,7 @@ func apiRoutes(e *gin.RouterGroup) {
 
 					// requires push permissions
 					repo.GET("/token", session.MustPush, api.GetRepoToken)
+					repo.POST("/token/rotate", session.MustRepoAdmin(), api.RotateRepoTokens)
 
 					// requires push permissions
 					repo.GET("/secrets", session.MustPush, api.GetSecretList)

--- a/server/router/api_test.go
+++ b/server/router/api_test.go
@@ -88,3 +88,66 @@ func TestRepoTokenRouteRequiresPush(t *testing.T) {
 	_, err = s.TokenFind(repo, model.TokenTypeBadge)
 	assert.NoError(t, err)
 }
+
+func TestRepoTokenRotateRouteRequiresAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := datastore.NewTestStore(t)
+	repo := &model.Repo{
+		ForgeID:       1,
+		ForgeRemoteID: "repo-token-rotate-route",
+		Owner:         "owner",
+		Name:          "repo-token-rotate-route",
+		FullName:      "owner/repo-token-rotate-route",
+		Visibility:    model.VisibilityPrivate,
+	}
+	require.NoError(t, s.CreateRepo(repo))
+	old := model.NewToken(repo.ID, model.TokenTypeBadge)
+	require.NoError(t, s.TokenCreate(old))
+	user := &model.User{ID: 1, Login: "user", ForgeID: repo.ForgeID}
+
+	manager := manager_mocks.NewMockManager(t)
+	manager.On("ForgeFromRepo", mock.Anything).Return(forge_mocks.NewMockForge(t), nil)
+	previousManager := server.Config.Services.Manager
+	server.Config.Services.Manager = manager
+	t.Cleanup(func() { server.Config.Services.Manager = previousManager })
+
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Set("store", s)
+		c.Set("user", user)
+		c.Next()
+	})
+	apiRoutes(engine.Group(""))
+
+	rotateToken := func() *httptest.ResponseRecorder {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/api/repos/"+strconv.FormatInt(repo.ID, 10)+"/token/rotate", nil)
+		engine.ServeHTTP(recorder, request)
+		return recorder
+	}
+
+	perm := &model.Perm{
+		UserID: user.ID,
+		RepoID: repo.ID,
+		Pull:   true,
+		Push:   true,
+		Synced: time.Now().Unix(),
+	}
+	require.NoError(t, s.PermUpsert(perm))
+
+	denied := rotateToken()
+	assert.Equal(t, http.StatusForbidden, denied.Code)
+	stored, err := s.TokenFind(repo, model.TokenTypeBadge)
+	require.NoError(t, err)
+	assert.Equal(t, old.Value, stored.Value)
+
+	perm.Admin = true
+	require.NoError(t, s.PermUpsert(perm))
+
+	allowed := rotateToken()
+	assert.Equal(t, http.StatusOK, allowed.Code)
+	stored, err = s.TokenFind(repo, model.TokenTypeBadge)
+	require.NoError(t, err)
+	assert.NotEqual(t, old.Value, stored.Value)
+}

--- a/server/router/api_test.go
+++ b/server/router/api_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server"
+	forge_mocks "go.woodpecker-ci.org/woodpecker/v3/server/forge/mocks"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	manager_mocks "go.woodpecker-ci.org/woodpecker/v3/server/services/mocks"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/datastore"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
+)
+
+func TestRepoTokenRouteRequiresPush(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := datastore.NewTestStore(t)
+	repo := &model.Repo{
+		ForgeID:       1,
+		ForgeRemoteID: "repo-token-route",
+		Owner:         "owner",
+		Name:          "repo-token-route",
+		FullName:      "owner/repo-token-route",
+		Visibility:    model.VisibilityPrivate,
+	}
+	require.NoError(t, s.CreateRepo(repo))
+	user := &model.User{ID: 1, Login: "user", ForgeID: repo.ForgeID}
+
+	manager := manager_mocks.NewMockManager(t)
+	manager.On("ForgeFromRepo", mock.Anything).Return(forge_mocks.NewMockForge(t), nil)
+	previousManager := server.Config.Services.Manager
+	server.Config.Services.Manager = manager
+	t.Cleanup(func() { server.Config.Services.Manager = previousManager })
+
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Set("store", s)
+		c.Set("user", user)
+		c.Next()
+	})
+	apiRoutes(engine.Group(""))
+
+	requestToken := func() *httptest.ResponseRecorder {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/api/repos/"+strconv.FormatInt(repo.ID, 10)+"/token", nil)
+		engine.ServeHTTP(recorder, request)
+		return recorder
+	}
+
+	perm := &model.Perm{UserID: user.ID, RepoID: repo.ID, Pull: true, Synced: time.Now().Unix()}
+	require.NoError(t, s.PermUpsert(perm))
+
+	denied := requestToken()
+	assert.Equal(t, http.StatusNotFound, denied.Code)
+	_, err := s.TokenFind(repo, model.TokenTypeBadge)
+	assert.ErrorIs(t, err, types.ErrRecordNotExist)
+
+	perm.Push = true
+	require.NoError(t, s.PermUpsert(perm))
+
+	allowed := requestToken()
+	assert.Equal(t, http.StatusOK, allowed.Code)
+	_, err = s.TokenFind(repo, model.TokenTypeBadge)
+	assert.NoError(t, err)
+}

--- a/server/store/datastore/migration/migration.go
+++ b/server/store/datastore/migration/migration.go
@@ -80,6 +80,7 @@ var allBeans = []any{
 	new(model.Forge),
 	new(model.Workflow),
 	new(model.Org),
+	new(model.Token),
 }
 
 // TODO: make xormigrate context aware

--- a/server/store/datastore/org_test.go
+++ b/server/store/datastore/org_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestOrgCRUD(t *testing.T) {
-	store, closer := newTestStore(t, new(model.Org), new(model.Repo), new(model.Secret), new(model.Config), new(model.Perm), new(model.Registry), new(model.Redirection), new(model.Pipeline))
+	store, closer := newTestStore(t, new(model.Org), new(model.Repo), new(model.Secret), new(model.Config), new(model.Perm), new(model.Registry), new(model.Redirection), new(model.Token), new(model.Pipeline))
 	defer closer()
 
 	org1 := &model.Org{

--- a/server/store/datastore/repo.go
+++ b/server/store/datastore/repo.go
@@ -118,6 +118,9 @@ func (s storage) deleteRepo(sess *xorm.Session, repo *model.Repo) error {
 	if _, err := sess.Where("repo_id = ?", repo.ID).Delete(new(model.Redirection)); err != nil {
 		return err
 	}
+	if _, err := sess.Where("repo_id = ?", repo.ID).Delete(new(model.Token)); err != nil {
+		return err
+	}
 
 	// delete related pipelines
 	for {

--- a/server/store/datastore/repo_test.go
+++ b/server/store/datastore/repo_test.go
@@ -296,6 +296,7 @@ func TestRepoCrud(t *testing.T) {
 		new(model.Registry),
 		new(model.Config),
 		new(model.Redirection),
+		new(model.Token),
 		new(model.Workflow))
 	defer closer()
 
@@ -362,6 +363,7 @@ func TestRepoDelete(t *testing.T) {
 		new(model.Registry),
 		new(model.Config),
 		new(model.Redirection),
+		new(model.Token),
 		new(model.Workflow))
 	defer closer()
 

--- a/server/store/datastore/token.go
+++ b/server/store/datastore/token.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"errors"
+	"fmt"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
+)
+
+func (s storage) TokenCreate(token *model.Token) error {
+	if err := token.Validate(); err != nil {
+		return err
+	}
+	err := wrapInsert(s.engine.Insert(token))
+	if errors.Is(err, types.ErrInsertDuplicateDetected) {
+		return fmt.Errorf("create token failed, duplicate detected: %w", err)
+	}
+	return err
+}
+
+func (s storage) TokenFind(repo *model.Repo, tokenType model.TokenType) (*model.Token, error) {
+	token := new(model.Token)
+	return token, wrapGet(s.engine.Where("repo_id = ? AND type = ?", repo.ID, tokenType).Get(token))
+}

--- a/server/store/datastore/token.go
+++ b/server/store/datastore/token.go
@@ -37,3 +37,35 @@ func (s storage) TokenFind(repo *model.Repo, tokenType model.TokenType) (*model.
 	token := new(model.Token)
 	return token, wrapGet(s.engine.Where("repo_id = ? AND type = ?", repo.ID, tokenType).Get(token))
 }
+
+// TokenReplace swaps all tokens of a repo for the given ones in a single
+// transaction, so a repo is never left without or with half of its tokens.
+func (s storage) TokenReplace(repo *model.Repo, tokens []*model.Token) error {
+	for _, token := range tokens {
+		if err := token.Validate(); err != nil {
+			return err
+		}
+		if token.RepoID != repo.ID {
+			return fmt.Errorf("token repo id %d does not match repo id %d", token.RepoID, repo.ID)
+		}
+	}
+
+	sess := s.engine.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+
+	if _, err := sess.Where("repo_id = ?", repo.ID).Delete(new(model.Token)); err != nil {
+		return err
+	}
+
+	for _, token := range tokens {
+		token.ID = 0
+		if err := wrapInsert(sess.Insert(token)); err != nil {
+			return err
+		}
+	}
+
+	return sess.Commit()
+}

--- a/server/store/datastore/token_test.go
+++ b/server/store/datastore/token_test.go
@@ -83,3 +83,90 @@ func TestTokenDeletedWithRepo(t *testing.T) {
 	_, err := store.TokenFind(repo, model.TokenTypeBadge)
 	assert.ErrorIs(t, err, types.ErrRecordNotExist)
 }
+
+// Replacing has to clear rows of a type this version no longer knows too,
+// those can only be dropped wholesale.
+func TestTokenReplace(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Token))
+	defer closer()
+
+	repo := &model.Repo{ID: 1, Name: "repo"}
+	other := &model.Repo{ID: 2, Name: "other"}
+	assert.NoError(t, store.TokenCreate(model.NewToken(repo.ID, model.TokenTypeBadge)))
+	otherToken := model.NewToken(other.ID, model.TokenTypeBadge)
+	assert.NoError(t, store.TokenCreate(otherToken))
+
+	// a stale token of a type this server version no longer supports
+	_, err := store.engine.Insert(&model.Token{RepoID: repo.ID, Type: model.TokenType("gone"), Value: "stale"})
+	assert.NoError(t, err)
+
+	fresh := model.NewToken(repo.ID, model.TokenTypeBadge)
+	assert.NoError(t, store.TokenReplace(repo, []*model.Token{fresh}))
+
+	stored, err := store.TokenFind(repo, model.TokenTypeBadge)
+	assert.NoError(t, err)
+	assert.Equal(t, fresh.Value, stored.Value)
+	_, err = store.TokenFind(repo, model.TokenType("gone"))
+	assert.ErrorIs(t, err, types.ErrRecordNotExist)
+
+	// tokens of other repos are untouched
+	stored, err = store.TokenFind(other, model.TokenTypeBadge)
+	assert.NoError(t, err)
+	assert.Equal(t, otherToken.Value, stored.Value)
+}
+
+// A rejected token must not take the old ones down with it.
+func TestTokenReplaceKeepsOldOnInvalid(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Token))
+	defer closer()
+
+	repo := &model.Repo{ID: 1, Name: "repo"}
+	old := model.NewToken(repo.ID, model.TokenTypeBadge)
+	assert.NoError(t, store.TokenCreate(old))
+
+	err := store.TokenReplace(repo, []*model.Token{{RepoID: repo.ID, Type: model.TokenType("unknown"), Value: "x"}})
+	assert.Error(t, err)
+
+	stored, err := store.TokenFind(repo, model.TokenTypeBadge)
+	assert.NoError(t, err)
+	assert.Equal(t, old.Value, stored.Value)
+}
+
+func TestTokenReplaceRejectsTokenForAnotherRepo(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Token))
+	defer closer()
+
+	repo := &model.Repo{ID: 1, Name: "repo"}
+	other := &model.Repo{ID: 2, Name: "other"}
+	old := model.NewToken(repo.ID, model.TokenTypeBadge)
+	assert.NoError(t, store.TokenCreate(old))
+
+	err := store.TokenReplace(repo, []*model.Token{model.NewToken(other.ID, model.TokenTypeBadge)})
+	assert.ErrorContains(t, err, "does not match repo id")
+
+	stored, err := store.TokenFind(repo, model.TokenTypeBadge)
+	assert.NoError(t, err)
+	assert.Equal(t, old.Value, stored.Value)
+	_, err = store.TokenFind(other, model.TokenTypeBadge)
+	assert.ErrorIs(t, err, types.ErrRecordNotExist)
+}
+
+func TestTokenReplaceRollsBackInsertFailure(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Token))
+	defer closer()
+
+	repo := &model.Repo{ID: 1, Name: "repo"}
+	other := &model.Repo{ID: 2, Name: "other"}
+	old := model.NewToken(repo.ID, model.TokenTypeBadge)
+	assert.NoError(t, store.TokenCreate(old))
+	conflicting := model.NewToken(other.ID, model.TokenTypeBadge)
+	assert.NoError(t, store.TokenCreate(conflicting))
+
+	replacement := model.NewToken(repo.ID, model.TokenTypeBadge)
+	replacement.Value = conflicting.Value
+	assert.Error(t, store.TokenReplace(repo, []*model.Token{replacement}))
+
+	stored, err := store.TokenFind(repo, model.TokenTypeBadge)
+	assert.NoError(t, err)
+	assert.Equal(t, old.Value, stored.Value)
+}

--- a/server/store/datastore/token_test.go
+++ b/server/store/datastore/token_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
+)
+
+func TestTokenCreate(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Token))
+	defer closer()
+
+	repo := &model.Repo{ID: 1, Name: "repo"}
+	token := model.NewToken(repo.ID, model.TokenTypeBadge)
+	assert.NoError(t, store.TokenCreate(token))
+	assert.NotEqualValues(t, 0, token.ID)
+
+	// a repo can only hold one token per type
+	duplicate := model.NewToken(repo.ID, model.TokenTypeBadge)
+	assert.ErrorIs(t, store.TokenCreate(duplicate), types.ErrInsertDuplicateDetected)
+
+	// invalid tokens are rejected
+	assert.Error(t, store.TokenCreate(&model.Token{RepoID: repo.ID, Type: model.TokenType("unknown"), Value: "x"}))
+}
+
+func TestTokenFind(t *testing.T) {
+	store, closer := newTestStore(t, new(model.Token))
+	defer closer()
+
+	repo1 := &model.Repo{ID: 1, Name: "repo1"}
+	repo2 := &model.Repo{ID: 2, Name: "repo2"}
+	token := model.NewToken(repo1.ID, model.TokenTypeBadge)
+	assert.NoError(t, store.TokenCreate(token))
+
+	found, err := store.TokenFind(repo1, model.TokenTypeBadge)
+	assert.NoError(t, err)
+	assert.Equal(t, token.Value, found.Value)
+
+	// tokens are not shared between repos
+	_, err = store.TokenFind(repo2, model.TokenTypeBadge)
+	assert.ErrorIs(t, err, types.ErrRecordNotExist)
+}
+
+func TestTokenDeletedWithRepo(t *testing.T) {
+	store, closer := newTestStore(t,
+		new(model.Token),
+		new(model.Repo),
+		new(model.Perm),
+		new(model.Pipeline),
+		new(model.PipelineConfig),
+		new(model.LogEntry),
+		new(model.Step),
+		new(model.Secret),
+		new(model.Registry),
+		new(model.Config),
+		new(model.Redirection),
+		new(model.Workflow))
+	defer closer()
+
+	repo := &model.Repo{Name: "repo", Owner: "owner", FullName: "owner/repo", ForgeRemoteID: "1"}
+	assert.NoError(t, store.CreateRepo(repo))
+	assert.NoError(t, store.TokenCreate(model.NewToken(repo.ID, model.TokenTypeBadge)))
+
+	assert.NoError(t, store.DeleteRepo(repo))
+
+	_, err := store.TokenFind(repo, model.TokenTypeBadge)
+	assert.ErrorIs(t, err, types.ErrRecordNotExist)
+}

--- a/server/store/mocks/mock_Store.go
+++ b/server/store/mocks/mock_Store.go
@@ -6239,6 +6239,63 @@ func (_c *MockStore_TokenFind_Call) RunAndReturn(run func(repo *model.Repo, toke
 	return _c
 }
 
+// TokenReplace provides a mock function for the type MockStore
+func (_mock *MockStore) TokenReplace(repo *model.Repo, tokens []*model.Token) error {
+	ret := _mock.Called(repo, tokens)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TokenReplace")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*model.Repo, []*model.Token) error); ok {
+		r0 = returnFunc(repo, tokens)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_TokenReplace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TokenReplace'
+type MockStore_TokenReplace_Call struct {
+	*mock.Call
+}
+
+// TokenReplace is a helper method to define mock.On call
+//   - repo *model.Repo
+//   - tokens []*model.Token
+func (_e *MockStore_Expecter) TokenReplace(repo any, tokens any) *MockStore_TokenReplace_Call {
+	return &MockStore_TokenReplace_Call{Call: _e.mock.On("TokenReplace", repo, tokens)}
+}
+
+func (_c *MockStore_TokenReplace_Call) Run(run func(repo *model.Repo, tokens []*model.Token)) *MockStore_TokenReplace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *model.Repo
+		if args[0] != nil {
+			arg0 = args[0].(*model.Repo)
+		}
+		var arg1 []*model.Token
+		if args[1] != nil {
+			arg1 = args[1].([]*model.Token)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_TokenReplace_Call) Return(err error) *MockStore_TokenReplace_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_TokenReplace_Call) RunAndReturn(run func(repo *model.Repo, tokens []*model.Token) error) *MockStore_TokenReplace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdatePipeline provides a mock function for the type MockStore
 func (_mock *MockStore) UpdatePipeline(pipeline *model.Pipeline) error {
 	ret := _mock.Called(pipeline)

--- a/server/store/mocks/mock_Store.go
+++ b/server/store/mocks/mock_Store.go
@@ -6120,6 +6120,125 @@ func (_c *MockStore_TaskList_Call) RunAndReturn(run func() ([]*model.Task, error
 	return _c
 }
 
+// TokenCreate provides a mock function for the type MockStore
+func (_mock *MockStore) TokenCreate(token *model.Token) error {
+	ret := _mock.Called(token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TokenCreate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*model.Token) error); ok {
+		r0 = returnFunc(token)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_TokenCreate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TokenCreate'
+type MockStore_TokenCreate_Call struct {
+	*mock.Call
+}
+
+// TokenCreate is a helper method to define mock.On call
+//   - token *model.Token
+func (_e *MockStore_Expecter) TokenCreate(token any) *MockStore_TokenCreate_Call {
+	return &MockStore_TokenCreate_Call{Call: _e.mock.On("TokenCreate", token)}
+}
+
+func (_c *MockStore_TokenCreate_Call) Run(run func(token *model.Token)) *MockStore_TokenCreate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *model.Token
+		if args[0] != nil {
+			arg0 = args[0].(*model.Token)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_TokenCreate_Call) Return(err error) *MockStore_TokenCreate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_TokenCreate_Call) RunAndReturn(run func(token *model.Token) error) *MockStore_TokenCreate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// TokenFind provides a mock function for the type MockStore
+func (_mock *MockStore) TokenFind(repo *model.Repo, tokenType model.TokenType) (*model.Token, error) {
+	ret := _mock.Called(repo, tokenType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TokenFind")
+	}
+
+	var r0 *model.Token
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*model.Repo, model.TokenType) (*model.Token, error)); ok {
+		return returnFunc(repo, tokenType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*model.Repo, model.TokenType) *model.Token); ok {
+		r0 = returnFunc(repo, tokenType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Token)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(*model.Repo, model.TokenType) error); ok {
+		r1 = returnFunc(repo, tokenType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_TokenFind_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TokenFind'
+type MockStore_TokenFind_Call struct {
+	*mock.Call
+}
+
+// TokenFind is a helper method to define mock.On call
+//   - repo *model.Repo
+//   - tokenType model.TokenType
+func (_e *MockStore_Expecter) TokenFind(repo any, tokenType any) *MockStore_TokenFind_Call {
+	return &MockStore_TokenFind_Call{Call: _e.mock.On("TokenFind", repo, tokenType)}
+}
+
+func (_c *MockStore_TokenFind_Call) Run(run func(repo *model.Repo, tokenType model.TokenType)) *MockStore_TokenFind_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *model.Repo
+		if args[0] != nil {
+			arg0 = args[0].(*model.Repo)
+		}
+		var arg1 model.TokenType
+		if args[1] != nil {
+			arg1 = args[1].(model.TokenType)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_TokenFind_Call) Return(token *model.Token, err error) *MockStore_TokenFind_Call {
+	_c.Call.Return(token, err)
+	return _c
+}
+
+func (_c *MockStore_TokenFind_Call) RunAndReturn(run func(repo *model.Repo, tokenType model.TokenType) (*model.Token, error)) *MockStore_TokenFind_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdatePipeline provides a mock function for the type MockStore
 func (_mock *MockStore) UpdatePipeline(pipeline *model.Pipeline) error {
 	ret := _mock.Called(pipeline)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -168,6 +168,10 @@ type Store interface {
 	CronListNextExecute(int64, int64) ([]*model.Cron, error)
 	CronGetLock(*model.Cron, int64) (bool, error)
 
+	// Token
+	TokenCreate(*model.Token) error
+	TokenFind(*model.Repo, model.TokenType) (*model.Token, error)
+
 	// Forge
 	ForgeCreate(*model.Forge) error
 	ForgeGet(int64) (*model.Forge, error)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -171,6 +171,7 @@ type Store interface {
 	// Token
 	TokenCreate(*model.Token) error
 	TokenFind(*model.Repo, model.TokenType) (*model.Token, error)
+	TokenReplace(*model.Repo, []*model.Token) error
 
 	// Forge
 	ForgeCreate(*model.Forge) error

--- a/shared/utils/random.go
+++ b/shared/utils/random.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"encoding/base32"
+	"math"
+
+	"github.com/tink-crypto/tink-go/v2/subtle/random"
+)
+
+// base32NoPadding keeps generated strings free of the '=' padding, so they can
+// be used in URLs and headers without escaping.
+var base32NoPadding = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+const (
+	// Every base32 character carries five bits.
+	bitsPerBase32Char = 5
+	bitsPerByte       = 8
+)
+
+// RandomString returns a cryptographically secure random string of exactly
+// length characters, drawn from the base32 alphabet. It is the single place
+// tokens, secrets and hashes are generated, so their strength does not depend
+// on every call site getting the encoding right.
+func RandomString(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
+	byteLen := (length*bitsPerBase32Char + bitsPerByte - 1) / bitsPerByte
+	if byteLen > math.MaxUint32 {
+		byteLen = math.MaxUint32
+	}
+
+	return base32NoPadding.EncodeToString(random.GetRandomBytes(uint32(byteLen)))[:length]
+}

--- a/shared/utils/random.go
+++ b/shared/utils/random.go
@@ -27,8 +27,9 @@ var base32NoPadding = base32.StdEncoding.WithPadding(base32.NoPadding)
 
 const (
 	// Every base32 character carries five bits.
-	bitsPerBase32Char = 5
-	bitsPerByte       = 8
+	bitsPerBase32Char     = 5
+	bitsPerByte           = 8
+	maxRandomStringLength = uint64(math.MaxUint32) * bitsPerByte / bitsPerBase32Char
 )
 
 // RandomString returns a cryptographically secure random string of exactly
@@ -40,10 +41,11 @@ func RandomString(length int) string {
 		return ""
 	}
 
-	byteLen := (length*bitsPerBase32Char + bitsPerByte - 1) / bitsPerByte
-	if byteLen > math.MaxUint32 {
-		byteLen = math.MaxUint32
+	requestedLength := uint64(length)
+	if requestedLength > maxRandomStringLength {
+		return ""
 	}
+	byteLen := (requestedLength*bitsPerBase32Char + bitsPerByte - 1) / bitsPerByte
 
 	return base32NoPadding.EncodeToString(random.GetRandomBytes(uint32(byteLen)))[:length]
 }

--- a/shared/utils/random_test.go
+++ b/shared/utils/random_test.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -49,4 +50,14 @@ func TestRandomStringIsRandom(t *testing.T) {
 func TestRandomStringWithoutLength(t *testing.T) {
 	assert.Empty(t, RandomString(0))
 	assert.Empty(t, RandomString(-1))
+}
+
+func TestRandomStringTooLong(t *testing.T) {
+	tooLong := int(^uint(0) >> 1)
+	maxLength := uint64(math.MaxUint32) * bitsPerByte / bitsPerBase32Char
+	if uint64(tooLong) <= maxLength {
+		t.Skip("int cannot represent an oversized request on this platform")
+	}
+
+	assert.Empty(t, RandomString(tooLong))
 }

--- a/shared/utils/random_test.go
+++ b/shared/utils/random_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomString(t *testing.T) {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+	for _, length := range []int{1, 7, 8, 32, 52, 100} {
+		value := RandomString(length)
+
+		assert.Len(t, value, length)
+		assert.NotContains(t, value, "=", "padding would need escaping in URLs")
+		for _, char := range value {
+			assert.True(t, strings.ContainsRune(alphabet, char), "unexpected character %q", char)
+		}
+	}
+}
+
+func TestRandomStringIsRandom(t *testing.T) {
+	const runs = 100
+
+	seen := make(map[string]struct{}, runs)
+	for range runs {
+		seen[RandomString(52)] = struct{}{}
+	}
+
+	assert.Len(t, seen, runs, "every call should return its own value")
+}
+
+func TestRandomStringWithoutLength(t *testing.T) {
+	assert.Empty(t, RandomString(0))
+	assert.Empty(t, RandomString(-1))
+}

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -197,6 +197,12 @@
           "repair": "Repair repository",
           "success": "Repository repaired"
         },
+        "rotate_tokens": {
+          "rotate_tokens": "Rotate all tokens",
+          "desc": "Rotate all repository tokens and clean up stale ones",
+          "confirm": "Existing private badge URLs and other links containing a repository token will stop working immediately.\n\nRotate all repository tokens?",
+          "success": "Repository tokens rotated"
+        },
         "disable": {
           "disable": "Disable repository",
           "success": "Repository disabled"

--- a/web/src/compositions/useInjectProvide.ts
+++ b/web/src/compositions/useInjectProvide.ts
@@ -8,6 +8,7 @@ import type { Tab } from './useTabs';
 export interface InjectKeys {
   repo: Ref<Repo>;
   'repo-permissions': Ref<RepoPermissions>;
+  'badge-token': Ref<string>;
   org: Ref<Org>;
   'org-permissions': Ref<OrgPermissions>;
   pipeline: Ref<Pipeline>;

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 import ApiClient, { encodeQueryString } from './client';
+import { TokenType } from './types';
 import type {
   Agent,
   Cron,
@@ -17,6 +18,7 @@ import type {
   RepoPermissions,
   RepoSettings,
   Secret,
+  Token,
   User,
 } from './types';
 
@@ -69,6 +71,10 @@ export default class WoodpeckerClient extends ApiClient {
   async getRepoBranches(repoId: number, opts?: PaginationOptions): Promise<string[]> {
     const query = encodeQueryString(opts);
     return this._get(`/api/repos/${repoId}/branches?${query}`) as Promise<string[]>;
+  }
+
+  async getRepoToken(repoId: number, type: TokenType = TokenType.Badge): Promise<Token> {
+    return this._get(`/api/repos/${repoId}/token?type=${type}`) as Promise<Token>;
   }
 
   async getRepoPullRequests(repoId: number, opts?: PaginationOptions): Promise<PullRequest[]> {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -77,6 +77,10 @@ export default class WoodpeckerClient extends ApiClient {
     return this._get(`/api/repos/${repoId}/token?type=${type}`) as Promise<Token>;
   }
 
+  async rotateRepoTokens(repoId: number): Promise<Token[]> {
+    return this._post(`/api/repos/${repoId}/token/rotate`) as Promise<Token[]>;
+  }
+
   async getRepoPullRequests(repoId: number, opts?: PaginationOptions): Promise<PullRequest[]> {
     const query = encodeQueryString(opts);
     return this._get(`/api/repos/${repoId}/pull_requests?${query}`) as Promise<PullRequest[]>;

--- a/web/src/lib/api/types/index.ts
+++ b/web/src/lib/api/types/index.ts
@@ -9,5 +9,6 @@ export * from './queue';
 export * from './registry';
 export * from './repo';
 export * from './secret';
+export * from './token';
 export * from './user';
 export * from './webhook';

--- a/web/src/lib/api/types/token.ts
+++ b/web/src/lib/api/types/token.ts
@@ -1,0 +1,14 @@
+/* eslint-disable no-unused-vars */
+export enum TokenType {
+  Badge = 'badge',
+}
+/* eslint-enable */
+
+// A secret bound to a repo, granting access to a single feature of it.
+export interface Token {
+  id: number;
+  repo_id: number;
+  type: TokenType;
+  value: string;
+  created: number;
+}

--- a/web/src/views/repo/RepoWrapper.vue
+++ b/web/src/views/repo/RepoWrapper.vue
@@ -111,6 +111,7 @@ const forgeIcon = computed<IconNames>(() => {
 // non-public repos only serve their badge to holders of the badge token, which
 // in turn is only readable with push permissions
 const badgeToken = ref<string>('');
+provide('badge-token', badgeToken);
 
 async function loadBadgeToken() {
   badgeToken.value = '';

--- a/web/src/views/repo/RepoWrapper.vue
+++ b/web/src/views/repo/RepoWrapper.vue
@@ -71,6 +71,7 @@ import { useForgeStore } from '~/compositions/useForgeStore';
 import { provide } from '~/compositions/useInjectProvide';
 import useNotifications from '~/compositions/useNotifications';
 import useRepos from '~/compositions/useRepos';
+import { RepoVisibility } from '~/lib/api/types';
 import type { Forge, Repo, RepoPermissions } from '~/lib/api/types';
 import { usePipelineStore } from '~/store/pipelines';
 import { useRepoStore } from '~/store/repos';
@@ -107,6 +108,18 @@ const forgeIcon = computed<IconNames>(() => {
   return 'repo';
 });
 
+// non-public repos only serve their badge to holders of the badge token, which
+// in turn is only readable with push permissions
+const badgeToken = ref<string>('');
+
+async function loadBadgeToken() {
+  badgeToken.value = '';
+  if (repo.value?.visibility === RepoVisibility.Public || !repoPermissions.value?.push) {
+    return;
+  }
+  badgeToken.value = (await apiClient.getRepoToken(repositoryId.value)).value;
+}
+
 async function loadRepo() {
   repoPermissions.value = await apiClient.getRepoPermissions(repositoryId.value);
   if (!repoPermissions.value.pull) {
@@ -126,6 +139,7 @@ async function loadRepo() {
   if (repo.value) {
     forge.value = (await forgeStore.getForge(repo.value?.forge_id)).value;
   }
+  await loadBadgeToken();
   updateLastAccess(repositoryId.value);
 }
 
@@ -137,5 +151,17 @@ watch([repositoryId], () => {
   loadRepo();
 });
 
-const badgeUrl = computed(() => repo.value && `${config.rootPath}/api/badges/${repo.value.id}/status.svg`);
+const badgeUrl = computed(() => {
+  if (!repo.value) {
+    return undefined;
+  }
+
+  const url = `${config.rootPath}/api/badges/${repo.value.id}/status.svg`;
+  if (repo.value.visibility === RepoVisibility.Public) {
+    return url;
+  }
+
+  // without the token the badge would only state that it may not be shown
+  return badgeToken.value === '' ? undefined : `${url}?token=${encodeURIComponent(badgeToken.value)}`;
+});
 </script>

--- a/web/src/views/repo/settings/Actions.test.ts
+++ b/web/src/views/repo/settings/Actions.test.ts
@@ -1,0 +1,105 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, ref } from 'vue';
+import { createI18n } from 'vue-i18n';
+
+import en from '~/assets/locales/en.json';
+import type { Repo, Token } from '~/lib/api/types';
+import { RepoVisibility, TokenType } from '~/lib/api/types';
+
+import Actions from './Actions.vue';
+
+const apiClient = vi.hoisted(() => ({
+  rotateRepoTokens: vi.fn(),
+}));
+const notifications = vi.hoisted(() => ({ notify: vi.fn() }));
+const router = vi.hoisted(() => ({ replace: vi.fn() }));
+
+vi.mock('vue-router', () => ({ useRouter: () => router }));
+vi.mock('~/compositions/useApiClient', () => ({ default: () => apiClient }));
+vi.mock('~/compositions/useNotifications', () => ({ default: () => notifications }));
+vi.mock('~/compositions/useWPTitle', () => ({ useWPTitle: () => undefined }));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en },
+});
+
+const SettingsStub = defineComponent({ template: '<section><slot/></section>' });
+
+function repo(): Repo {
+  return {
+    id: 1,
+    active: true,
+    forge_remote_id: '1',
+    full_name: 'owner/repo',
+    visibility: RepoVisibility.Private,
+  } as Repo;
+}
+
+function token(value: string): Token {
+  return {
+    id: 1,
+    repo_id: 1,
+    type: TokenType.Badge,
+    value,
+    created: 0,
+  };
+}
+
+function mountActions() {
+  const badgeToken = ref('old-token');
+  const wrapper = mount(Actions, {
+    global: {
+      plugins: [i18n],
+      provide: { repo: ref(repo()), 'badge-token': badgeToken },
+      stubs: { Settings: SettingsStub },
+    },
+  });
+  const rotateButton = wrapper
+    .findAll('button')
+    .find((button) => button.text() === i18n.global.t('repo.settings.actions.rotate_tokens.rotate_tokens'));
+  expect(rotateButton).toBeDefined();
+  expect(rotateButton!.text()).toBe(i18n.global.t('repo.settings.actions.rotate_tokens.rotate_tokens'));
+  return { badgeToken, rotateButton: rotateButton!, wrapper };
+}
+
+beforeEach(() => {
+  apiClient.rotateRepoTokens.mockReset();
+  notifications.notify.mockReset();
+  router.replace.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe('repository token rotation', () => {
+  it('does not rotate tokens when confirmation is rejected', async () => {
+    const confirm = vi.fn().mockReturnValue(false);
+    vi.stubGlobal('confirm', confirm);
+    const { badgeToken, rotateButton } = mountActions();
+
+    await rotateButton.trigger('click');
+    await flushPromises();
+
+    expect(confirm).toHaveBeenCalledWith(i18n.global.t('repo.settings.actions.rotate_tokens.confirm'));
+    expect(confirm.mock.calls[0][0]).toContain('stop working immediately');
+    expect(apiClient.rotateRepoTokens).not.toHaveBeenCalled();
+    expect(badgeToken.value).toBe('old-token');
+  });
+
+  it('updates the shared badge token from the rotation response', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    apiClient.rotateRepoTokens.mockResolvedValue([token('new-token')]);
+    const { badgeToken, rotateButton } = mountActions();
+
+    await rotateButton.trigger('click');
+    await flushPromises();
+
+    expect(apiClient.rotateRepoTokens).toHaveBeenCalledWith(1);
+    expect(badgeToken.value).toBe('new-token');
+    expect(notifications.notify).toHaveBeenCalledWith({
+      title: i18n.global.t('repo.settings.actions.rotate_tokens.success'),
+      type: 'success',
+    });
+  });
+});

--- a/web/src/views/repo/settings/Actions.vue
+++ b/web/src/views/repo/settings/Actions.vue
@@ -11,6 +11,16 @@
       />
 
       <Button
+        class="my-1 mr-4"
+        color="blue"
+        start-icon="secret"
+        :is-loading="isRotatingTokens"
+        :text="$t('repo.settings.actions.rotate_tokens.rotate_tokens')"
+        :title="$t('repo.settings.actions.rotate_tokens.desc')"
+        @click="rotateTokens"
+      />
+
+      <Button
         v-if="isActive"
         color="blue"
         class="my-1 mr-4"
@@ -53,6 +63,7 @@ import { useAsyncAction } from '~/compositions/useAsyncAction';
 import { requiredInject } from '~/compositions/useInjectProvide';
 import useNotifications from '~/compositions/useNotifications';
 import { useWPTitle } from '~/compositions/useWPTitle';
+import { TokenType } from '~/lib/api/types';
 
 const apiClient = useApiClient();
 const router = useRouter();
@@ -60,10 +71,23 @@ const notifications = useNotifications();
 const i18n = useI18n();
 
 const repo = requiredInject('repo');
+const badgeToken = requiredInject('badge-token');
 
 const { doSubmit: repairRepo, isLoading: isRepairingRepo } = useAsyncAction(async () => {
   await apiClient.repairRepo(repo.value.id);
   notifications.notify({ title: i18n.t('repo.settings.actions.repair.success'), type: 'success' });
+});
+
+const { doSubmit: rotateTokens, isLoading: isRotatingTokens } = useAsyncAction(async () => {
+  // TODO: use proper dialog
+  // eslint-disable-next-line no-alert
+  if (!confirm(i18n.t('repo.settings.actions.rotate_tokens.confirm'))) {
+    return;
+  }
+
+  const tokens = await apiClient.rotateRepoTokens(repo.value.id);
+  badgeToken.value = tokens.find((token) => token.type === TokenType.Badge)?.value ?? '';
+  notifications.notify({ title: i18n.t('repo.settings.actions.rotate_tokens.success'), type: 'success' });
 });
 
 const { doSubmit: deleteRepo, isLoading: isDeletingRepo } = useAsyncAction(async () => {

--- a/web/src/views/repo/settings/Badge.test.ts
+++ b/web/src/views/repo/settings/Badge.test.ts
@@ -1,0 +1,107 @@
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, nextTick, ref } from 'vue';
+import { createI18n } from 'vue-i18n';
+
+import en from '~/assets/locales/en.json';
+import type { Repo, Token } from '~/lib/api/types';
+import { RepoVisibility, TokenType } from '~/lib/api/types';
+
+import Badge from './Badge.vue';
+
+const apiClient = vi.hoisted(() => ({
+  getRepoBranches: vi.fn(),
+  getRepoToken: vi.fn(),
+}));
+
+vi.mock('~/compositions/useApiClient', () => ({ default: () => apiClient }));
+vi.mock('~/compositions/useConfig', () => ({ default: () => ({ rootPath: '' }) }));
+vi.mock('~/compositions/usePaginate', () => ({ usePaginate: async () => [] }));
+vi.mock('~/compositions/useWPTitle', () => ({ useWPTitle: () => undefined }));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en },
+});
+
+const SettingsStub = defineComponent({ template: '<section><slot name="titleActions"/><slot/></section>' });
+const InputFieldStub = defineComponent({ template: '<div><slot id="field"/></div>' });
+
+function privateRepo(id: number): Repo {
+  return {
+    id,
+    default_branch: 'main',
+    full_name: `owner/repo-${id}`,
+    visibility: RepoVisibility.Private,
+  } as Repo;
+}
+
+function token(repoId: number, value: string): Token {
+  return {
+    id: repoId,
+    repo_id: repoId,
+    type: TokenType.Badge,
+    value,
+    created: 0,
+  };
+}
+
+function mountBadge(repo = ref(privateRepo(1))) {
+  const wrapper = shallowMount(Badge, {
+    global: {
+      plugins: [i18n],
+      provide: { repo },
+      stubs: {
+        CheckboxesField: true,
+        InputField: InputFieldStub,
+        SelectField: true,
+        Settings: SettingsStub,
+        TextField: true,
+      },
+    },
+  });
+  return { repo, wrapper };
+}
+
+beforeEach(() => {
+  apiClient.getRepoBranches.mockReset();
+  apiClient.getRepoToken.mockReset();
+  localStorage.clear();
+});
+
+describe('badge settings token', () => {
+  it('hides private badge snippets until their token is loaded', async () => {
+    const pending = Promise.withResolvers<Token>();
+    apiClient.getRepoToken.mockReturnValueOnce(pending.promise);
+    const { wrapper } = mountBadge();
+    await nextTick();
+
+    expect(wrapper.find('.code-box').exists()).toBe(false);
+
+    pending.resolve(token(1, 'private-token'));
+    await flushPromises();
+
+    expect(wrapper.find('.code-box').text()).toContain('token=private-token');
+  });
+
+  it('discards a token response for a repo that is no longer displayed', async () => {
+    const first = Promise.withResolvers<Token>();
+    const second = Promise.withResolvers<Token>();
+    apiClient.getRepoToken.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const { repo, wrapper } = mountBadge();
+    await nextTick();
+
+    repo.value = privateRepo(2);
+    await nextTick();
+
+    second.resolve(token(2, 'current-token'));
+    await flushPromises();
+    expect(wrapper.find('.code-box').text()).toContain('token=current-token');
+
+    first.resolve(token(1, 'stale-token'));
+    await flushPromises();
+    expect(wrapper.find('.code-box').text()).toContain('token=current-token');
+    expect(wrapper.find('.code-box').text()).not.toContain('token=stale-token');
+  });
+});

--- a/web/src/views/repo/settings/Badge.vue
+++ b/web/src/views/repo/settings/Badge.vue
@@ -87,13 +87,23 @@ const step = ref<string>('');
 // non-public repos only serve their badge when the badge token is passed along
 const badgeToken = ref<string>('');
 const needsToken = computed(() => repo.value.visibility !== RepoVisibility.Public);
+let badgeTokenRequest = 0;
 
 async function loadBadgeToken() {
+  const request = ++badgeTokenRequest;
+  badgeToken.value = '';
   if (!needsToken.value) {
-    badgeToken.value = '';
     return;
   }
-  badgeToken.value = (await apiClient.getRepoToken(repo.value.id)).value;
+
+  try {
+    const token = await apiClient.getRepoToken(repo.value.id);
+    if (request === badgeTokenRequest) {
+      badgeToken.value = token.value;
+    }
+  } catch {
+    // The API client reports the request error; keep token-bound output hidden.
+  }
 }
 
 async function loadBranches() {
@@ -114,6 +124,10 @@ const baseUrl = `${window.location.protocol}//${window.location.hostname}${
 }`;
 const { rootPath } = useConfig();
 const badgeUrl = computed(() => {
+  if (needsToken.value && badgeToken.value === '') {
+    return undefined;
+  }
+
   const params = [];
 
   if (branch.value !== '') {
@@ -147,16 +161,21 @@ const repoUrl = computed(
 );
 
 const badgeContent = computed(() => {
+  const url = badgeUrl.value;
+  if (!url) {
+    return '';
+  }
+
   if (badgeType.value === 'url') {
-    return `${baseUrl}${badgeUrl.value}`;
+    return `${baseUrl}${url}`;
   }
 
   if (badgeType.value === 'markdown') {
-    return `[![status-badge](${baseUrl}${badgeUrl.value})](${baseUrl}${repoUrl.value})`;
+    return `[![status-badge](${baseUrl}${url})](${baseUrl}${repoUrl.value})`;
   }
 
   if (badgeType.value === 'html') {
-    return `<a href="${baseUrl}${repoUrl.value}" target="_blank">\n  <img src="${baseUrl}${badgeUrl.value.replaceAll('&', '&amp;')}" alt="status-badge" />\n</a>`;
+    return `<a href="${baseUrl}${repoUrl.value}" target="_blank">\n  <img src="${baseUrl}${url.replaceAll('&', '&amp;')}" alt="status-badge" />\n</a>`;
   }
 
   return '';

--- a/web/src/views/repo/settings/Badge.vue
+++ b/web/src/views/repo/settings/Badge.vue
@@ -70,7 +70,7 @@ import useConfig from '~/compositions/useConfig';
 import { requiredInject } from '~/compositions/useInjectProvide';
 import { usePaginate } from '~/compositions/usePaginate';
 import { useWPTitle } from '~/compositions/useWPTitle';
-import { WebhookEvents } from '~/lib/api/types';
+import { RepoVisibility, WebhookEvents } from '~/lib/api/types';
 
 const apiClient = useApiClient();
 const repo = requiredInject('repo');
@@ -83,6 +83,18 @@ const branch = ref<string>('');
 const events = ref<string[]>([WebhookEvents.Push]);
 const workflow = ref<string>('');
 const step = ref<string>('');
+
+// non-public repos only serve their badge when the badge token is passed along
+const badgeToken = ref<string>('');
+const needsToken = computed(() => repo.value.visibility !== RepoVisibility.Public);
+
+async function loadBadgeToken() {
+  if (!needsToken.value) {
+    badgeToken.value = '';
+    return;
+  }
+  badgeToken.value = (await apiClient.getRepoToken(repo.value.id)).value;
+}
 
 async function loadBranches() {
   branches.value = (await usePaginate((page) => apiClient.getRepoBranches(repo.value.id, { page })))
@@ -123,6 +135,10 @@ const badgeUrl = computed(() => {
     }
   }
 
+  if (badgeToken.value !== '') {
+    params.push(`token=${encodeURIComponent(badgeToken.value)}`);
+  }
+
   return `${rootPath}/api/badges/${repo.value.id}/status.svg${params.length > 0 ? `?${params.join('&')}` : ''}`;
 });
 const repoUrl = computed(
@@ -140,7 +156,7 @@ const badgeContent = computed(() => {
   }
 
   if (badgeType.value === 'html') {
-    return `<a href="${baseUrl}${repoUrl.value}" target="_blank">\n  <img src="${baseUrl}${badgeUrl.value.replace('&', '&amp;')}" alt="status-badge" />\n</a>`;
+    return `<a href="${baseUrl}${repoUrl.value}" target="_blank">\n  <img src="${baseUrl}${badgeUrl.value.replaceAll('&', '&amp;')}" alt="status-badge" />\n</a>`;
   }
 
   return '';
@@ -148,10 +164,12 @@ const badgeContent = computed(() => {
 
 onMounted(() => {
   loadBranches();
+  loadBadgeToken();
 });
 
 watch(repo, () => {
   loadBranches();
+  loadBadgeToken();
 });
 
 const { t } = useI18n();


### PR DESCRIPTION
This adds tokens to woodpecker for scoped access.

currently this is only used for badges to gate private repos ... but more could come.

dRAFT because only spec drafted, ai coded and heavy reviewed ... but no real execution done jet