### PR TITLE
fix(forge/gitlab): use group Path instead of Name for membership lookup

### DIFF
--- a/server/forge/gitlab/gitlab.go
+++ b/server/forge/gitlab/gitlab.go
@@ -706,7 +706,7 @@ func (g *GitLab) OrgMembership(ctx context.Context, u *model.User, owner string)
 	}
 	var gid int64
 	for _, group := range groups {
-		if group.Name == owner {
+		if group.Path == owner {
 			gid = group.ID
 			break
 		}


### PR DESCRIPTION
## Summary

GitLab groups have both a display `name` and a URL `path`. Woodpecker stores the `path` as the org name, but `OrgMembership` compared against the `name` field. When these differ, the membership check always fails with 403.

## Changes

- `server/forge/gitlab/gitlab.go`: in `OrgMembership`, use `group.Path` instead of `group.Name` to match the owner. This is correct because Woodpecker only uses paths internally, and display names are not guaranteed to be unique.

## Test Plan

- Verify that a user who is a member of a GitLab group where `name != path` can now access the org in Woodpecker (no more 403 on `/api/orgs/{id}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)