### PR TITLE
feat: Add pipeline token to authenticate against Woodpecker APIs

### DIFF
--- a/server/api/repo.go
+++ b/server/api/repo.go
@@ -327,6 +327,9 @@ func PatchRepo(c *gin.Context) {
 	if in.SecretExtensionNetrc != nil {
 		repo.SecretExtensionNetrc = *in.SecretExtensionNetrc
 	}
+	if in.ExposeAccessTokenEvents != nil {
+		repo.ExposeAccessTokenEvents = *in.ExposeAccessTokenEvents
+	}
 
 	err := _store.UpdateRepo(repo)
 	if err != nil {

--- a/server/model/repo.go
+++ b/server/model/repo.go
@@ -78,6 +78,7 @@ type Repo struct {
 	RegistryExtensionNetrc       bool                 `json:"registry_extension_netrc"          xorm:"DEFAULT FALSE 'registry_extension_netrc'"`
 	SecretExtensionEndpoint      string               `json:"secret_extension_endpoint"       xorm:"varchar(500) 'secret_extension_endpoint'"`
 	SecretExtensionNetrc         bool                 `json:"secret_extension_netrc"          xorm:"DEFAULT FALSE 'secret_extension_netrc'"`
+	ExposeAccessTokenEvents      []WebhookEvent       `json:"expose_access_token_events" xorm:"json 'expose_access_token_events'"`
 
 	// Rest API Only
 
@@ -169,6 +170,7 @@ type RepoPatch struct {
 	RegistryExtensionNetrc       *bool                      `json:"registry_extension_netrc"`
 	SecretExtensionEndpoint      *string                    `json:"secret_extension_endpoint,omitempty"`
 	SecretExtensionNetrc         *bool                      `json:"secret_extension_netrc,omitempty"`
+	ExposeAccessTokenEvents      *[]WebhookEvent            `json:"expose_access_token_events"`
 } //	@name	RepoPatch
 
 type ForgeRemoteID string

--- a/server/pipeline/items.go
+++ b/server/pipeline/items.go
@@ -70,17 +70,27 @@ func parsePipeline(ctx context.Context, forge forge.Forge, store store.Store, cu
 		})
 	}
 
-	t := token.New(token.PipelineToken)
-	t.Set("user-id", strconv.FormatInt(user.ID, 10))
-	t.Set("pipeline-id", strconv.FormatInt(currentPipeline.ID, 10))
-	// TODO: If a pipeline is restarted, Timestamp is equal to the timestamp of start of the last pipeline.
-	tokenString, err := t.SignExpires(user.Hash, currentPipeline.Timestamp+repo.Timeout*60)
+	if len(repo.ExposeAccessTokenEvents) > 0 {
+		t := token.New(token.PipelineToken)
+		t.Set("user-id", strconv.FormatInt(user.ID, 10))
+		t.Set("pipeline-id", strconv.FormatInt(currentPipeline.ID, 10))
+		// TODO: If a pipeline is restarted, Timestamp is equal to the timestamp of start of the last pipeline.
+		tokenString, err := t.SignExpires(user.Hash, currentPipeline.Timestamp+repo.Timeout*60)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate pipeline token: %w", err)
+		}
 
-	secrets = append(secrets, compiler.Secret{
-		Name:   "woodpecker_token",
-		Value:  tokenString,
-		Events: []pipeline_metadata.Event{pipeline_metadata.EventPush, pipeline_metadata.EventManual},
-	})
+		var events []pipeline_metadata.Event
+		for _, event := range repo.ExposeAccessTokenEvents {
+			events = append(events, pipeline_metadata.Event(event))
+		}
+
+		secrets = append(secrets, compiler.Secret{
+			Name:   "woodpecker_token",
+			Value:  tokenString,
+			Events: events,
+		})
+	}
 
 	registryService := server.Config.Services.Manager.RegistryServiceFromRepo(repo)
 	regs, err := registryService.RegistryListPipeline(ctx, repo, currentPipeline, netrc)

