### PR TITLE
fix(server): prefix manual trigger Ref with refs/heads/

### DIFF
--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -100,7 +100,7 @@ func createTmpPipeline(event model.WebhookEvent, commit *model.Commit, user *mod
 		Avatar:  user.Avatar,
 		Message: "MANUAL PIPELINE @ " + opts.Branch,
 
-		Ref:                 opts.Branch,
+		Ref:                 "refs/heads/" + opts.Branch,
 		AdditionalVariables: opts.Variables,
 
 		Author: user.Login,


### PR DESCRIPTION
## Summary
Manual pipeline triggers set `Ref` to the bare branch name (e.g. `dev`), while GitLab/webhook and cron triggers set it to the fully-qualified ref (e.g. `refs/heads/dev`).

This inconsistency causes `when.ref` constraints (e.g. `refs/heads/dev`) to silently filter out all workflows on manual triggers, returning HTTP 204 ("No matching workflows found") even though the config is valid.

## Changes
- `server/api/pipeline.go`: in `createTmpPipeline`, set `Ref: "refs/heads/" + opts.Branch` to match the behavior of `server/cron/cron.go` (which already uses `"refs/heads/" + cron.Branch`).

## Test Plan
- Manual trigger of a repo whose `.woodpecker.yml` uses `when.ref.include: [refs/heads/dev]` now creates the pipeline instead of returning 204.
- Cron and push triggers remain unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)