### PR TITLE
Docker: give SQLite a writable temp dir

### DIFF
--- a/docker/Dockerfile.server.alpine.multiarch.rootless
+++ b/docker/Dockerfile.server.alpine.multiarch.rootless
@@ -11,6 +11,7 @@ ENV GODEBUG=netdns=go
 ENV WOODPECKER_IN_CONTAINER=true
 ENV XDG_CACHE_HOME=/var/lib/woodpecker
 ENV XDG_DATA_HOME=/var/lib/woodpecker
+ENV SQLITE_TMPDIR=/var/lib/woodpecker
 EXPOSE 8000 9000 80 443
 
 COPY dist/server/${TARGETOS}_${TARGETARCH}/woodpecker-server /bin/

--- a/docker/Dockerfile.server.multiarch.rootless
+++ b/docker/Dockerfile.server.multiarch.rootless
@@ -11,6 +11,7 @@ ENV GODEBUG=netdns=go
 ENV WOODPECKER_IN_CONTAINER=true
 ENV XDG_CACHE_HOME=/var/lib/woodpecker
 ENV XDG_DATA_HOME=/var/lib/woodpecker
+ENV SQLITE_TMPDIR=/var/lib/woodpecker
 EXPOSE 8000 9000 80 443
 
 # copy certs from certs image


### PR DESCRIPTION
Migration deduplicate-log-entries (#7004) runs a
DELETE whose plan needs a temp b-tree, which spills to a temp file. SQLite looks for one in SQLITE_TMPDIR, TMPDIR, /var/tmp, /usr/tmp, /tmp, then CWD. The server image is built FROM scratch, sets no WORKDIR and runs as uid 1000, so none of those exist or are writable and startup fails with "disk I/O error: permission denied".

Point SQLite at the data volume. It is writable by definition, since the DB and its rollback journal already live there.

close https://github.com/woodpecker-ci/woodpecker/issues/7020