--- a/server/pipeline/items.go
+++ b/server/pipeline/items.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 
@@ -32,6 +33,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	"go.woodpecker-ci.org/woodpecker/v3/server/pipeline/metadata"
 	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+	"go.woodpecker-ci.org/woodpecker/v3/shared/token"
 )
 
 func parsePipeline(ctx context.Context, forge forge.Forge, store store.Store, currentPipeline *model.Pipeline, user *model.User, repo *model.Repo, forgeYamls []*forge_types.FileMeta, envs map[string]string) ([]*builder.Item, error) {
@@ -67,6 +69,18 @@ func parsePipeline(ctx context.Context, forge forge.Forge, store store.Store, cu
 			Events:         events,
 		})
 	}
+
+	t := token.New(token.PipelineToken)
+	t.Set("user-id", strconv.FormatInt(user.ID, 10))
+	t.Set("pipeline-id", strconv.FormatInt(currentPipeline.ID, 10))
+	// TODO: If a pipeline is restarted, Timestamp is equal to the timestamp of start of the last pipeline.
+	tokenString, err := t.SignExpires(user.Hash, currentPipeline.Timestamp+repo.Timeout*60)
+
+	secrets = append(secrets, compiler.Secret{
+		Name:   "woodpecker_token",
+		Value:  tokenString,
+		Events: []pipeline_metadata.Event{pipeline_metadata.EventPush, pipeline_metadata.EventManual},
+	})
 
 	registryService := server.Config.Services.Manager.RegistryServiceFromRepo(repo)
 	regs, err := registryService.RegistryListPipeline(ctx, repo, currentPipeline, netrc)

--- a/server/router/middleware/session/user.go
+++ b/server/router/middleware/session/user.go
@@ -43,7 +43,7 @@ func SetUser() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var user *model.User
 
