### PR TITLE
Make oauth2 refresh time configurable

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -211,6 +211,12 @@ var flags = append([]cli.Flag{
 		Usage:   "session expiration time",
 		Value:   time.Hour * 72,
 	},
+	&cli.DurationFlag{
+		Sources: cli.EnvVars("WOODPECKER_OAUTH_REFRESH_TIME"),
+		Name:    "oauth-refresh-time",
+		Usage:   "how long before a forge oauth token expires to refresh it",
+		Value:   time.Minute * 30,
+	},
 	&cli.StringSliceFlag{
 		Sources: cli.EnvVars("WOODPECKER_PLUGINS_PRIVILEGED"),
 		Name:    "plugins-privileged",

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -31,6 +31,7 @@ import (
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/cache"
+	"go.woodpecker-ci.org/woodpecker/v3/server/forge"
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/setup"
 	"go.woodpecker-ci.org/woodpecker/v3/server/logging"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
@@ -243,6 +244,7 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 	server.Config.Server.StatusContext = c.String("status-context")
 	server.Config.Server.StatusContextFormat = c.String("status-context-format")
 	server.Config.Server.SessionExpires = c.Duration("session-expires")
+	forge.TokenMinTTL = c.Duration("oauth-refresh-time")
 	u, _ := url.Parse(server.Config.Server.Host)
 	rootPath := strings.TrimSuffix(u.Path, "/")
 	if rootPath != "" && !strings.HasPrefix(rootPath, "/") {

--- a/docs/docs/30-administration/10-configuration/10-server.md
+++ b/docs/docs/30-administration/10-configuration/10-server.md
@@ -870,6 +870,13 @@ Context: when someone does log into Woodpecker, a temporary session token is cre
 As long as the session is valid (until it expires or log-out),
 a user can log into Woodpecker, without re-authentication.
 
+### OAUTH_REFRESH_TIME
+
+- Name: `WOODPECKER_OAUTH_REFRESH_TIME`
+- Default: `30m`
+
+How long before a forge oauth token expires that Woodpecker should refresh it.
+
 ### PLUGINS_PRIVILEGED
 
 - Name: `WOODPECKER_PLUGINS_PRIVILEGED`


### PR DESCRIPTION
Since oauth tokens are still fetched at the start of a pipeline (until #2851 ) because tokens run out, see eg #4558.

Setting the token refresh expiry time in the forge is insufficient: it will indeed decrease the chance that time is running out, but still relies on a hardcode refresh time.