### PR TITLE
Prevent repository buttons from overlapping search bar

### DIFF
--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -71,8 +71,8 @@
     "activity": "Activity",
     "branches": "Branches",
     "pull_requests": "Pull requests",
-    "add": "Add repository",
-    "refresh": "Refresh repository list",
+    "add": "Add repo",
+    "refresh": "Refresh repos",
     "user_none": "This organization/user has no projects yet",
     "not_allowed": "You are not allowed to access this repository",
     "enable": {

--- a/web/src/assets/locales/en.json
+++ b/web/src/assets/locales/en.json
@@ -71,8 +71,8 @@
     "activity": "Activity",
     "branches": "Branches",
     "pull_requests": "Pull requests",
-    "add": "Add repo",
-    "refresh": "Refresh repos",
+    "add": "Add repository",
+    "refresh": "Refresh repository list",
     "user_none": "This organization/user has no projects yet",
     "not_allowed": "You are not allowed to access this repository",
     "enable": {

--- a/web/src/components/layout/scaffold/Header.vue
+++ b/web/src/components/layout/scaffold/Header.vue
@@ -30,7 +30,7 @@
           />
           <div
             v-if="$slots.headerActions"
-            class="flex min-w-0 items-center gap-x-2 md:justify-end"
+            class="flex items-center gap-x-2 md:justify-end"
             :class="{
               'md:flex-1': searchBoxPresent,
             }"

--- a/web/src/components/layout/scaffold/Header.vue
+++ b/web/src/components/layout/scaffold/Header.vue
@@ -30,7 +30,7 @@
           />
           <div
             v-if="$slots.headerActions"
-            class="flex items-center gap-x-2 md:justify-end"
+            class="flex flex-wrap items-center gap-x-2 gap-y-2 md:flex-nowrap md:justify-end"
             :class="{
               'md:flex-1': searchBoxPresent,
             }"

--- a/web/src/components/layout/scaffold/Header.vue
+++ b/web/src/components/layout/scaffold/Header.vue
@@ -22,7 +22,7 @@
           </div>
           <TextField
             v-if="searchBoxPresent"
-            class="order-3 w-full grow md:order-none md:w-auto"
+            class="order-3 h-9 w-full grow md:order-none md:w-auto"
             :aria-label="$t('search')"
             :placeholder="$t('search')"
             :model-value="search"

--- a/web/src/views/Repos.vue
+++ b/web/src/views/Repos.vue
@@ -5,8 +5,21 @@
     </template>
 
     <template #headerActions>
-      <Button :to="{ name: 'repo-add' }" start-icon="plus" :text="$t('repo.add')" />
-      <Button start-icon="refresh" :is-loading="isRefreshing" :text="$t('repo.refresh')" @click="refreshRepositories" />
+      <Button
+        :to="{ name: 'repo-add' }"
+        start-icon="plus"
+        :title="$t('repo.add')"
+        :aria-label="$t('repo.add')"
+        class="h-9"
+      />
+      <Button
+        start-icon="refresh"
+        :is-loading="isRefreshing"
+        :title="$t('repo.refresh')"
+        :aria-label="$t('repo.refresh')"
+        class="h-9"
+        @click="refreshRepositories"
+      />
     </template>
 
     <Transition name="fade" mode="out-in">


### PR DESCRIPTION
Minimal fix for: https://github.com/woodpecker-ci/woodpecker/issues/6739
Supersedes: https://github.com/woodpecker-ci/woodpecker/pull/6804

<img width="2596" height="1172" alt="image" src="https://github.com/user-attachments/assets/a535e046-33ee-4fa4-9c98-a1ad90c1ea45" />

<img width="1702" height="1178" alt="image" src="https://github.com/user-attachments/assets/9ca36418-2486-4f71-a866-25a2a4b90dea" />

<img width="1266" height="1176" alt="image" src="https://github.com/user-attachments/assets/e8a8a4df-6e61-465d-93d7-d8958d8a4156" />

