### PR TITLE
Log a filtered webhook at debug instead of error

### DIFF
--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -226,7 +226,14 @@ func PostHook(c *gin.Context) {
 		defer cancel()
 		pl, err = pipeline.Create(bgCtx, _store, repo, pipelineFromForge)
 		if err != nil {
-			log.Error().Err(err).Str("repo", repo.FullName).Msg("could not create pipeline from webhook")
+			// An all-filtered pipeline (no workflow matched its `when`) is a clean
+			// no-op, not a failure: Create already deleted it. Log it at debug so
+			// PR/metadata/closed webhooks that match nothing don't spam error logs.
+			if errors.Is(err, pipeline.ErrFiltered) {
+				log.Debug().Str("repo", repo.FullName).Msg("webhook produced no matching workflows; skipped")
+			} else {
+				log.Error().Err(err).Str("repo", repo.FullName).Msg("could not create pipeline from webhook")
+			}
 		}
 		done <- struct{}{}
 	}()

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -226,11 +226,12 @@ func PostHook(c *gin.Context) {
 		defer cancel()
 		pl, err = pipeline.Create(bgCtx, _store, repo, pipelineFromForge)
 		if err != nil {
-			// A filtered pipeline is a clean no-op rather than a failure: either
-			// nothing matched its `when` filters, the config was absent, or the
-			// commit asked to be skipped. Create leaves no pipeline behind in
-			// any of those cases. Log it at debug so PR, metadata and closed
-			// webhooks that match nothing don't spam the error log.
+			// A filtered pipeline is not a failure: either the commit asked to
+			// be skipped, the config was absent, or nothing matched its `when`
+			// filters. Only the skip-ci case returns before the pipeline is
+			// persisted; the other two delete the row they created, on a best
+			// effort basis. Log it at debug so PR, metadata and closed webhooks
+			// that match nothing don't spam the error log.
 			if errors.Is(err, pipeline.ErrFiltered) {
 				log.Debug().Str("repo", repo.FullName).Msg("webhook produced no matching workflows; skipped")
 			} else {

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -226,9 +226,11 @@ func PostHook(c *gin.Context) {
 		defer cancel()
 		pl, err = pipeline.Create(bgCtx, _store, repo, pipelineFromForge)
 		if err != nil {
-			// An all-filtered pipeline (no workflow matched its `when`) is a clean
-			// no-op, not a failure: Create already deleted it. Log it at debug so
-			// PR/metadata/closed webhooks that match nothing don't spam error logs.
+			// A filtered pipeline is a clean no-op rather than a failure: either
+			// nothing matched its `when` filters, the config was absent, or the
+			// commit asked to be skipped. Create leaves no pipeline behind in
+			// any of those cases. Log it at debug so PR, metadata and closed
+			// webhooks that match nothing don't spam the error log.
 			if errors.Is(err, pipeline.ErrFiltered) {
 				log.Debug().Str("repo", repo.FullName).Msg("webhook produced no matching workflows; skipped")
 			} else {

--- a/server/pipeline/create_filtered_test.go
+++ b/server/pipeline/create_filtered_test.go
@@ -15,12 +15,19 @@
 package pipeline
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
+	"go.woodpecker-ci.org/woodpecker/v3/server"
+	forge_mocks "go.woodpecker-ci.org/woodpecker/v3/server/forge/mocks"
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	config_service_mocks "go.woodpecker-ci.org/woodpecker/v3/server/services/config/mocks"
+	manager_mocks "go.woodpecker-ci.org/woodpecker/v3/server/services/mocks"
+	registry_service_mocks "go.woodpecker-ci.org/woodpecker/v3/server/services/registry/mocks"
+	secret_service_mocks "go.woodpecker-ci.org/woodpecker/v3/server/services/secret/mocks"
 	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
 )
 
@@ -48,13 +55,57 @@ func TestCreateSkipCommitMessageReturnsErrFiltered(t *testing.T) {
 	assert.ErrorIs(t, err, ErrFiltered)
 }
 
-// A filtered pipeline is not a failure, so it must not be reported as one.
-// This pins the property the sentinel exists for: ErrFiltered is
-// distinguishable from an arbitrary error carrying the same message.
-func TestErrFilteredIsDistinguishable(t *testing.T) {
-	t.Parallel()
+// The webhook error-log spam this change addresses comes from the `when`
+// filter path: the config parses, but every workflow is filtered out, so
+// Create deletes the pipeline it just persisted and returns ErrFiltered.
+// Unlike the skip-ci case this happens after CreatePipeline, so the store
+// sees both calls.
+func TestCreateAllWorkflowsFilteredReturnsErrFiltered(t *testing.T) {
+	repo := &model.Repo{ID: 1, UserID: 1, FullName: "octocat/hello-world", Config: ".woodpecker.yaml"}
 
-	assert.ErrorIs(t, ErrFiltered, ErrFiltered)
-	assert.False(t, errors.Is(errors.New(ErrFiltered.Error()), ErrFiltered),
-		"a same-text error must not satisfy errors.Is; callers rely on the sentinel identity")
+	// A push webhook against a config whose only workflow runs on tag events
+	// leaves nothing to run.
+	yaml := []byte("when:\n  - event: tag\n\nsteps:\n  - name: test\n    image: alpine\n    commands:\n      - echo hi\n")
+
+	mockStore := store_mocks.NewMockStore(t)
+	mockStore.On("GetUser", int64(1)).Return(&model.User{ID: 1, Login: "octocat"}, nil)
+	mockStore.On("CreatePipeline", mock.Anything, mock.Anything).Return(nil)
+	mockStore.On("GetPipelineLastBefore", mock.Anything, mock.Anything, mock.Anything).Return(&model.Pipeline{}, nil)
+	mockStore.On("ConfigPersist", mock.Anything).Return(&model.Config{ID: 1, RepoID: 1}, nil)
+	mockStore.On("PipelineConfigCreate", mock.Anything).Return(nil)
+	// The pipeline row is created and then removed again.
+	mockStore.On("DeletePipeline", mock.Anything).Return(nil).Once()
+
+	mockForge := forge_mocks.NewMockForge(t)
+	mockForge.On("Name").Return("github")
+	mockForge.On("URL").Return("https://github.com")
+	mockForge.On("Netrc", mock.Anything, mock.Anything).Return(&model.Netrc{}, nil)
+
+	mockManager := manager_mocks.NewMockManager(t)
+	mockManager.On("ForgeFromRepo", mock.Anything).Return(mockForge, nil)
+
+	configService := config_service_mocks.NewMockService(t)
+	configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]*forge_types.FileMeta{{Name: ".woodpecker.yaml", Data: yaml}}, nil)
+	mockManager.On("ConfigServiceFromRepo", mock.Anything).Return(configService)
+
+	secretService := secret_service_mocks.NewMockService(t)
+	secretService.On("SecretListPipeline", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*model.Secret{}, nil)
+	mockManager.On("SecretServiceFromRepo", mock.Anything).Return(secretService, nil)
+
+	registryService := registry_service_mocks.NewMockService(t)
+	registryService.On("RegistryListPipeline", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*model.Registry{}, nil)
+	mockManager.On("RegistryServiceFromRepo", mock.Anything).Return(registryService, nil)
+
+	mockManager.On("EnvironmentService").Return(nil, nil)
+
+	server.Config.Services.Manager = mockManager
+
+	created, err := Create(t.Context(), mockStore, repo, &model.Pipeline{
+		Event: model.EventPush,
+		Ref:   "refs/heads/main",
+	})
+
+	assert.Nil(t, created)
+	assert.ErrorIs(t, err, ErrFiltered)
 }

--- a/server/pipeline/create_filtered_test.go
+++ b/server/pipeline/create_filtered_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+// Callers distinguish a filtered pipeline from a real failure with
+// errors.Is(err, ErrFiltered), so Create must return the sentinel unwrapped.
+// Wrapping it with a formatted message would keep errors.Is working, but
+// returning a fresh errors.New with the same text would not, and that
+// difference is invisible at the call site.
+func TestCreateSkipCommitMessageReturnsErrFiltered(t *testing.T) {
+	t.Parallel()
+
+	mockStore := store_mocks.NewMockStore(t)
+	repo := &model.Repo{ID: 10, UserID: 1, FullName: "octocat/hello-world"}
+	mockStore.On("GetUser", int64(1)).Return(&model.User{ID: 1, Login: "octocat"}, nil)
+
+	// A skip-ci commit is filtered before the pipeline is ever persisted, so
+	// no CreatePipeline or DeletePipeline call is expected. mockStore is
+	// strict: an unexpected store call fails the test.
+	created, err := Create(t.Context(), mockStore, repo, &model.Pipeline{
+		Event:   model.EventPush,
+		Message: "chore: tidy up [skip ci]",
+	})
+
+	assert.Nil(t, created)
+	assert.ErrorIs(t, err, ErrFiltered)
+}
+
+// A filtered pipeline is not a failure, so it must not be reported as one.
+// This pins the property the sentinel exists for: ErrFiltered is
+// distinguishable from an arbitrary error carrying the same message.
+func TestErrFilteredIsDistinguishable(t *testing.T) {
+	t.Parallel()
+
+	assert.ErrorIs(t, ErrFiltered, ErrFiltered)
+	assert.False(t, errors.Is(errors.New(ErrFiltered.Error()), ErrFiltered),
+		"a same-text error must not satisfy errors.Is; callers rely on the sentinel identity")
+}


### PR DESCRIPTION
`pipeline.Create` returns `pipeline.ErrFiltered` when a webhook produces no
work. Three paths reach it: a commit message asking to be skipped
(`create.go:49`), no pipeline config in the repo (`:86`), and no workflow whose
`when` conditions match (`:130`). The async webhook goroutine logs any error
from `Create` at error level (`server/api/hook.go:229`), so every such webhook
writes "could not create pipeline from webhook" to the server log. On a repo
with narrow `when` filters that is most of the incoming hooks.

This checks for `ErrFiltered` and logs it at debug. Other failures from
`Create` still log at error.

Filtering is the documented, expected outcome for a non-matching hook, so it
should not be reported as a server error.

Only the skip-ci path returns before the pipeline row is persisted. The other
two delete the row they created and log-and-discard any failure from that
delete, so the comment on the new branch describes the paths separately rather
than calling the whole thing a no-op.

Tests are in `server/pipeline/create_filtered_test.go`:
`TestCreateSkipCommitMessageReturnsErrFiltered` covers the skip-ci path, and
`TestCreateAllWorkflowsFilteredReturnsErrFiltered` covers the `when`-filter
path that motivates the change. Both assert the sentinel is reachable through
`errors.Is`, which is what the new branch in `hook.go` depends on.
