### PR TITLE
fix(server): include timezone data in container images

### DIFF
--- a/docker/Dockerfile.server.alpine.multiarch.rootless
+++ b/docker/Dockerfile.server.alpine.multiarch.rootless
@@ -1,3 +1,5 @@
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.27 AS timezone-data
+
 FROM docker.io/alpine:3.24
 
 ARG TARGETOS TARGETARCH
@@ -12,8 +14,11 @@ ENV WOODPECKER_IN_CONTAINER=true
 ENV XDG_CACHE_HOME=/var/lib/woodpecker
 ENV XDG_DATA_HOME=/var/lib/woodpecker
 ENV SQLITE_TMPDIR=/var/lib/woodpecker
+# Keep the .zip suffix: Go uses this IANA archive for named cron timezones.
+ENV ZONEINFO=/usr/share/zoneinfo.zip
 EXPOSE 8000 9000 80 443
 
+COPY --from=timezone-data /usr/local/go/lib/time/zoneinfo.zip /usr/share/zoneinfo.zip
 COPY dist/server/${TARGETOS}_${TARGETARCH}/woodpecker-server /bin/
 
 USER woodpecker

--- a/docker/Dockerfile.server.multiarch.rootless
+++ b/docker/Dockerfile.server.multiarch.rootless
@@ -16,6 +16,9 @@ EXPOSE 8000 9000 80 443
 
 # copy certs from certs image
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Keep the .zip suffix: Go uses this IANA archive for named cron timezones.
+COPY --from=build /usr/local/go/lib/time/zoneinfo.zip /usr/share/zoneinfo.zip
+ENV ZONEINFO=/usr/share/zoneinfo.zip
 # copy server binary
 COPY dist/server/${TARGETOS}_${TARGETARCH}/woodpecker-server /bin/
 COPY --from=build /etc/passwd /etc/passwd


### PR DESCRIPTION
Fixes #6688.

Both published server image variants currently lack IANA timezone data, so named Woodpecker cron timezones are rejected.

This keeps the change in container packaging only: both scratch and Alpine server images copy the same Go-distributed `zoneinfo.zip` and set `ZONEINFO` to it. That makes the cron scheduler's named `time.LoadLocation` values available consistently without a host mount or runtime package install.

Validation:
- `go test -tags external_web ./cmd/server -run 'Test.*Cron' -count=1`\n- inspected the actual `golang:1.27` archive: 598 zones, including `America/Denver`, `Europe/Berlin`, `US/Eastern`, and `Asia/Calcutta`\n- `git diff --check`\n\nClaude Code review completed in a focused loop; its accepted feedback is reflected here. Scheduler, `TZ`/local-time semantics, and broader CI changes were deliberately left out of this cron parsing fix.