-		t, err := token.ParseRequest([]token.Type{token.UserToken, token.SessToken}, c.Request, func(t *token.Token) (string, error) {
+		t, err := token.ParseRequest([]token.Type{token.UserToken, token.SessToken, token.PipelineToken}, c.Request, func(t *token.Token) (string, error) {
 			var err error
 			userID, err := strconv.ParseInt(t.Get("user-id"), 10, 64)
 			if err != nil {
@@ -55,16 +55,34 @@ func SetUser() gin.HandlerFunc {
 		if err == nil {
 			c.Set("user", user)
 
-			// if this is a session token (ie not the API token)
-			// this means the user is accessing with a web browser,
-			// so we should implement CSRF protection measures.
-			if t.Type == token.SessToken {
+			switch t.Type {
+			case token.SessToken:
+				// if this is a session token (ie not the API token)
+				// this means the user is accessing with a web browser,
+				// so we should implement CSRF protection measures.
 				err = token.CheckCsrf(c.Request, func(_ *token.Token) (string, error) {
 					return user.Hash, nil
 				})
 				// if csrf token validation fails, exit immediately
 				// with a not authorized error.
 				if err != nil {
+					c.AbortWithStatus(http.StatusUnauthorized)
+					return
+				}
+			case token.PipelineToken:
+				/// If this is a token generated for a pipeline,
+				// check if the pipeline is still running.
+				pipelineID, err := strconv.ParseInt(t.Get("pipeline-id"), 10, 64)
+				if err != nil {
+					c.AbortWithStatus(http.StatusInternalServerError)
+					return
+				}
+				pipeline, err := store.FromContext(c).GetPipeline(pipelineID)
+				if err != nil {
+					c.AbortWithError(http.StatusInternalServerError, err)
+					return
+				}
+				if pipeline.Status != model.StatusRunning {
 					c.AbortWithStatus(http.StatusUnauthorized)
 					return
 				}

--- a/shared/token/token.go
+++ b/shared/token/token.go
@@ -34,6 +34,7 @@ const (
 	CsrfToken       Type = "csrf"
 	AgentToken      Type = "agent"
 	OAuthStateToken Type = "oauth-state"
+	PipelineToken   Type = "pipeline"
 )
 
 // SignerAlgo id default algorithm used to sign JWT tokens.

--- a/web/src/lib/api/types/repo.ts
+++ b/web/src/lib/api/types/repo.ts
@@ -105,6 +105,8 @@ export interface Repo {
 
   // True if repo only exist in the woodpecker store and not at the forge anymore
   has_no_forge_repo?: boolean;
+
+  expose_access_token_events: string[];
 }
 
 /* eslint-disable no-unused-vars */
@@ -134,6 +136,7 @@ export type RepoSettings = Pick<
   | 'allow_deploy'
   | 'cancel_previous_pipeline_events'
   | 'netrc_trusted'
+  | 'expose_access_token_events'
 >;
 
 export type ExtensionSettings = Pick<

--- a/web/src/views/repo/settings/General.vue
+++ b/web/src/views/repo/settings/General.vue
@@ -158,6 +158,18 @@
         </template>
       </InputField>
 
+      <InputField
+        label="Expose Woodpecker token"
+      >
+        <CheckboxesField
+          v-model="repoSettings.expose_access_token_events"
+          :options="exposeAccessTokenEventsOptions"
+        />
+        <template #description>
+          Selected event triggers will expose the <span class="code-box-inline">woodpecker_token</span> secret to the pipeline.
+        </template>
+      </InputField>
+
       <Button
         type="submit"
         class="mr-auto"
@@ -219,6 +231,7 @@ function loadRepoSettings() {
     allow_deploy: repo.value.allow_deploy,
     cancel_previous_pipeline_events: repo.value.cancel_previous_pipeline_events || [],
     netrc_trusted: repo.value.netrc_trusted || [],
+    expose_access_token_events: repo.value.expose_access_token_events || [],
   };
 }
 
@@ -271,6 +284,16 @@ const cancelPreviousPipelineEventsOptions: CheckboxOption[] = [
     text: i18n.t('repo.pipeline.event.pr'),
   },
   { value: WebhookEvents.Deploy, text: i18n.t('repo.pipeline.event.deploy') },
+];
+
+const exposeAccessTokenEventsOptions: CheckboxOption[] = [
+  { value: WebhookEvents.Push, text: i18n.t('repo.pipeline.event.push') },
+  { value: WebhookEvents.Tag, text: i18n.t('repo.pipeline.event.tag') },
+  { value: WebhookEvents.Release, text: i18n.t('repo.pipeline.event.release') },
+  { value: WebhookEvents.PullRequest, text: i18n.t('repo.pipeline.event.pr') },
+  { value: WebhookEvents.Deploy, text: i18n.t('repo.pipeline.event.deploy') },
+  { value: WebhookEvents.Cron, text: i18n.t('repo.pipeline.event.cron') },
+  { value: WebhookEvents.Manual, text: i18n.t('repo.pipeline.event.manual') },
 ];
 
 useWPTitle(computed(() => [i18n.t('repo.settings.general.project'), repo.value.full_name]));


### PR DESCRIPTION
This PR is currently more of a POC and it's not ready to be merged. I'm seeking suggestions and comments, if this feature is accepted by the maintainers I will refine it.

## Implementation

I like the concept of the `GITHUB_TOKEN` access token of GitHub's CI. This implementation is inspired by it.

Currently, in this implementation, whenever a pipeline is started, the server generates a secret (named `woodpecker_token`) and adds it along side of the other secrets. Both the user-id and the pipeline-id are included into the JWT claims.
The token is valid as long as the pipeline is running, but as a safeguard it also has an expiration of "timestamp of when it's started + repo timeout".
The scope of the token is the same of a normal user/session token.

## Why

I needed a way of seamlessly calling woodpecker APIs to start a deployment after a pipeline has finished executing. The [trigger](https://woodpecker-ci.org/plugins/trigger) plugin exists, but you still need to embed a user token.
With this PR the plugin would work out of the box, after the user has enabled the token in the repo settings.