### PR TITLE
Restart a pipeline that errored before its config was persisted

### DIFF
--- a/server/api/pipeline_test.go
+++ b/server/api/pipeline_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/metadata"
 	"go.woodpecker-ci.org/woodpecker/v3/server"
@@ -464,5 +465,119 @@ func TestCreatePipeline(t *testing.T) {
 		mockStore.AssertCalled(t, "GetUser", int64(1))
 		mockStore.AssertCalled(t, "CreatePipeline", mock.Anything)
 		mockStore.AssertCalled(t, "UpdatePipeline", mock.Anything)
+	})
+}
+
+// TestPostPipeline covers restart (PostPipeline -> pipeline.Restart). The
+// regression case: a pipeline that errored before persisting any config (e.g. a
+// transient config-extension outage) has no old config rows, but a healthy
+// refetch on restart still yields a valid definition. It must restart, not fail
+// with "pipeline definition not found". The guard case: when the refetch is also
+// empty, that error still fires.
+func TestPostPipeline(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// erroredParent mimics a pipeline that failed during creation before its
+	// config was persisted: status error, and ConfigsForPipeline returns nothing.
+	newErroredParent := func() *model.Pipeline {
+		return &model.Pipeline{
+			ID:      2,
+			Number:  2,
+			Status:  model.StatusError,
+			Event:   model.EventPull,
+			Branch:  "main",
+			Refspec: "feature:main",
+		}
+	}
+
+	fakeRepo := &model.Repo{ID: 1, UserID: 1, FullName: "test/repo", CancelPreviousPipelineEvents: []model.WebhookEvent{}}
+	fakeUser := &model.User{ID: 1, Login: "testuser", Email: "test@example.com", Avatar: "avatar.png", Hash: "hash123"}
+	validConfig := []*forge_types.FileMeta{
+		{Name: ".woodpecker.yml", Data: []byte("when:\n  event: manual\nsteps:\n  test:\n    image: alpine:latest\n    commands:\n      - echo test")},
+	}
+
+	// setupPost wires the full handler mock surface and invokes PostPipeline.
+	// fetchResult is what the config service serves on the restart refetch.
+	setupPost := func(t *testing.T, parent *model.Pipeline, fetchResult []*forge_types.FileMeta) *httptest.ResponseRecorder {
+		mockStore := store_mocks.NewMockStore(t)
+		mockConfigService := config_service_mocks.NewMockService(t)
+		mockSecretService := secret_service_mocks.NewMockService(t)
+		mockRegistryService := registry_service_mocks.NewMockService(t)
+
+		mockForge := forge_mocks.NewMockForge(t)
+		mockForge.On("Name").Return("mock").Maybe()
+		mockForge.On("URL").Return("https://example.com").Maybe()
+		mockForge.On("Netrc", fakeUser, fakeRepo).Return(&model.Netrc{}, nil).Maybe()
+		mockForge.On("Status", mock.Anything, fakeUser, fakeRepo, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+		mockSecretService.On("SecretListPipeline", mock.Anything, fakeRepo, mock.Anything, mock.Anything, mock.Anything).Return([]*model.Secret{}, nil).Maybe()
+		mockRegistryService.On("RegistryListPipeline", mock.Anything, fakeRepo, mock.Anything, mock.Anything).Return([]*model.Registry{}, nil).Maybe()
+
+		mockManager := manager_mocks.NewMockManager(t)
+		mockManager.On("ForgeFromRepo", fakeRepo).Return(mockForge, nil)
+		mockManager.On("ForgeFromUser", fakeUser).Return(mockForge, nil).Maybe()
+		mockManager.On("ConfigServiceFromRepo", fakeRepo).Return(mockConfigService)
+		mockManager.On("SecretServiceFromRepo", fakeRepo).Return(mockSecretService).Maybe()
+		mockManager.On("RegistryServiceFromRepo", fakeRepo).Return(mockRegistryService).Maybe()
+		mockManager.On("EnvironmentService").Return(nil).Maybe()
+		server.Config.Services.Manager = mockManager
+
+		mockQueue := queue_mocks.NewMockQueue(t)
+		mockQueue.On("Push", mock.Anything, mock.Anything).Return(nil).Maybe()
+		mockQueue.On("PushAtOnce", mock.Anything, mock.Anything).Return(nil).Maybe()
+		server.Config.Services.Scheduler = scheduler.NewScheduler(t.Context(), mockStore, mockQueue, memory.New())
+
+		// restart=true refetch: the parent had no persisted config rows.
+		mockConfigService.On("Fetch", mock.Anything, mockForge, fakeUser, fakeRepo, mock.Anything, mock.Anything, true).Return(fetchResult, nil)
+
+		mockStore.On("GetUser", int64(1)).Return(fakeUser, nil)
+		mockStore.On("ConfigsForPipeline", parent.ID).Return([]*model.Config{}, nil)
+		mockStore.On("CreatePipeline", mock.Anything).Return(nil)
+		mockStore.On("GetPipelineLastBefore", fakeRepo, "main", mock.Anything).Return(nil, types.ErrRecordNotExist).Maybe()
+		mockStore.On("GetActivePipelineList", fakeRepo).Return([]*model.Pipeline{}, nil).Maybe()
+		mockStore.On("ConfigPersist", mock.Anything).Return(&model.Config{ID: 1}, nil).Maybe()
+		mockStore.On("ConfigFindIdentical", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+		mockStore.On("PipelineConfigCreate", mock.Anything).Return(nil).Maybe()
+		mockStore.On("WorkflowsCreate", mock.Anything).Return(nil).Maybe()
+		mockStore.On("UpdatePipeline", mock.Anything).Return(nil).Maybe()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Set("store", mockStore)
+		c.Set("repo", fakeRepo)
+		c.Set("user", fakeUser)
+		c.Set("pipeline", parent)
+		c.Request, _ = http.NewRequest(http.MethodPost, "", nil)
+
+		PostPipeline(c)
+		return w
+	}
+
+	// Regression: config-less errored parent + a healthy refetch must restart,
+	// not report "pipeline definition not found". Before the fix, Restart guarded
+	// on the (empty) old config rows and errored here.
+	t.Run("restart of a config-less errored pipeline succeeds when the refetch yields config", func(t *testing.T) {
+		w := setupPost(t, newErroredParent(), validConfig)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var got model.Pipeline
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		assert.NotEqual(t, model.StatusError, got.Status, "restart should not land in error status")
+		for _, e := range got.Errors {
+			assert.NotEqual(t, "pipeline definition not found", e.Message)
+		}
+	})
+
+	// Guard preserved: no old config AND an empty refetch is a genuine
+	// "definition not found".
+	t.Run("restart still errors when no old config and the refetch is empty", func(t *testing.T) {
+		w := setupPost(t, newErroredParent(), []*forge_types.FileMeta{})
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var got model.Pipeline
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		assert.Equal(t, model.StatusError, got.Status)
+		require.NotEmpty(t, got.Errors)
+		assert.Equal(t, "pipeline definition not found", got.Errors[0].Message)
 	})
 }

--- a/server/api/pipeline_test.go
+++ b/server/api/pipeline_test.go
@@ -468,17 +468,10 @@ func TestCreatePipeline(t *testing.T) {
 	})
 }
 
-// TestPostPipeline covers restart (PostPipeline -> pipeline.Restart). The
-// regression case: a pipeline that errored before persisting any config (e.g. a
-// transient config-extension outage) has no old config rows, but a healthy
-// refetch on restart still yields a valid definition. It must restart, not fail
-// with "pipeline definition not found". The guard case: when the refetch is also
-// empty, that error still fires.
 func TestPostPipeline(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	// erroredParent mimics a pipeline that failed during creation before its
-	// config was persisted: status error, and ConfigsForPipeline returns nothing.
+	// A pipeline that failed before its config was persisted.
 	newErroredParent := func() *model.Pipeline {
 		return &model.Pipeline{
 			ID:      2,
@@ -492,16 +485,13 @@ func TestPostPipeline(t *testing.T) {
 
 	fakeRepo := &model.Repo{ID: 1, UserID: 1, FullName: "test/repo", CancelPreviousPipelineEvents: []model.WebhookEvent{}}
 	fakeUser := &model.User{ID: 1, Login: "testuser", Email: "test@example.com", Avatar: "avatar.png", Hash: "hash123"}
-	// The event must match the parent's, or the workflow is filtered out and the
-	// restart finishes with no workflows at all, which would satisfy the
-	// assertions below without proving the config was compiled.
+	// The event must match the parent's, or the workflow is filtered out.
 	validConfig := []*forge_types.FileMeta{
 		{Name: ".woodpecker.yml", Data: []byte("when:\n  event: pull_request\nsteps:\n  test:\n    image: alpine:latest\n    commands:\n      - echo test")},
 	}
 
-	// setupPost wires the full handler mock surface and invokes PostPipeline.
-	// fetchResult is what the config service serves on the restart refetch. The
-	// store is returned so a caller can assert which persist calls really ran.
+	// fetchResult is what the config service serves on the refetch. The store is
+	// returned so callers can assert which persist calls ran.
 	setupPost := func(t *testing.T, parent *model.Pipeline, fetchResult []*forge_types.FileMeta) (*httptest.ResponseRecorder, *store_mocks.MockStore) {
 		mockStore := store_mocks.NewMockStore(t)
 		mockConfigService := config_service_mocks.NewMockService(t)
@@ -531,7 +521,6 @@ func TestPostPipeline(t *testing.T) {
 		mockQueue.On("PushAtOnce", mock.Anything, mock.Anything).Return(nil).Maybe()
 		server.Config.Services.Scheduler = scheduler.NewScheduler(t.Context(), mockStore, mockQueue, memory.New())
 
-		// restart=true refetch: the parent had no persisted config rows.
 		mockConfigService.On("Fetch", mock.Anything, mockForge, fakeUser, fakeRepo, mock.Anything, mock.Anything, true).Return(fetchResult, nil)
 
 		mockStore.On("GetUser", int64(1)).Return(fakeUser, nil)
@@ -557,9 +546,7 @@ func TestPostPipeline(t *testing.T) {
 		return w, mockStore
 	}
 
-	// Regression: config-less errored parent + a healthy refetch must restart,
-	// not report "pipeline definition not found". Before the fix, Restart guarded
-	// on the (empty) old config rows and errored here.
+	// Before the fix, Restart guarded on the empty old config rows.
 	t.Run("restart of a config-less errored pipeline succeeds when the refetch yields config", func(t *testing.T) {
 		w, mockStore := setupPost(t, newErroredParent(), validConfig)
 
@@ -570,16 +557,14 @@ func TestPostPipeline(t *testing.T) {
 		for _, e := range got.Errors {
 			assert.NotEqual(t, "pipeline definition not found", e.Message)
 		}
-		// The refetched config has to be compiled into real work and stored
-		// against the new pipeline, or the restart only looks successful.
+		// The config must be compiled into real work, not just fetched.
 		assert.NotEmpty(t, got.Workflows, "restart should produce workflows from the refetched config")
 		mockStore.AssertCalled(t, "ConfigPersist", mock.Anything)
 		mockStore.AssertCalled(t, "PipelineConfigCreate", mock.Anything)
 		mockStore.AssertCalled(t, "WorkflowsCreate", mock.Anything)
 	})
 
-	// Guard preserved: no old config AND an empty refetch is a genuine
-	// "definition not found".
+	// No old config and an empty refetch is a genuine "not found".
 	t.Run("restart still errors when no old config and the refetch is empty", func(t *testing.T) {
 		w, _ := setupPost(t, newErroredParent(), []*forge_types.FileMeta{})
 

--- a/server/api/pipeline_test.go
+++ b/server/api/pipeline_test.go
@@ -492,13 +492,17 @@ func TestPostPipeline(t *testing.T) {
 
 	fakeRepo := &model.Repo{ID: 1, UserID: 1, FullName: "test/repo", CancelPreviousPipelineEvents: []model.WebhookEvent{}}
 	fakeUser := &model.User{ID: 1, Login: "testuser", Email: "test@example.com", Avatar: "avatar.png", Hash: "hash123"}
+	// The event must match the parent's, or the workflow is filtered out and the
+	// restart finishes with no workflows at all, which would satisfy the
+	// assertions below without proving the config was compiled.
 	validConfig := []*forge_types.FileMeta{
-		{Name: ".woodpecker.yml", Data: []byte("when:\n  event: manual\nsteps:\n  test:\n    image: alpine:latest\n    commands:\n      - echo test")},
+		{Name: ".woodpecker.yml", Data: []byte("when:\n  event: pull_request\nsteps:\n  test:\n    image: alpine:latest\n    commands:\n      - echo test")},
 	}
 
 	// setupPost wires the full handler mock surface and invokes PostPipeline.
-	// fetchResult is what the config service serves on the restart refetch.
-	setupPost := func(t *testing.T, parent *model.Pipeline, fetchResult []*forge_types.FileMeta) *httptest.ResponseRecorder {
+	// fetchResult is what the config service serves on the restart refetch. The
+	// store is returned so a caller can assert which persist calls really ran.
+	setupPost := func(t *testing.T, parent *model.Pipeline, fetchResult []*forge_types.FileMeta) (*httptest.ResponseRecorder, *store_mocks.MockStore) {
 		mockStore := store_mocks.NewMockStore(t)
 		mockConfigService := config_service_mocks.NewMockService(t)
 		mockSecretService := secret_service_mocks.NewMockService(t)
@@ -550,14 +554,14 @@ func TestPostPipeline(t *testing.T) {
 		c.Request, _ = http.NewRequest(http.MethodPost, "", nil)
 
 		PostPipeline(c)
-		return w
+		return w, mockStore
 	}
 
 	// Regression: config-less errored parent + a healthy refetch must restart,
 	// not report "pipeline definition not found". Before the fix, Restart guarded
 	// on the (empty) old config rows and errored here.
 	t.Run("restart of a config-less errored pipeline succeeds when the refetch yields config", func(t *testing.T) {
-		w := setupPost(t, newErroredParent(), validConfig)
+		w, mockStore := setupPost(t, newErroredParent(), validConfig)
 
 		require.Equal(t, http.StatusOK, w.Code)
 		var got model.Pipeline
@@ -566,12 +570,18 @@ func TestPostPipeline(t *testing.T) {
 		for _, e := range got.Errors {
 			assert.NotEqual(t, "pipeline definition not found", e.Message)
 		}
+		// The refetched config has to be compiled into real work and stored
+		// against the new pipeline, or the restart only looks successful.
+		assert.NotEmpty(t, got.Workflows, "restart should produce workflows from the refetched config")
+		mockStore.AssertCalled(t, "ConfigPersist", mock.Anything)
+		mockStore.AssertCalled(t, "PipelineConfigCreate", mock.Anything)
+		mockStore.AssertCalled(t, "WorkflowsCreate", mock.Anything)
 	})
 
 	// Guard preserved: no old config AND an empty refetch is a genuine
 	// "definition not found".
 	t.Run("restart still errors when no old config and the refetch is empty", func(t *testing.T) {
-		w := setupPost(t, newErroredParent(), []*forge_types.FileMeta{})
+		w, _ := setupPost(t, newErroredParent(), []*forge_types.FileMeta{})
 
 		require.Equal(t, http.StatusOK, w.Code)
 		var got model.Pipeline

--- a/server/pipeline/restart.go
+++ b/server/pipeline/restart.go
@@ -41,15 +41,16 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 		return nil, &ErrBadRequest{Msg: "cannot restart a pipeline with status blocked"}
 	}
 
-	// fetch the old pipeline config from the database
-	configs, err := store.ConfigsForPipeline(lastPipeline.ID)
+	// Seed the refetch with the old pipeline's persisted config. The forge
+	// fetcher reuses this as-is on restart; a config extension may replace it.
+	oldConfigs, err := store.ConfigsForPipeline(lastPipeline.ID)
 	if err != nil {
 		log.Error().Err(err).Msgf("failure to get pipeline config for %s", repo.FullName)
 		return nil, &ErrNotFound{Msg: fmt.Sprintf("failure to get pipeline config for %s. %s", repo.FullName, err)}
 	}
 
 	var pipelineFiles []*forge_types.FileMeta
-	for _, y := range configs {
+	for _, y := range oldConfigs {
 		pipelineFiles = append(pipelineFiles, &forge_types.FileMeta{Data: y.Data, Name: y.Name})
 	}
 
@@ -74,7 +75,12 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 		return nil, errors.New(msg)
 	}
 
-	if len(configs) == 0 {
+	// Guard on the refetched config, not the old persisted rows. A pipeline that
+	// errored before persisting any config (e.g. a transient config-extension
+	// failure) has no old rows, yet a healthy refetch here can still yield a
+	// valid definition to restart from. Only a genuinely empty result — no old
+	// config and nothing served — is "definition not found".
+	if len(pipelineFiles) == 0 {
 		newPipeline, uErr := UpdateToStatusError(store, *newPipeline, errors.New("pipeline definition not found"))
 		if uErr != nil {
 			log.Debug().Err(uErr).Msg("failure to update pipeline status")
@@ -82,6 +88,19 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 			updatePipelineStatus(ctx, forge, newPipeline, repo, user)
 		}
 		return newPipeline, nil
+	}
+	// Persist the refetched config and link it, so the restart's config-of-record
+	// matches what it actually runs (mirrors Create). ConfigPersist dedups by
+	// (repo, name, hash), so an unchanged config reuses the existing rows.
+	configs := make([]*model.Config, 0, len(pipelineFiles))
+	for _, pipelineFile := range pipelineFiles {
+		config, cErr := findOrPersistPipelineConfig(store, newPipeline, pipelineFile)
+		if cErr != nil {
+			msg := fmt.Sprintf("failure to find or persist pipeline config for %s", repo.FullName)
+			log.Error().Err(cErr).Msg(msg)
+			return nil, errors.New(msg)
+		}
+		configs = append(configs, config)
 	}
 	if err := linkPipelineConfigs(store, configs, newPipeline.ID); err != nil {
 		msg := fmt.Sprintf("failure to persist pipeline config for %s.", repo.FullName)

--- a/server/pipeline/restart.go
+++ b/server/pipeline/restart.go
@@ -41,8 +41,7 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 		return nil, &ErrBadRequest{Msg: "cannot restart a pipeline with status blocked"}
 	}
 
-	// Seed the refetch with the old pipeline's persisted config. The forge
-	// fetcher reuses this as-is on restart; a config extension may replace it.
+	// The forge fetcher reuses this as-is; a config extension may replace it.
 	oldConfigs, err := store.ConfigsForPipeline(lastPipeline.ID)
 	if err != nil {
 		log.Error().Err(err).Msgf("failure to get pipeline config for %s", repo.FullName)
@@ -75,11 +74,8 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 		return nil, errors.New(msg)
 	}
 
-	// Guard on the refetched config, not the old persisted rows. A pipeline that
-	// errored before persisting any config (e.g. a transient config-extension
-	// failure) has no old rows, yet a healthy refetch here can still yield a
-	// valid definition to restart from. Only a genuinely empty result — no old
-	// config and nothing served — is "definition not found".
+	// Guard on the refetched config: a pipeline that errored before persisting
+	// any config has no old rows but can still refetch a valid definition.
 	if len(pipelineFiles) == 0 {
 		newPipeline, uErr := UpdateToStatusError(store, *newPipeline, errors.New("pipeline definition not found"))
 		if uErr != nil {
@@ -89,9 +85,8 @@ func Restart(ctx context.Context, store store.Store, lastPipeline *model.Pipelin
 		}
 		return newPipeline, nil
 	}
-	// Persist the refetched config and link it, so the restart's config-of-record
-	// matches what it actually runs (mirrors Create). ConfigPersist dedups by
-	// (repo, name, hash), so an unchanged config reuses the existing rows.
+	// Persist and link the refetched config, as Create does. ConfigPersist
+	// dedups on (repo, name, hash).
 	configs := make([]*model.Config, 0, len(pipelineFiles))
 	for _, pipelineFile := range pipelineFiles {
 		config, cErr := findOrPersistPipelineConfig(store, newPipeline, pipelineFile)


### PR DESCRIPTION
Closes #7115

`Restart` reads the old pipeline's persisted configs
(`server/pipeline/restart.go:45`), refetches through the config service
(`:58`), then fails with "pipeline definition not found" if the *old* rows were
empty (`:77`). A pipeline that errored before any config was persisted
therefore cannot be restarted even when the refetch returns a valid
definition.

#6857 moved config persistence in `Create` ahead of `createPipelineItems`, so
a parse failure no longer leaves a pipeline without configs. The
`configFetchErr` path in `Create` still returns at `create.go:93`, above the
persistence block at `:96`, and `updatePipelineWithErr` stores the pipeline in
error state, so a restartable pipeline with no config rows is still reachable.

This guards on the refetched `pipelineFiles` rather than the old rows, and
persists and links the refetched config through `findOrPersistPipelineConfig`
the way `Create` does, so the restart's config of record matches what it runs.
`ConfigPersist` dedups on (repo, name, hash), so an unchanged config reuses the
existing rows.

The refetch itself is existing behaviour and is pinned to the parent pipeline's
commit, so a restart still builds the revision it was started for.

Tests are in `server/api/pipeline_test.go`. `TestPostPipeline` covers the
restart succeeding when the refetch yields a config, asserting the workflows
are actually created and the config is persisted and linked, and covers the
refetch coming back empty still reporting "pipeline definition not found".

On the earlier reports: #2982 and #5970 both cover this symptom and both are
closed, #5970 as a duplicate of #2982. I opened #7115 rather than reopening
either, because what remains is narrower than what those describe: not the
parse-failure route #6857 fixed, but the config-fetch route that still returns
before persistence. If you read that as already-settled ground, I am happy to
close this and take it to the issue instead.